### PR TITLE
Fix cargo test

### DIFF
--- a/api/src/tests/multisig_transactions_test.rs
+++ b/api/src/tests/multisig_transactions_test.rs
@@ -25,6 +25,7 @@ async fn test_multisig_transaction_with_payload_succeeds() {
             vec![owner_account_2.address(), owner_account_3.address()],
             2,    /* 2-of-3 */
             1000, /* initial balance */
+            None,
         )
         .await;
     assert_eq!(1000, context.get_apt_balance(multisig_account).await);
@@ -63,6 +64,7 @@ async fn test_multisig_transaction_to_update_owners() {
             vec![owner_account_2.address()],
             2,
             0, /* initial balance */
+            None,
         )
         .await;
     assert_eq!(0, context.get_apt_balance(multisig_account).await);
@@ -96,12 +98,16 @@ async fn test_multisig_transaction_to_update_owners() {
 
     // There should be 4 owners now.
     assert_multisig_tx_executed(&mut context, multisig_account, add_owners_payload, 1).await;
-    assert_owners(&context, multisig_account, vec![
-        owner_account_1.address(),
-        owner_account_2.address(),
-        owner_account_3.address(),
-        owner_account_4.address(),
-    ])
+    assert_owners(
+        &context,
+        multisig_account,
+        vec![
+            owner_account_1.address(),
+            owner_account_2.address(),
+            owner_account_3.address(),
+            owner_account_4.address(),
+        ],
+    )
     .await;
 
     let remove_owners_payload = bcs::to_bytes(&MultisigTransactionPayload::EntryFunction(
@@ -130,11 +136,15 @@ async fn test_multisig_transaction_to_update_owners() {
         .await;
     // There should be 3 owners now that owner 4 has been kicked out.
     assert_multisig_tx_executed(&mut context, multisig_account, remove_owners_payload, 2).await;
-    assert_owners(&context, multisig_account, vec![
-        owner_account_1.address(),
-        owner_account_2.address(),
-        owner_account_3.address(),
-    ])
+    assert_owners(
+        &context,
+        multisig_account,
+        vec![
+            owner_account_1.address(),
+            owner_account_2.address(),
+            owner_account_3.address(),
+        ],
+    )
     .await;
 }
 
@@ -149,6 +159,7 @@ async fn test_multisig_transaction_update_signature_threshold() {
             vec![owner_account_2.address()],
             2,    /* 2-of-2 */
             1000, /* initial balance */
+            None,
         )
         .await;
 
@@ -189,7 +200,7 @@ async fn test_multisig_transaction_update_signature_threshold() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_multisig_transaction_with_insufficient_balance_to_cover_gas() {
-    let mut context = new_test_context(current_function_name!());
+    let mut context: TestContext = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     // Owner 2 has no APT balance.
     let owner_account_2 = &mut context.gen_account();
@@ -199,6 +210,7 @@ async fn test_multisig_transaction_with_insufficient_balance_to_cover_gas() {
             vec![owner_account_2.address()],
             1,
             1000, /* initial balance */
+            None,
         )
         .await;
 
@@ -217,7 +229,7 @@ async fn test_multisig_transaction_with_payload_and_failing_execution() {
     let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
-        .create_multisig_account(owner_account, vec![], 1, 1000)
+        .create_multisig_account(owner_account, vec![], 1, 1000, None)
         .await;
     assert_eq!(1000, context.get_apt_balance(multisig_account).await);
     let multisig_payload = construct_multisig_txn_transfer_payload(owner_account.address(), 2000);
@@ -241,7 +253,7 @@ async fn test_multisig_transaction_with_payload_hash() {
     let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
-        .create_multisig_account(owner_account, vec![], 1, 1000)
+        .create_multisig_account(owner_account, vec![], 1, 1000, None)
         .await;
     assert_eq!(1000, context.get_apt_balance(multisig_account).await);
     let multisig_payload = construct_multisig_txn_transfer_payload(owner_account.address(), 1000);
@@ -273,7 +285,7 @@ async fn test_multisig_transaction_with_payload_hash_and_failing_execution() {
     let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
-        .create_multisig_account(owner_account, vec![], 1, 1000)
+        .create_multisig_account(owner_account, vec![], 1, 1000, None)
         .await;
     assert_eq!(1000, context.get_apt_balance(multisig_account).await);
     let multisig_payload = construct_multisig_txn_transfer_payload(owner_account.address(), 2000);
@@ -308,7 +320,7 @@ async fn test_multisig_transaction_with_payload_not_matching_hash() {
     let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
-        .create_multisig_account(owner_account, vec![], 1, 1000)
+        .create_multisig_account(owner_account, vec![], 1, 1000, None)
         .await;
     let multisig_payload = construct_multisig_txn_transfer_payload(owner_account.address(), 500);
     context
@@ -345,6 +357,7 @@ async fn test_multisig_transaction_simulation() {
             vec![owner_account_2.address(), owner_account_3.address()],
             2,    /* 2-of-3 */
             1000, /* initial balance */
+            None,
         )
         .await;
 
@@ -402,6 +415,7 @@ async fn test_simulate_multisig_transaction_should_charge_gas_against_sender() {
             vec![],
             1,  /* 1-of-1 */
             10, /* initial balance */
+            None,
         )
         .await;
     assert_eq!(10, context.get_apt_balance(multisig_account).await);

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -19,7 +19,7 @@ use aptos_types::{
         authenticator::{AuthenticationKey, TransactionAuthenticator},
         EntryFunction, Script, SignedTransaction,
     },
-    utility_coin::APTOS_COIN_TYPE,
+    utility_coin::SUPRA_COIN_TYPE,
 };
 use move_core_types::{
     identifier::Identifier,
@@ -770,7 +770,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_address() {
         "0x1222",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u64).unwrap(),
@@ -789,7 +789,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_module_name() {
         "0x1",
         "CoinInvalid",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u64).unwrap(),
@@ -808,7 +808,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_name() {
         "0x1",
         "Coin",
         "transfer_invalid",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u64).unwrap(),
@@ -827,7 +827,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_arguments() {
         "0x1",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u8).unwrap(), // invalid type
@@ -846,7 +846,7 @@ async fn test_get_txn_execute_failed_by_missing_entry_function_arguments() {
         "0x1",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             // missing arguments
@@ -869,7 +869,7 @@ async fn test_get_txn_execute_failed_by_entry_function_validation() {
         "0x1",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&123u64).unwrap(), // exceed limit, account balance is 0.
@@ -892,7 +892,7 @@ async fn test_get_txn_execute_failed_by_entry_function_invalid_module_name() {
         "0x1",
         "coin",
         "transfer::what::what",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&123u64).unwrap(), // exceed limit, account balance is 0.
@@ -915,7 +915,7 @@ async fn test_get_txn_execute_failed_by_entry_function_invalid_function_name() {
         "0x1",
         "coin::coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![SUPRA_COIN_TYPE.clone()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&123u64).unwrap(), // exceed limit, account balance is 0.

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -419,7 +419,7 @@ impl TestContext {
             create_multisig_account_address(account.address(), account.sequence_number());
         let create_multisig_txn = account.sign_with_transaction_builder(
             factory
-                .create_multisig_account(additional_owners, signatures_required)
+                .create_multisig_account(additional_owners, signatures_required,u64::MAX)
                 .expiration_timestamp_secs(u64::MAX),
         );
         self.commit_block(&vec![

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -184,6 +184,8 @@ pub struct TestContext {
 }
 
 impl TestContext {
+    const DEFAULT_MULTISIG_TX_TIMEOUT_SECS: u64 = 1000;
+
     pub fn new(
         context: Context,
         rng: rand::rngs::StdRng,
@@ -413,13 +415,18 @@ impl TestContext {
         additional_owners: Vec<AccountAddress>,
         signatures_required: u64,
         initial_balance: u64,
+        override_default_timeout: Option<u64>,
     ) -> AccountAddress {
         let factory = self.transaction_factory();
         let multisig_address =
             create_multisig_account_address(account.address(), account.sequence_number());
         let create_multisig_txn = account.sign_with_transaction_builder(
             factory
-                .create_multisig_account(additional_owners, signatures_required,u64::MAX)
+                .create_multisig_account(
+                    additional_owners,
+                    signatures_required,
+                    override_default_timeout.unwrap_or(Self::DEFAULT_MULTISIG_TX_TIMEOUT_SECS),
+                )
                 .expiration_timestamp_secs(u64::MAX),
         );
         self.commit_block(&vec![

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -135,7 +135,7 @@
 
 </dd>
 <dt>
-<code>vesting_percentage: u8</code>
+<code>vpool_locking_percentage: u8</code>
 </dt>
 <dd>
 
@@ -486,20 +486,20 @@
 
 
 
+<a id="0x1_genesis_EPERCENTAGE_INVALID"></a>
+
+
+
+<pre><code><b>const</b> <a href="genesis.md#0x1_genesis_EPERCENTAGE_INVALID">EPERCENTAGE_INVALID</a>: u64 = 6;
+</code></pre>
+
+
+
 <a id="0x1_genesis_EVESTING_SCHEDULE_IS_ZERO"></a>
 
 
 
 <pre><code><b>const</b> <a href="genesis.md#0x1_genesis_EVESTING_SCHEDULE_IS_ZERO">EVESTING_SCHEDULE_IS_ZERO</a>: u64 = 3;
-</code></pre>
-
-
-
-<a id="0x1_genesis_PERCENTAGE_INVALID"></a>
-
-
-
-<pre><code><b>const</b> <a href="genesis.md#0x1_genesis_PERCENTAGE_INVALID">PERCENTAGE_INVALID</a>: u64 = 6;
 </code></pre>
 
 
@@ -1057,6 +1057,8 @@ encoded in a single BCS byte array.
         delegator_config.delegation_pool_creation_seed,
     );
     <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">delegation_pool::get_owned_pool_address</a>(delegator_config.owner_address);
+		<a href="delegation_pool.md#0x1_delegation_pool_set_operator">delegation_pool::set_operator</a>(&owner_signer,delegator_config.validator.validator_config.operator_address);
+		<a href="delegation_pool.md#0x1_delegation_pool_set_delegated_voter">delegation_pool::set_delegated_voter</a>(&owner_signer,delegator_config.validator.validator_config.voter_address);
 
     <b>let</b> i = 0;
     <b>while</b> (i &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&delegator_config.delegator_addresses)) {
@@ -1101,7 +1103,7 @@ encoded in a single BCS byte array.
     delegation_percentage: u64,
 ) {
 		<b>let</b> unique_accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>assert</b>!(delegation_percentage &gt; 0 && delegation_percentage &lt;= 100, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_PERCENTAGE_INVALID">PERCENTAGE_INVALID</a>));
+    <b>assert</b>!(delegation_percentage &gt; 0 && delegation_percentage &lt;= 100, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EPERCENTAGE_INVALID">EPERCENTAGE_INVALID</a>));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(&pbo_delegator_configs, |pbo_delegator_config| {
         <b>let</b> pbo_delegator_config: &<a href="genesis.md#0x1_genesis_PboDelegatorConfiguration">PboDelegatorConfiguration</a> = pbo_delegator_config;
 			<b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_contains">vector::contains</a>(&unique_accounts,&pbo_delegator_config.delegator_config.owner_address),
@@ -1135,6 +1137,7 @@ encoded in a single BCS byte array.
     pbo_delegator_config: &<a href="genesis.md#0x1_genesis_PboDelegatorConfiguration">PboDelegatorConfiguration</a>,
     delegation_percentage: u64,
 ) {
+		<b>assert</b>!(delegation_percentage&gt;0 && delegation_percentage&lt;=100,<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EPERCENTAGE_INVALID">EPERCENTAGE_INVALID</a>));
     <b>let</b> unique_accounts:<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(&pbo_delegator_config.delegator_config.delegator_addresses, |delegator_address| {
         <b>let</b> delegator_address: &<b>address</b> = delegator_address;
@@ -1165,14 +1168,15 @@ encoded in a single BCS byte array.
         pbo_delegator_config.principle_lockup_time,
     );
 
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">delegation_pool::get_owned_pool_address</a>(pbo_delegator_config.delegator_config.owner_address);
+    <b>let</b> pool_address = <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_get_owned_pool_address">pbo_delegation_pool::get_owned_pool_address</a>(pbo_delegator_config.delegator_config.owner_address);
 		<b>let</b> validator = pbo_delegator_config.delegator_config.validator.validator_config;
+		<a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_set_operator">pbo_delegation_pool::set_operator</a>(&owner_signer,validator.operator_address);
+		<a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_set_delegated_voter">pbo_delegation_pool::set_delegated_voter</a>(&owner_signer,validator.voter_address);
 		<a href="genesis.md#0x1_genesis_assert_validator_addresses_check">assert_validator_addresses_check</a>(&validator);
 
 		<b>if</b> (pbo_delegator_config.delegator_config.validator.join_during_genesis) {
-            <a href="genesis.md#0x1_genesis_initialize_validator">initialize_validator</a>(pool_address,&validator);
-        };
-
+        <a href="genesis.md#0x1_genesis_initialize_validator">initialize_validator</a>(pool_address,&validator);
+    };
 }
 </code></pre>
 
@@ -1195,21 +1199,19 @@ encoded in a single BCS byte array.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_assert_validator_addresses_check">assert_validator_addresses_check</a>(validator: &<a href="genesis.md#0x1_genesis_ValidatorConfiguration">ValidatorConfiguration</a>)
-	{
-		 <b>assert</b>!(
-               <a href="account.md#0x1_account_exists_at">account::exists_at</a>(validator.owner_address),
-               <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="genesis.md#0x1_genesis_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>),
-           );
-           <b>assert</b>!(
-               <a href="account.md#0x1_account_exists_at">account::exists_at</a>(validator.operator_address),
-               <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="genesis.md#0x1_genesis_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>),
-           );
-           <b>assert</b>!(
-               <a href="account.md#0x1_account_exists_at">account::exists_at</a>(validator.voter_address),
-               <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="genesis.md#0x1_genesis_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>),
-           );
-
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_assert_validator_addresses_check">assert_validator_addresses_check</a>(validator: &<a href="genesis.md#0x1_genesis_ValidatorConfiguration">ValidatorConfiguration</a>) {
+       <b>assert</b>!(
+           <a href="account.md#0x1_account_exists_at">account::exists_at</a>(validator.owner_address),
+           <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="genesis.md#0x1_genesis_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>),
+       );
+       <b>assert</b>!(
+           <a href="account.md#0x1_account_exists_at">account::exists_at</a>(validator.operator_address),
+           <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="genesis.md#0x1_genesis_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>),
+       );
+       <b>assert</b>!(
+           <a href="account.md#0x1_account_exists_at">account::exists_at</a>(validator.voter_address),
+           <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="genesis.md#0x1_genesis_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>),
+       );
 	}
 </code></pre>
 
@@ -1242,8 +1244,8 @@ encoded in a single BCS byte array.
         <b>let</b> schedule_length = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&pool_config.vesting_numerators);
         <b>assert</b>!(schedule_length &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EVESTING_SCHEDULE_IS_ZERO">EVESTING_SCHEDULE_IS_ZERO</a>));
         <b>assert</b>!(pool_config.vesting_denominator &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EDENOMINATOR_IS_ZERO">EDENOMINATOR_IS_ZERO</a>));
-        <b>assert</b>!(pool_config.vesting_percentage &gt; 0 && pool_config.vesting_percentage &lt;=100 ,
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_PERCENTAGE_INVALID">PERCENTAGE_INVALID</a>));
+        <b>assert</b>!(pool_config.vpool_locking_percentage &gt; 0 && pool_config.vpool_locking_percentage &lt;=100 ,
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EPERCENTAGE_INVALID">EPERCENTAGE_INVALID</a>));
         //check the sum of numerator are &lt;= denominator.
         <b>let</b> sum = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_fold">vector::fold</a>(pool_config.vesting_numerators,0,|acc, x| acc + x);
         // Check that total of all fraction in `vesting_schedule` is not greater than 1
@@ -1280,7 +1282,7 @@ encoded in a single BCS byte array.
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> unique_accounts,shareholder);
             <b>let</b> shareholder_signer = <a href="create_signer.md#0x1_create_signer">create_signer</a>(shareholder);
             <b>let</b> amount = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(shareholder);
-            <b>let</b> amount_to_extract = (amount * (pool_config.vesting_percentage <b>as</b> u64)) / 100;
+            <b>let</b> amount_to_extract = (amount * (pool_config.vpool_locking_percentage <b>as</b> u64)) / 100;
             <b>let</b> coin_share = <a href="coin.md#0x1_coin_withdraw">coin::withdraw</a>&lt;SupraCoin&gt;(&shareholder_signer, amount_to_extract);
             <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> buy_ins,shareholder,coin_share);
             j = j + 1;
@@ -1417,7 +1419,7 @@ The last step of genesis.
         rewards_rate_denominator,
         voting_power_increase_limit
     );
-    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags">features::change_feature_flags</a>(supra_framework, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[1, 2], <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags">features::change_feature_flags</a>(supra_framework, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[1, 2, 11], <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
     <a href="genesis.md#0x1_genesis_initialize_supra_coin">initialize_supra_coin</a>(supra_framework);
     <a href="aptos_governance.md#0x1_aptos_governance_initialize_for_verification">aptos_governance::initialize_for_verification</a>(
         supra_framework,

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -617,7 +617,7 @@ module supra_framework::genesis {
         chain_status::set_genesis_end(supra_framework);
     }
 
-    #[verify_only]
+    #[test_only]
     use std::features;
 
     #[verify_only]
@@ -660,7 +660,7 @@ module supra_framework::genesis {
             rewards_rate_denominator,
             voting_power_increase_limit
         );
-        features::change_feature_flags(supra_framework, vector[1, 2], vector[]);
+        features::change_feature_flags(supra_framework, vector[1, 2, 11], vector[]);
         initialize_supra_coin(supra_framework);
         aptos_governance::initialize_for_verification(
             supra_framework,
@@ -676,7 +676,6 @@ module supra_framework::genesis {
 
     #[test_only]
     const ONE_APT: u64 = 100000000;
-
     #[test_only]
     public fun setup() {
         initialize(
@@ -694,6 +693,7 @@ module supra_framework::genesis {
             1,
             30,
         )
+		
     }
 
     #[test]
@@ -758,6 +758,7 @@ module supra_framework::genesis {
     #[test(supra_framework = @0x1)]
     fun test_create_delegation_pool(supra_framework: &signer) {
         setup();
+		features::change_feature_flags(supra_framework,vector[11],vector[]);
         initialize_supra_coin(supra_framework);
         let owner = @0x121341;
         create_account(supra_framework, owner, 0);
@@ -802,6 +803,7 @@ module supra_framework::genesis {
     #[test(supra_framework = @0x1)]
     fun test_create_delegation_pools(supra_framework: &signer) {
         setup();
+		features::change_feature_flags(supra_framework,vector[11],vector[]);
         initialize_supra_coin(supra_framework);
         let owner1 = @0x121341;
         create_account(supra_framework, owner1, 0);
@@ -879,6 +881,9 @@ module supra_framework::genesis {
     #[test(supra_framework = @0x1)]
     fun test_create_pbo_delegation_pool(supra_framework: &signer) {
         setup();
+		
+		features::change_feature_flags(supra_framework,vector[11],vector[]);
+
         initialize_supra_coin(supra_framework);
         let owner = @0x121341;
 		let (_, pk_1) = stake::generate_identity();
@@ -927,6 +932,7 @@ module supra_framework::genesis {
     #[test(supra_framework = @0x1)]
     fun test_create_pbo_delegation_pools(supra_framework: &signer) {
         setup();
+		features::change_feature_flags(supra_framework,vector[11],vector[]);
         initialize_supra_coin(supra_framework);
         let owner1 = @0x121341;
 		create_account(supra_framework,@0x121341,0);

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -617,9 +617,8 @@ module supra_framework::genesis {
         chain_status::set_genesis_end(supra_framework);
     }
 
-    #[test_only]
+    #[verify_only]
     use std::features;
-
     #[verify_only]
     fun initialize_for_verification(
         gas_schedule: vector<u8>,
@@ -674,6 +673,8 @@ module supra_framework::genesis {
         set_genesis_end(supra_framework);
     }
 
+    #[test_only]
+    use std::features;
     #[test_only]
     const ONE_APT: u64 = 100000000;
     #[test_only]

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -674,8 +674,6 @@ module supra_framework::genesis {
     }
 
     #[test_only]
-    use std::features;
-    #[test_only]
     const ONE_APT: u64 = 100000000;
     #[test_only]
     public fun setup() {
@@ -758,6 +756,7 @@ module supra_framework::genesis {
 
     #[test(supra_framework = @0x1)]
     fun test_create_delegation_pool(supra_framework: &signer) {
+		use std::features;
         setup();
 		features::change_feature_flags(supra_framework,vector[11],vector[]);
         initialize_supra_coin(supra_framework);
@@ -803,6 +802,7 @@ module supra_framework::genesis {
 
     #[test(supra_framework = @0x1)]
     fun test_create_delegation_pools(supra_framework: &signer) {
+		use std::features;
         setup();
 		features::change_feature_flags(supra_framework,vector[11],vector[]);
         initialize_supra_coin(supra_framework);
@@ -881,6 +881,7 @@ module supra_framework::genesis {
 
     #[test(supra_framework = @0x1)]
     fun test_create_pbo_delegation_pool(supra_framework: &signer) {
+		use std::features;
         setup();
 		
 		features::change_feature_flags(supra_framework,vector[11],vector[]);
@@ -932,6 +933,7 @@ module supra_framework::genesis {
 
     #[test(supra_framework = @0x1)]
     fun test_create_pbo_delegation_pools(supra_framework: &signer) {
+		use std::features;
         setup();
 		features::change_feature_flags(supra_framework,vector[11],vector[]);
         initialize_supra_coin(supra_framework);

--- a/aptos-move/framework/supra-framework/sources/vesting_without_staking.move
+++ b/aptos-move/framework/supra-framework/sources/vesting_without_staking.move
@@ -700,11 +700,11 @@ module supra_framework::vesting_without_staking {
 
 
     #[test_only]
-    public entry fun setup(supra_framework: &signer, accounts: &vector<address>) {
+    public entry fun setup(supra_framework: &signer, accounts: vector<address>) {
         use supra_framework::aptos_account::create_account;
         timestamp::set_time_has_started_for_testing(supra_framework);
         stake::initialize_for_test(supra_framework);
-        vector::for_each_ref(accounts, |addr| {
+        vector::for_each_ref(&accounts, |addr| {
             let addr: address = *addr;
             if (!account::exists_at(addr)) {
                 create_account(addr);
@@ -782,7 +782,7 @@ module supra_framework::vesting_without_staking {
         let shares = &vector[shareholder_1_share, shareholder_2_share];
         // Create the vesting contract.
         setup(
-            supra_framework, &vector[admin_address, withdrawal_address, shareholder_1_address, shareholder_2_address]);
+            supra_framework, vector[admin_address, withdrawal_address, shareholder_1_address, shareholder_2_address]);
         // let contract_address = setup_vesting_contract(admin, shareholders, shares, withdrawal_address);
         let contract_address = setup_vesting_contract_with_schedule(
             admin,
@@ -828,7 +828,7 @@ module supra_framework::vesting_without_staking {
         let shares = &vector[shareholder_1_share, shareholder_2_share];
         // Create the vesting contract.
         setup(
-            supra_framework, &vector[admin_address, withdrawal_address, shareholder_1_address, shareholder_2_address]);
+            supra_framework, vector[admin_address, withdrawal_address, shareholder_1_address, shareholder_2_address]);
         let contract_address = setup_vesting_contract(admin, shareholders, shares, withdrawal_address);
         assert!(vector::length(&borrow_global<AdminStore>(admin_address).vesting_contracts) == 1, 0);
         let vested_amount_1 = 0;
@@ -911,7 +911,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1], &vector[0], admin_address);
     }
 
@@ -922,7 +922,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         setup_vesting_contract(admin, &vector[], &vector[], admin_address);
     }
 
@@ -933,7 +933,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @5);
     }
 
@@ -944,7 +944,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @11);
     }
 
@@ -955,7 +955,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         create_account_for_test(@11);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @11);
     }
@@ -964,35 +964,35 @@ module supra_framework::vesting_without_staking {
     #[test(supra_framework = @0x1)]
     #[expected_failure(abort_code = 0x10002, location = Self)]
     public entry fun test_create_empty_vesting_schedule_should_fail(supra_framework: &signer) {
-        setup(supra_framework, &vector[]);
+        setup(supra_framework, vector[]);
         create_vesting_schedule(vector[], 1, 1);
     }
 
     #[test(supra_framework = @0x1)]
     #[expected_failure(abort_code = 0x10002, location = Self)]
     public entry fun test_create_first_element_zero_vesting_schedule_should_fail(supra_framework: &signer) {
-        setup(supra_framework, &vector[]);
+        setup(supra_framework, vector[]);
         create_vesting_schedule(vector[fixed_point32::create_from_raw_value(0), fixed_point32::create_from_raw_value(8)], 1, 1);
     }
 
     #[test(supra_framework = @0x1)]
     #[expected_failure(abort_code = 0x10002, location = Self)]
     public entry fun test_create_last_element_zero_vesting_schedule_should_fail(supra_framework: &signer) {
-        setup(supra_framework, &vector[]);
+        setup(supra_framework, vector[]);
         create_vesting_schedule(vector[ fixed_point32::create_from_raw_value(8), fixed_point32::create_from_raw_value(0)], 1, 1);
     }
 
     #[test(supra_framework = @0x1)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
     public entry fun test_create_vesting_schedule_with_zero_period_duration_should_fail(supra_framework: &signer) {
-        setup(supra_framework, &vector[]);
+        setup(supra_framework, vector[]);
         create_vesting_schedule(vector[fixed_point32::create_from_rational(1, 1)], 1, 0);
     }
 
     #[test(supra_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x10006, location = Self)]
     public entry fun test_create_vesting_schedule_with_invalid_vesting_start_should_fail(supra_framework: &signer) {
-        setup(supra_framework, &vector[]);
+        setup(supra_framework, vector[]);
         timestamp::update_global_time_for_test_secs(1000);
         create_vesting_schedule(
             vector[fixed_point32::create_from_rational(1, 1)],
@@ -1008,7 +1008,7 @@ module supra_framework::vesting_without_staking {
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
-        setup(supra_framework, &vector[admin_address, shareholder_address]);
+        setup(supra_framework, vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract_with_schedule(
             admin,
             &vector[shareholder_address],
@@ -1042,7 +1042,7 @@ module supra_framework::vesting_without_staking {
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
-        setup(supra_framework, &vector[admin_address, shareholder_address]);
+        setup(supra_framework, vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address);
 
@@ -1060,7 +1060,7 @@ module supra_framework::vesting_without_staking {
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
-        setup(supra_framework, &vector[admin_address, shareholder_address]);
+        setup(supra_framework, vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address);
 
@@ -1078,7 +1078,7 @@ module supra_framework::vesting_without_staking {
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
-        setup(supra_framework, &vector[admin_address, shareholder_address]);
+        setup(supra_framework, vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address);
 
@@ -1093,7 +1093,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address);
         set_beneficiary(admin, contract_address, @1, @11);
@@ -1106,7 +1106,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address);
         create_account_for_test(@11);
@@ -1119,7 +1119,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address, @11]);
+        setup(supra_framework, vector[admin_address, @11]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@1], &vector[GRANT_AMOUNT], admin_address);
         set_beneficiary(admin, contract_address, @1, @11);
@@ -1140,7 +1140,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address]);
+        setup(supra_framework, vector[admin_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address);
         let role = utf8(b"RANDOM");
@@ -1156,7 +1156,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address, @11, @12]);
+        setup(supra_framework, vector[admin_address, @11, @12]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address);
         set_beneficiary(admin, contract_address, @11, @12);
@@ -1181,7 +1181,7 @@ module supra_framework::vesting_without_staking {
         resetter: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address, @11, @12]);
+        setup(supra_framework, vector[admin_address, @11, @12]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address);
         set_beneficiary(admin, contract_address, @11, @12);
@@ -1204,7 +1204,7 @@ module supra_framework::vesting_without_staking {
         random: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address, @11]);
+        setup(supra_framework, vector[admin_address, @11]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address);
 
@@ -1219,7 +1219,7 @@ module supra_framework::vesting_without_staking {
         admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
-        setup(supra_framework, &vector[admin_address, @11, @12]);
+        setup(supra_framework, vector[admin_address, @11, @12]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address);
 

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -76,7 +76,7 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
 
 #[test]
 fn move_framework_unit_tests() {
-    run_tests_for_pkg("aptos-framework");
+    run_tests_for_pkg("supra-framework");
 }
 
 #[test]

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -65,12 +65,14 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
     natives::configure_for_unit_test();
     extended_checks::configure_extended_checks_for_unit_test();
     // move_stdlib has the testing feature enabled to include debug native functions
+	let mut f = Features::default();
+	f.enable(aptos_types::on_chain_config::FeatureFlag::DELEGATION_POOLS);
     natives::aptos_natives(
         LATEST_GAS_FEATURE_VERSION,
         NativeGasParameters::zeros(),
         MiscGasParameters::zeros(),
         TimedFeaturesBuilder::enable_all().build(),
-        Features::default(),
+        f,
     )
 }
 

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -40,6 +40,8 @@ pub struct Create {
     pub(crate) additional_owners: Vec<AccountAddress>,
     /// The number of signatures (approvals or rejections) required to execute or remove a proposed
     /// transaction.
+	#[clap(long)]
+	pub(crate) timeout_duration: u64,
     #[clap(long)]
     pub(crate) num_signatures_required: u64,
     #[clap(flatten)]
@@ -99,6 +101,7 @@ impl CliCommand<CreateSummary> for Create {
                 // TODO: Support passing in custom metadata.
                 vec![],
                 vec![],
+				self.timeout_duration,
             ))
             .await
             .map(CreateSummary::from)

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -38,10 +38,12 @@ pub struct Create {
     /// Addresses of additional owners for the new multisig, beside the transaction sender.
     #[clap(long, num_args = 0.., value_parser = crate::common::types::load_account_arg)]
     pub(crate) additional_owners: Vec<AccountAddress>,
-    /// The number of signatures (approvals or rejections) required to execute or remove a proposed
-    /// transaction.
+	/// account level timeout_duration in seconds, all created Tx must be approved and 
+	/// executed before this timeout (from its creation) otherwise the Tx is marked for rejection
 	#[clap(long)]
 	pub(crate) timeout_duration: u64,
+    /// The number of signatures (approvals or rejections) required to execute or remove a proposed
+    /// transaction.
     #[clap(long)]
     pub(crate) num_signatures_required: u64,
     #[clap(flatten)]

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -266,7 +266,7 @@ impl CoinActivity {
             event_creation_number: BURN_GAS_EVENT_CREATION_NUM,
             event_sequence_number: user_transaction_request.sequence_number.0 as i64,
             owner_address: standardize_address(&user_transaction_request.sender.to_string()),
-            coin_type: APTOS_COIN_TYPE.to_string(),
+            coin_type: SUPRA_COIN_TYPE.to_string(),
             amount: aptos_coin_burned,
             activity_type: GAS_FEE_EVENT.to_string(),
             is_gas_fee: true,

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -280,7 +280,7 @@ impl TransactionProcessor for CoinTransactionProcessor {
         // get aptos_coin info for supply tracking
         // TODO: This only needs to be fetched once. Need to persist somehow
         let maybe_aptos_coin_info =
-            &CoinInfoQuery::get_by_coin_type(APTOS_COIN_TYPE.to_string(), &mut conn).unwrap();
+            &CoinInfoQuery::get_by_coin_type(SUPRA_COIN_TYPE.to_string(), &mut conn).unwrap();
 
         let mut all_coin_activities = vec![];
         let mut all_coin_balances = vec![];

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -135,7 +135,7 @@ fn get_aptos_coin_mint_transaction(
         /* sequence_number = */ aptos_root_seq_num,
         aptos_root_key.clone(),
         aptos_root_key.public_key(),
-        Some(aptos_stdlib::aptos_coin_mint(*account, amount)),
+        Some(aptos_stdlib::supra_coin_mint(*account, amount)),
     )
 }
 

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -119,7 +119,7 @@ fn test_reconfiguration() {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(aptos_stdlib::aptos_coin_mint(validator_account, 1_000_000)),
+        Some(aptos_stdlib::supra_coin_mint(validator_account, 1_000_000)),
     );
     // txn2 = a dummy block prologue to bump the timer.
     let txn2 = Transaction::BlockMetadata(BlockMetadata::new(

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -174,12 +174,14 @@ impl TransactionFactory {
         &self,
         additional_owners: Vec<AccountAddress>,
         signatures_required: u64,
+		timeout_duration: u64,
     ) -> TransactionBuilder {
         self.payload(aptos_stdlib::multisig_account_create_with_owners(
             additional_owners,
             signatures_required,
             vec![],
             vec![],
+			timeout_duration,
         ))
     }
 

--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -187,7 +187,7 @@ impl<'t> AptosPublicInfo<'t> {
     pub async fn mint(&mut self, addr: AccountAddress, amount: u64) -> Result<()> {
         let mint_txn = self.root_account.sign_with_transaction_builder(
             self.transaction_factory()
-                .payload(aptos_stdlib::aptos_coin_mint(addr, amount)),
+                .payload(aptos_stdlib::supra_coin_mint(addr, amount)),
         );
         self.rest_client.submit_and_wait(&mint_txn).await?;
         Ok(())

--- a/testsuite/smoke-test/src/aptos/error_report.rs
+++ b/testsuite/smoke-test/src/aptos/error_report.rs
@@ -17,7 +17,7 @@ async fn submit_and_check_err<F: Fn(TransactionBuilder) -> TransactionBuilder>(
 ) {
     let payload = info
         .transaction_factory()
-        .payload(aptos_stdlib::aptos_coin_claim_mint_capability())
+        .payload(aptos_stdlib::supra_coin_claim_mint_capability())
         .sequence_number(0);
     let txn = local_account.sign_transaction(f(payload).build());
     let err = format!(

--- a/testsuite/smoke-test/src/aptos/mint_transfer.rs
+++ b/testsuite/smoke-test/src/aptos/mint_transfer.rs
@@ -49,7 +49,7 @@ async fn test_mint_transfer() {
     let delegate_txn1 = info
         .root_account()
         .sign_with_transaction_builder(txn_factory.payload(
-            aptos_stdlib::aptos_coin_delegate_mint_capability(account1.address()),
+            aptos_stdlib::supra_coin_delegate_mint_capability(account1.address()),
         ));
     info.client().submit_and_wait(&delegate_txn1).await.unwrap();
 
@@ -57,16 +57,16 @@ async fn test_mint_transfer() {
     let delegate_txn2 = info
         .root_account()
         .sign_with_transaction_builder(txn_factory.payload(
-            aptos_stdlib::aptos_coin_delegate_mint_capability(account2.address()),
+            aptos_stdlib::supra_coin_delegate_mint_capability(account2.address()),
         ));
     info.client().submit_and_wait(&delegate_txn2).await.unwrap();
 
     let claim_txn = account1.sign_with_transaction_builder(
-        txn_factory.payload(aptos_stdlib::aptos_coin_claim_mint_capability()),
+        txn_factory.payload(aptos_stdlib::supra_coin_claim_mint_capability()),
     );
     info.client().submit_and_wait(&claim_txn).await.unwrap();
     let mint_txn = account1.sign_with_transaction_builder(
-        txn_factory.payload(aptos_stdlib::aptos_coin_mint(account1.address(), 10000)),
+        txn_factory.payload(aptos_stdlib::supra_coin_mint(account1.address(), 10000)),
     );
     info.client().submit_and_wait(&mint_txn).await.unwrap();
 

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -80,7 +80,7 @@ fn test_validate_transaction() {
     let vm_validator = TestValidator::new();
 
     let address = account_config::aptos_test_root_address();
-    let program = aptos_stdlib::aptos_coin_mint(address, 100);
+    let program = aptos_stdlib::supra_coin_mint(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,


### PR DESCRIPTION
CI has following set of tests which were breaking

```cargo test --release -p aptos-framework -- --skip prover```

It seems that move compiler from CLI is different from when it is used from `cargo`, which requires some fixes in `vesting_without_staking.move` test cases. Apparently `&vector<address>` is not allowed when compiler is triggered from the above cargo command.

Additionally, from the test environment that above `cargo` sets up, does not enable `FeatureFlag::DELEGATION_POOLS`, this triggers assertion failure in pool creation test cases. Somehow could not fix in rust, so had to fix in test environment in `genesis.move`.

Multisig account creation now takes one more argument, `timeout_duration`, so the rust counterpart complained. @so-kkroy22 / @supra-yoga may test and check that mutisig account creation from rust is working fine.

Apart from this, `rust-analyzer` pointed out some issues where `aptos` or `APTOS` has to be changed from `supra` or `SUPRA`.

These changes should also ensure that the CI checks in `integrate_consensus_key` branch passes.