### PR TITLE
fix unnecessary looping by stopping when cfraction crosses one

### DIFF
--- a/aptos-move/framework/supra-framework/doc/pbo_delegation_pool.md
+++ b/aptos-move/framework/supra-framework/doc/pbo_delegation_pool.md
@@ -3698,8 +3698,9 @@ accurate as time passes
         / unlock_schedule.period_duration;
     <b>let</b> last_unlocked_period = unlock_schedule.last_unlock_period;
     <b>let</b> schedule_length = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&unlock_schedule.schedule);
+    <b>let</b> one = <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_create_from_rational">fixed_point64::create_from_rational</a>(1,1);
     <b>let</b> cfraction = unlock_schedule.cumulative_unlocked_fraction;
-    <b>while</b> (last_unlocked_period &lt; unlock_periods_passed) {
+    <b>while</b> (last_unlocked_period &lt; unlock_periods_passed && <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_less">fixed_point64::less</a>(cfraction,one)) {
         <b>let</b> next_fraction = <b>if</b> (schedule_length &lt;= last_unlocked_period) {
             *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&unlock_schedule.schedule, schedule_length - 1)
         } <b>else</b> { *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&unlock_schedule.schedule, last_unlocked_period) };


### PR DESCRIPTION
In `can_unlock_principle` the loop keeps looping even though `cfraction` might have become greater than one. That is just unnecessary waste and in cases where a long time has elapsed (cliff is lesser, period is lesser but very long time has elapsed) in that case this loop would exceed execution limit. As it is there is no utility in looping after unlocked fraction crosses `1`.