### PR TITLE
Ensured that the Supra protocol configuration settings are stored in the Move state.

### DIFF
--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -73,6 +73,7 @@
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
 <b>use</b> <a href="supra_account.md#0x1_supra_account">0x1::supra_account</a>;
 <b>use</b> <a href="supra_coin.md#0x1_supra_coin">0x1::supra_coin</a>;
+<b>use</b> <a href="supra_config.md#0x1_supra_config">0x1::supra_config</a>;
 <b>use</b> <a href="supra_governance.md#0x1_supra_governance">0x1::supra_governance</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
 <b>use</b> <a href="transaction_fee.md#0x1_transaction_fee">0x1::transaction_fee</a>;
@@ -550,7 +551,7 @@
 Genesis step 1: Initialize aptos framework account and core modules on chain.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, genesis_timestamp_in_microseconds: u64)
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="supra_config.md#0x1_supra_config">supra_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, genesis_timestamp_in_microseconds: u64)
 </code></pre>
 
 
@@ -565,6 +566,7 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     initial_version: u64,
     <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="supra_config.md#0x1_supra_config">supra_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     epoch_interval_microsecs: u64,
     minimum_stake: u64,
     maximum_stake: u64,
@@ -603,6 +605,7 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
 
     <a href="consensus_config.md#0x1_consensus_config_initialize">consensus_config::initialize</a>(&supra_framework_account, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>);
     <a href="execution_config.md#0x1_execution_config_set">execution_config::set</a>(&supra_framework_account, <a href="execution_config.md#0x1_execution_config">execution_config</a>);
+    <a href="supra_config.md#0x1_supra_config_set">supra_config::set</a>(&supra_framework_account, <a href="supra_config.md#0x1_supra_config">supra_config</a>);
     <a href="version.md#0x1_version_initialize">version::initialize</a>(&supra_framework_account, initial_version);
     <a href="stake.md#0x1_stake_initialize">stake::initialize</a>(&supra_framework_account);
     <a href="staking_config.md#0x1_staking_config_initialize">staking_config::initialize</a>(
@@ -1385,7 +1388,7 @@ The last step of genesis.
 
 
 <pre><code>#[verify_only]
-<b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, voting_duration_secs: u64, supra_min_voting_threshold: u64, voters: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">genesis::AccountMap</a>&gt;, employee_vesting_start: u64, employee_vesting_period_duration: u64, employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">genesis::EmployeeAccountMap</a>&gt;, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
+<b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="supra_config.md#0x1_supra_config">supra_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, voting_duration_secs: u64, supra_min_voting_threshold: u64, voters: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">genesis::AccountMap</a>&gt;, employee_vesting_start: u64, employee_vesting_period_duration: u64, employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">genesis::EmployeeAccountMap</a>&gt;, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
 </code></pre>
 
 
@@ -1400,6 +1403,7 @@ The last step of genesis.
     initial_version: u64,
     <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="supra_config.md#0x1_supra_config">supra_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     epoch_interval_microsecs: u64,
     minimum_stake: u64,
     maximum_stake: u64,
@@ -1426,6 +1430,7 @@ The last step of genesis.
         initial_version,
         <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>,
         <a href="execution_config.md#0x1_execution_config">execution_config</a>,
+        <a href="supra_config.md#0x1_supra_config">supra_config</a>,
         epoch_interval_microsecs,
         minimum_stake,
         maximum_stake,
@@ -1532,7 +1537,7 @@ The last step of genesis.
 ### Function `initialize`
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, genesis_timestamp_in_microseconds: u64)
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="supra_config.md#0x1_supra_config">supra_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, genesis_timestamp_in_microseconds: u64)
 </code></pre>
 
 
@@ -1785,7 +1790,7 @@ The last step of genesis.
 
 
 <pre><code>#[verify_only]
-<b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, voting_duration_secs: u64, supra_min_voting_threshold: u64, voters: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">genesis::AccountMap</a>&gt;, employee_vesting_start: u64, employee_vesting_period_duration: u64, employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">genesis::EmployeeAccountMap</a>&gt;, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
+<b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="supra_config.md#0x1_supra_config">supra_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, voting_duration_secs: u64, supra_min_voting_threshold: u64, voters: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">genesis::AccountMap</a>&gt;, employee_vesting_start: u64, employee_vesting_period_duration: u64, employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">genesis::EmployeeAccountMap</a>&gt;, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
 </code></pre>
 
 

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -605,7 +605,7 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
 
     <a href="consensus_config.md#0x1_consensus_config_initialize">consensus_config::initialize</a>(&supra_framework_account, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>);
     <a href="execution_config.md#0x1_execution_config_set">execution_config::set</a>(&supra_framework_account, <a href="execution_config.md#0x1_execution_config">execution_config</a>);
-    <a href="supra_config.md#0x1_supra_config_set">supra_config::set</a>(&supra_framework_account, <a href="supra_config.md#0x1_supra_config">supra_config</a>);
+    <a href="supra_config.md#0x1_supra_config_initialize">supra_config::initialize</a>(&supra_framework_account, <a href="supra_config.md#0x1_supra_config">supra_config</a>);
     <a href="version.md#0x1_version_initialize">version::initialize</a>(&supra_framework_account, initial_version);
     <a href="stake.md#0x1_stake_initialize">stake::initialize</a>(&supra_framework_account);
     <a href="staking_config.md#0x1_staking_config_initialize">staking_config::initialize</a>(
@@ -1570,6 +1570,7 @@ The last step of genesis.
 <b>ensures</b> <b>exists</b>&lt;<a href="supra_governance.md#0x1_supra_governance_GovernanceResponsbility">supra_governance::GovernanceResponsbility</a>&gt;(@supra_framework);
 <b>ensures</b> <b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">consensus_config::ConsensusConfig</a>&gt;(@supra_framework);
 <b>ensures</b> <b>exists</b>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">execution_config::ExecutionConfig</a>&gt;(@supra_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">supra_config::SupraConfig</a>&gt;(@supra_framework);
 <b>ensures</b> <b>exists</b>&lt;<a href="version.md#0x1_version_Version">version::Version</a>&gt;(@supra_framework);
 <b>ensures</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">stake::ValidatorSet</a>&gt;(@supra_framework);
 <b>ensures</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">stake::ValidatorPerformance</a>&gt;(@supra_framework);

--- a/aptos-move/framework/supra-framework/doc/overview.md
+++ b/aptos-move/framework/supra-framework/doc/overview.md
@@ -62,6 +62,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::storage_gas`](storage_gas.md#0x1_storage_gas)
 -  [`0x1::supra_account`](supra_account.md#0x1_supra_account)
 -  [`0x1::supra_coin`](supra_coin.md#0x1_supra_coin)
+-  [`0x1::supra_config`](supra_config.md#0x1_supra_config)
 -  [`0x1::supra_governance`](supra_governance.md#0x1_supra_governance)
 -  [`0x1::system_addresses`](system_addresses.md#0x1_system_addresses)
 -  [`0x1::timestamp`](timestamp.md#0x1_timestamp)

--- a/aptos-move/framework/supra-framework/doc/reconfiguration_with_dkg.md
+++ b/aptos-move/framework/supra-framework/doc/reconfiguration_with_dkg.md
@@ -30,6 +30,7 @@ Reconfiguration with DKG helper functions.
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
 <b>use</b> <a href="stake.md#0x1_stake">0x1::stake</a>;
+<b>use</b> <a href="supra_config.md#0x1_supra_config">0x1::supra_config</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="validator_consensus_info.md#0x1_validator_consensus_info">0x1::validator_consensus_info</a>;
 <b>use</b> <a href="version.md#0x1_version">0x1::version</a>;
@@ -101,6 +102,7 @@ Run the default reconfiguration to enter the new epoch.
     <a href="dkg.md#0x1_dkg_try_clear_incomplete_session">dkg::try_clear_incomplete_session</a>(framework);
     <a href="consensus_config.md#0x1_consensus_config_on_new_epoch">consensus_config::on_new_epoch</a>(framework);
     <a href="execution_config.md#0x1_execution_config_on_new_epoch">execution_config::on_new_epoch</a>(framework);
+    <a href="supra_config.md#0x1_supra_config_on_new_epoch">supra_config::on_new_epoch</a>(framework);
     <a href="gas_schedule.md#0x1_gas_schedule_on_new_epoch">gas_schedule::on_new_epoch</a>(framework);
     std::version::on_new_epoch(framework);
     <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_on_new_epoch">features::on_new_epoch</a>(framework);
@@ -215,6 +217,7 @@ Abort if no DKG is in progress.
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">gas_schedule::GasScheduleV2</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">execution_config::ExecutionConfig</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">consensus_config::ConsensusConfig</a>&gt;;
+    <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">supra_config::SupraConfig</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">jwks::SupportedOIDCProviders</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">randomness_config::RandomnessConfig</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">randomness_config_seqnum::RandomnessConfigSeqNum</a>&gt;;

--- a/aptos-move/framework/supra-framework/doc/supra_config.md
+++ b/aptos-move/framework/supra-framework/doc/supra_config.md
@@ -13,6 +13,13 @@ Reconfiguration, and may be updated by root.
 -  [Function `set`](#0x1_supra_config_set)
 -  [Function `set_for_next_epoch`](#0x1_supra_config_set_for_next_epoch)
 -  [Function `on_new_epoch`](#0x1_supra_config_on_new_epoch)
+-  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
+    -  [Function `initialize`](#@Specification_1_initialize)
+    -  [Function `set`](#@Specification_1_set)
+    -  [Function `set_for_next_epoch`](#@Specification_1_set_for_next_epoch)
+    -  [Function `on_new_epoch`](#@Specification_1_on_new_epoch)
 
 
 <pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
@@ -194,6 +201,150 @@ Only used in reconfigurations to apply the pending <code><a href="supra_config.m
 
 
 </details>
+
+<a id="@Specification_1"></a>
+
+## Specification
+
+
+
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Requirement</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>During genesis, the Supra framework account should be assigned the supra config resource.</td>
+<td>Medium</td>
+<td>The supra_config::initialize function calls the assert_supra_framework function to ensure that the signer is the supra_framework and then assigns the SupraConfig resource to it.</td>
+<td>Formally verified via <a href="#high-level-req-1">initialize</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Only aptos framework account is allowed to update the supra protocol configuration.</td>
+<td>Medium</td>
+<td>The supra_config::set function ensures that the signer is supra_framework.</td>
+<td>Formally verified via <a href="#high-level-req-2">set</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Only a valid configuration can be used during initialization and update.</td>
+<td>Medium</td>
+<td>Both the initialize and set functions validate the config by ensuring its length to be greater than 0.</td>
+<td>Formally verified via <a href="#high-level-req-3.1">initialize</a> and <a href="#high-level-req-3.2">set</a>.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
+<pre><code><b>pragma</b> verify = <b>true</b>;
+<b>pragma</b> aborts_if_is_strict;
+<b>invariant</b> [suspendable] <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework);
+</code></pre>
+
+
+
+<a id="@Specification_1_initialize"></a>
+
+### Function `initialize`
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="supra_config.md#0x1_supra_config_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+Ensure caller is admin.
+Aborts if StateStorageUsage already exists.
+
+
+<pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
+// This enforces <a id="high-level-req-1" href="#high-level-req">high-level requirement 1</a>:
+<b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_supra_framework_address">system_addresses::is_supra_framework_address</a>(addr);
+<b>aborts_if</b> <b>exists</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework);
+// This enforces <a id="high-level-req-3.1" href="#high-level-req">high-level requirement 3</a>:
+<b>aborts_if</b> !(len(config) &gt; 0);
+<b>ensures</b> <b>global</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(addr) == <a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a> { config };
+</code></pre>
+
+
+
+<a id="@Specification_1_set"></a>
+
+### Function `set`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="supra_config.md#0x1_supra_config_set">set</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+Ensure the caller is admin and <code><a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a></code> should exist.
+When setting now time must be later than last_reconfiguration_time.
+
+
+<pre><code><b>pragma</b> verify_duration_estimate = 600;
+<b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
+<b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+// This enforces <a id="high-level-req-2" href="#high-level-req">high-level requirement 2</a>:
+<b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_supra_framework_address">system_addresses::is_supra_framework_address</a>(addr);
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework);
+// This enforces <a id="high-level-req-3.2" href="#high-level-req">high-level requirement 3</a>:
+<b>aborts_if</b> !(len(config) &gt; 0);
+<b>requires</b> <a href="chain_status.md#0x1_chain_status_is_genesis">chain_status::is_genesis</a>();
+<b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();
+<b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@supra_framework);
+<b>requires</b> <b>exists</b>&lt;CoinInfo&lt;SupraCoin&gt;&gt;(@supra_framework);
+<b>ensures</b> <b>global</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework).config == config;
+</code></pre>
+
+
+
+<a id="@Specification_1_set_for_next_epoch"></a>
+
+### Function `set_for_next_epoch`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="supra_config.md#0x1_supra_config_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="config_buffer.md#0x1_config_buffer_SetForNextEpochAbortsIf">config_buffer::SetForNextEpochAbortsIf</a>;
+</code></pre>
+
+
+
+<a id="@Specification_1_on_new_epoch"></a>
+
+### Function `on_new_epoch`
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="supra_config.md#0x1_supra_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>requires</b> @supra_framework == std::signer::address_of(framework);
+<b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;;
+<b>aborts_if</b> <b>false</b>;
+</code></pre>
 
 
 [move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/supra-framework/doc/supra_config.md
+++ b/aptos-move/framework/supra-framework/doc/supra_config.md
@@ -1,0 +1,199 @@
+
+<a id="0x1_supra_config"></a>
+
+# Module `0x1::supra_config`
+
+Maintains the consensus config for the blockchain. The config is stored in a
+Reconfiguration, and may be updated by root.
+
+
+-  [Resource `SupraConfig`](#0x1_supra_config_SupraConfig)
+-  [Constants](#@Constants_0)
+-  [Function `initialize`](#0x1_supra_config_initialize)
+-  [Function `set`](#0x1_supra_config_set)
+-  [Function `set_for_next_epoch`](#0x1_supra_config_set_for_next_epoch)
+-  [Function `on_new_epoch`](#0x1_supra_config_on_new_epoch)
+
+
+<pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
+<b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+</code></pre>
+
+
+
+<a id="0x1_supra_config_SupraConfig"></a>
+
+## Resource `SupraConfig`
+
+
+
+<pre><code><b>struct</b> <a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a> <b>has</b> drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_supra_config_EINVALID_CONFIG"></a>
+
+The provided on chain config bytes are empty or invalid
+
+
+<pre><code><b>const</b> <a href="supra_config.md#0x1_supra_config_EINVALID_CONFIG">EINVALID_CONFIG</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_supra_config_initialize"></a>
+
+## Function `initialize`
+
+Publishes the SupraConfig config.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="supra_config.md#0x1_supra_config_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="supra_config.md#0x1_supra_config_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config) &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="supra_config.md#0x1_supra_config_EINVALID_CONFIG">EINVALID_CONFIG</a>));
+    <b>move_to</b>(supra_framework, <a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a> { config });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_supra_config_set"></a>
+
+## Function `set`
+
+Deprecated by <code><a href="supra_config.md#0x1_supra_config_set_for_next_epoch">set_for_next_epoch</a>()</code>.
+
+WARNING: calling this while randomness is enabled will trigger a new epoch without randomness!
+
+TODO: update all the tests that reference this function, then disable this function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="supra_config.md#0x1_supra_config_set">set</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="supra_config.md#0x1_supra_config_set">set</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(<a href="account.md#0x1_account">account</a>);
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config) &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="supra_config.md#0x1_supra_config_EINVALID_CONFIG">EINVALID_CONFIG</a>));
+
+    <b>let</b> config_ref = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework).config;
+    *config_ref = config;
+
+    // Need <b>to</b> trigger <a href="reconfiguration.md#0x1_reconfiguration">reconfiguration</a> so validator nodes can sync on the updated configs.
+    <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_supra_config_set_for_next_epoch"></a>
+
+## Function `set_for_next_epoch`
+
+This can be called by on-chain governance to update on-chain configs for the next epoch.
+Example usage:
+```
+supra_framework::supra_config::set_for_next_epoch(&framework_signer, some_config_bytes);
+supra_framework::supra_governance::reconfigure(&framework_signer);
+```
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="supra_config.md#0x1_supra_config_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="supra_config.md#0x1_supra_config_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(<a href="account.md#0x1_account">account</a>);
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config) &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="supra_config.md#0x1_supra_config_EINVALID_CONFIG">EINVALID_CONFIG</a>));
+    std::config_buffer::upsert&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a> {config});
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_supra_config_on_new_epoch"></a>
+
+## Function `on_new_epoch`
+
+Only used in reconfigurations to apply the pending <code><a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a></code>, if there is any.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="supra_config.md#0x1_supra_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="supra_config.md#0x1_supra_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(framework);
+    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;()) {
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;();
+        <b>if</b> (<b>exists</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework)) {
+            *<b>borrow_global_mut</b>&lt;<a href="supra_config.md#0x1_supra_config_SupraConfig">SupraConfig</a>&gt;(@supra_framework) = new_config;
+        } <b>else</b> {
+            <b>move_to</b>(framework, new_config);
+        };
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/supra-framework/sources/configs/config_buffer.move
+++ b/aptos-move/framework/supra-framework/sources/configs/config_buffer.move
@@ -20,6 +20,7 @@ module supra_framework::config_buffer {
 
     friend supra_framework::consensus_config;
     friend supra_framework::execution_config;
+    friend supra_framework::supra_config;
     friend supra_framework::gas_schedule;
     friend supra_framework::jwks;
     friend supra_framework::jwk_consensus_config;

--- a/aptos-move/framework/supra-framework/sources/configs/supra_config.move
+++ b/aptos-move/framework/supra-framework/sources/configs/supra_config.move
@@ -1,0 +1,70 @@
+/// Maintains the consensus config for the blockchain. The config is stored in a
+/// Reconfiguration, and may be updated by root.
+module supra_framework::supra_config {
+    use std::error;
+    use std::vector;
+    use supra_framework::chain_status;
+    use supra_framework::config_buffer;
+
+    use supra_framework::reconfiguration;
+    use supra_framework::system_addresses;
+
+    friend supra_framework::genesis;
+    friend supra_framework::reconfiguration_with_dkg;
+
+    struct SupraConfig has drop, key, store {
+        config: vector<u8>,
+    }
+
+    /// The provided on chain config bytes are empty or invalid
+    const EINVALID_CONFIG: u64 = 1;
+
+    /// Publishes the SupraConfig config.
+    public(friend) fun initialize(supra_framework: &signer, config: vector<u8>) {
+        system_addresses::assert_supra_framework(supra_framework);
+        assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
+        move_to(supra_framework, SupraConfig { config });
+    }
+
+    /// Deprecated by `set_for_next_epoch()`.
+    ///
+    /// WARNING: calling this while randomness is enabled will trigger a new epoch without randomness!
+    ///
+    /// TODO: update all the tests that reference this function, then disable this function.
+    public fun set(account: &signer, config: vector<u8>) acquires SupraConfig {
+        system_addresses::assert_supra_framework(account);
+        chain_status::assert_genesis();
+        assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
+
+        let config_ref = &mut borrow_global_mut<SupraConfig>(@supra_framework).config;
+        *config_ref = config;
+
+        // Need to trigger reconfiguration so validator nodes can sync on the updated configs.
+        reconfiguration::reconfigure();
+    }
+
+    /// This can be called by on-chain governance to update on-chain configs for the next epoch.
+    /// Example usage:
+    /// ```
+    /// supra_framework::supra_config::set_for_next_epoch(&framework_signer, some_config_bytes);
+    /// supra_framework::supra_governance::reconfigure(&framework_signer);
+    /// ```
+    public fun set_for_next_epoch(account: &signer, config: vector<u8>) {
+        system_addresses::assert_supra_framework(account);
+        assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
+        std::config_buffer::upsert<SupraConfig>(SupraConfig {config});
+    }
+
+    /// Only used in reconfigurations to apply the pending `SupraConfig`, if there is any.
+    public(friend) fun on_new_epoch(framework: &signer) acquires SupraConfig {
+        system_addresses::assert_supra_framework(framework);
+        if (config_buffer::does_exist<SupraConfig>()) {
+            let new_config = config_buffer::extract<SupraConfig>();
+            if (exists<SupraConfig>(@supra_framework)) {
+                *borrow_global_mut<SupraConfig>(@supra_framework) = new_config;
+            } else {
+                move_to(framework, new_config);
+            };
+        }
+    }
+}

--- a/aptos-move/framework/supra-framework/sources/configs/supra_config.move
+++ b/aptos-move/framework/supra-framework/sources/configs/supra_config.move
@@ -1,11 +1,10 @@
-/// Maintains the consensus config for the blockchain. The config is stored in a
-/// Reconfiguration, and may be updated by root.
+/// Maintains protocol configuation settings specific to Supra. The config is stored in a
+/// may be updated by root.
 module supra_framework::supra_config {
     use std::error;
     use std::vector;
     use supra_framework::chain_status;
     use supra_framework::config_buffer;
-
     use supra_framework::reconfiguration;
     use supra_framework::system_addresses;
 
@@ -24,23 +23,6 @@ module supra_framework::supra_config {
         system_addresses::assert_supra_framework(supra_framework);
         assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
         move_to(supra_framework, SupraConfig { config });
-    }
-
-    /// Deprecated by `set_for_next_epoch()`.
-    ///
-    /// WARNING: calling this while randomness is enabled will trigger a new epoch without randomness!
-    ///
-    /// TODO: update all the tests that reference this function, then disable this function.
-    public fun set(account: &signer, config: vector<u8>) acquires SupraConfig {
-        system_addresses::assert_supra_framework(account);
-        chain_status::assert_genesis();
-        assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
-
-        let config_ref = &mut borrow_global_mut<SupraConfig>(@supra_framework).config;
-        *config_ref = config;
-
-        // Need to trigger reconfiguration so validator nodes can sync on the updated configs.
-        reconfiguration::reconfigure();
     }
 
     /// This can be called by on-chain governance to update on-chain configs for the next epoch.

--- a/aptos-move/framework/supra-framework/sources/configs/supra_config.spec.move
+++ b/aptos-move/framework/supra-framework/sources/configs/supra_config.spec.move
@@ -1,0 +1,83 @@
+spec supra_framework::supra_config {
+    /// <high-level-req>
+    /// No.: 1
+    /// Requirement: During genesis, the Supra framework account should be assigned the supra config resource.
+    /// Criticality: Medium
+    /// Implementation: The supra_config::initialize function calls the assert_supra_framework function to ensure
+    /// that the signer is the supra_framework and then assigns the SupraConfig resource to it.
+    /// Enforcement: Formally verified via [high-level-req-1](initialize).
+    ///
+    /// No.: 2
+    /// Requirement: Only aptos framework account is allowed to update the supra protocol configuration.
+    /// Criticality: Medium
+    /// Implementation: The supra_config::set function ensures that the signer is supra_framework.
+    /// Enforcement: Formally verified via [high-level-req-2](set).
+    ///
+    /// No.: 3
+    /// Requirement: Only a valid configuration can be used during initialization and update.
+    /// Criticality: Medium
+    /// Implementation: Both the initialize and set functions validate the config by ensuring its length to be greater
+    /// than 0.
+    /// Enforcement: Formally verified via [high-level-req-3.1](initialize) and [high-level-req-3.2](set).
+    /// </high-level-req>
+    ///
+    spec module {
+        use supra_framework::chain_status;
+        pragma verify = true;
+        pragma aborts_if_is_strict;
+        invariant [suspendable] chain_status::is_operating() ==> exists<SupraConfig>(@supra_framework);
+    }
+
+    /// Ensure caller is admin.
+    /// Aborts if StateStorageUsage already exists.
+    spec initialize(supra_framework: &signer, config: vector<u8>) {
+        use std::signer;
+        let addr = signer::address_of(supra_framework);
+        /// [high-level-req-1]
+        aborts_if !system_addresses::is_supra_framework_address(addr);
+        aborts_if exists<SupraConfig>(@supra_framework);
+        /// [high-level-req-3.1]
+        aborts_if !(len(config) > 0);
+        ensures global<SupraConfig>(addr) == SupraConfig { config };
+    }
+
+    /// Ensure the caller is admin and `SupraConfig` should exist.
+    /// When setting now time must be later than last_reconfiguration_time.
+    spec set(account: &signer, config: vector<u8>) {
+        use supra_framework::chain_status;
+        use supra_framework::timestamp;
+        use std::signer;
+        use supra_framework::stake;
+        use supra_framework::coin::CoinInfo;
+        use supra_framework::supra_coin::SupraCoin;
+        use supra_framework::transaction_fee;
+        use supra_framework::staking_config;
+
+        // TODO: set because of timeout (property proved)
+        pragma verify_duration_estimate = 600;
+        include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
+        let addr = signer::address_of(account);
+        /// [high-level-req-2]
+        aborts_if !system_addresses::is_supra_framework_address(addr);
+        aborts_if !exists<SupraConfig>(@supra_framework);
+        /// [high-level-req-3.2]
+        aborts_if !(len(config) > 0);
+
+        requires chain_status::is_genesis();
+        requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
+        requires exists<stake::ValidatorFees>(@supra_framework);
+        requires exists<CoinInfo<SupraCoin>>(@supra_framework);
+        ensures global<SupraConfig>(@supra_framework).config == config;
+    }
+
+    spec set_for_next_epoch(account: &signer, config: vector<u8>) {
+        include config_buffer::SetForNextEpochAbortsIf;
+    }
+
+    spec on_new_epoch(framework: &signer) {
+        requires @supra_framework == std::signer::address_of(framework);
+        include config_buffer::OnNewEpochRequirement<SupraConfig>;
+        aborts_if false;
+    }
+}

--- a/aptos-move/framework/supra-framework/sources/configs/supra_config.spec.move
+++ b/aptos-move/framework/supra-framework/sources/configs/supra_config.spec.move
@@ -41,36 +41,6 @@ spec supra_framework::supra_config {
         ensures global<SupraConfig>(addr) == SupraConfig { config };
     }
 
-    /// Ensure the caller is admin and `SupraConfig` should exist.
-    /// When setting now time must be later than last_reconfiguration_time.
-    spec set(account: &signer, config: vector<u8>) {
-        use supra_framework::chain_status;
-        use supra_framework::timestamp;
-        use std::signer;
-        use supra_framework::stake;
-        use supra_framework::coin::CoinInfo;
-        use supra_framework::supra_coin::SupraCoin;
-        use supra_framework::transaction_fee;
-        use supra_framework::staking_config;
-
-        // TODO: set because of timeout (property proved)
-        pragma verify_duration_estimate = 600;
-        include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
-        include staking_config::StakingRewardsConfigRequirement;
-        let addr = signer::address_of(account);
-        /// [high-level-req-2]
-        aborts_if !system_addresses::is_supra_framework_address(addr);
-        aborts_if !exists<SupraConfig>(@supra_framework);
-        /// [high-level-req-3.2]
-        aborts_if !(len(config) > 0);
-
-        requires chain_status::is_genesis();
-        requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
-        requires exists<stake::ValidatorFees>(@supra_framework);
-        requires exists<CoinInfo<SupraCoin>>(@supra_framework);
-        ensures global<SupraConfig>(@supra_framework).config == config;
-    }
-
     spec set_for_next_epoch(account: &signer, config: vector<u8>) {
         include config_buffer::SetForNextEpochAbortsIf;
     }

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -164,7 +164,7 @@ module supra_framework::genesis {
 
         consensus_config::initialize(&supra_framework_account, consensus_config);
         execution_config::set(&supra_framework_account, execution_config);
-        supra_config::set(&supra_framework_account, supra_config);
+        supra_config::initialize(&supra_framework_account, supra_config);
         version::initialize(&supra_framework_account, initial_version);
         stake::initialize(&supra_framework_account);
         staking_config::initialize(

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -20,6 +20,7 @@ module supra_framework::genesis {
     use supra_framework::coin;
     use supra_framework::consensus_config;
     use supra_framework::execution_config;
+    use supra_framework::supra_config;
     use supra_framework::create_signer::create_signer;
     use supra_framework::gas_schedule;
     use supra_framework::reconfiguration;
@@ -124,6 +125,7 @@ module supra_framework::genesis {
         initial_version: u64,
         consensus_config: vector<u8>,
         execution_config: vector<u8>,
+        supra_config: vector<u8>,
         epoch_interval_microsecs: u64,
         minimum_stake: u64,
         maximum_stake: u64,
@@ -162,6 +164,7 @@ module supra_framework::genesis {
 
         consensus_config::initialize(&supra_framework_account, consensus_config);
         execution_config::set(&supra_framework_account, execution_config);
+        supra_config::set(&supra_framework_account, supra_config);
         version::initialize(&supra_framework_account, initial_version);
         stake::initialize(&supra_framework_account);
         staking_config::initialize(
@@ -622,6 +625,7 @@ module supra_framework::genesis {
         initial_version: u64,
         consensus_config: vector<u8>,
         execution_config: vector<u8>,
+        supra_config: vector<u8>,
         epoch_interval_microsecs: u64,
         minimum_stake: u64,
         maximum_stake: u64,
@@ -648,6 +652,7 @@ module supra_framework::genesis {
             initial_version,
             consensus_config,
             execution_config,
+            supra_config,
             epoch_interval_microsecs,
             minimum_stake,
             maximum_stake,
@@ -684,6 +689,7 @@ module supra_framework::genesis {
             0,
             x"12",
             x"13",
+            x"14",
             1,
             0,
             1000 * ONE_APT,

--- a/aptos-move/framework/supra-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.spec.move
@@ -80,6 +80,7 @@ spec supra_framework::genesis {
         ensures exists<supra_governance::GovernanceResponsbility>(@supra_framework);
         ensures exists<consensus_config::ConsensusConfig>(@supra_framework);
         ensures exists<execution_config::ExecutionConfig>(@supra_framework);
+        ensures exists<supra_config::SupraConfig>(@supra_framework);
         ensures exists<version::Version>(@supra_framework);
         ensures exists<stake::ValidatorSet>(@supra_framework);
         ensures exists<stake::ValidatorPerformance>(@supra_framework);

--- a/aptos-move/framework/supra-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/supra-framework/sources/reconfiguration.move
@@ -19,6 +19,7 @@ module supra_framework::reconfiguration {
     friend supra_framework::block;
     friend supra_framework::consensus_config;
     friend supra_framework::execution_config;
+    friend supra_framework::supra_config;
     friend supra_framework::gas_schedule;
     friend supra_framework::genesis;
     friend supra_framework::version;

--- a/aptos-move/framework/supra-framework/sources/reconfiguration_with_dkg.move
+++ b/aptos-move/framework/supra-framework/sources/reconfiguration_with_dkg.move
@@ -15,6 +15,7 @@ module supra_framework::reconfiguration_with_dkg {
     use supra_framework::reconfiguration;
     use supra_framework::reconfiguration_state;
     use supra_framework::stake;
+    use supra_framework::supra_config;
     use supra_framework::system_addresses;
     friend supra_framework::block;
     friend supra_framework::supra_governance;
@@ -48,6 +49,7 @@ module supra_framework::reconfiguration_with_dkg {
         dkg::try_clear_incomplete_session(framework);
         consensus_config::on_new_epoch(framework);
         execution_config::on_new_epoch(framework);
+        supra_config::on_new_epoch(framework);
         gas_schedule::on_new_epoch(framework);
         std::version::on_new_epoch(framework);
         features::on_new_epoch(framework);

--- a/aptos-move/framework/supra-framework/sources/reconfiguration_with_dkg.spec.move
+++ b/aptos-move/framework/supra-framework/sources/reconfiguration_with_dkg.spec.move
@@ -41,6 +41,7 @@ spec supra_framework::reconfiguration_with_dkg {
         use supra_framework::jwks;
         use supra_framework::randomness_config;
         use supra_framework::jwk_consensus_config;
+        use supra_framework::supra_config;
         framework: signer;
         requires signer::address_of(framework) == @supra_framework;
         requires chain_status::is_operating();
@@ -53,6 +54,7 @@ spec supra_framework::reconfiguration_with_dkg {
         include config_buffer::OnNewEpochRequirement<gas_schedule::GasScheduleV2>;
         include config_buffer::OnNewEpochRequirement<execution_config::ExecutionConfig>;
         include config_buffer::OnNewEpochRequirement<consensus_config::ConsensusConfig>;
+        include config_buffer::OnNewEpochRequirement<supra_config::SupraConfig>;
         include config_buffer::OnNewEpochRequirement<jwks::SupportedOIDCProviders>;
         include config_buffer::OnNewEpochRequirement<randomness_config::RandomnessConfig>;
         include config_buffer::OnNewEpochRequirement<randomness_config_seqnum::RandomnessConfigSeqNum>;

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -124,6 +124,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
     framework: &ReleaseBundle,
     chain_id: ChainId,
     genesis_config: &GenesisConfiguration,
+    supra_config_bytes: Vec<u8>,
 ) -> Transaction {
     assert!(!genesis_config.is_test, "This is mainnet!");
     validate_genesis_config(genesis_config);
@@ -149,6 +150,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
         &consensus_config,
         &execution_config,
         &gas_schedule,
+        supra_config_bytes,
     );
     initialize_features(
         &mut session,
@@ -223,6 +225,7 @@ pub fn encode_genesis_transaction(
     consensus_config: &OnChainConsensusConfig,
     execution_config: &OnChainExecutionConfig,
     gas_schedule: &GasScheduleV2,
+    supra_config_bytes: Vec<u8>,
 ) -> Transaction {
     Transaction::GenesisTransaction(WriteSetPayload::Direct(encode_genesis_change_set(
         &aptos_root_key,
@@ -238,6 +241,7 @@ pub fn encode_genesis_transaction(
         consensus_config,
         execution_config,
         gas_schedule,
+        supra_config_bytes,
     )))
 }
 
@@ -255,6 +259,7 @@ pub fn encode_genesis_change_set(
     consensus_config: &OnChainConsensusConfig,
     execution_config: &OnChainExecutionConfig,
     gas_schedule: &GasScheduleV2,
+    supra_config_bytes: Vec<u8>,
 ) -> ChangeSet {
     validate_genesis_config(genesis_config);
 
@@ -276,6 +281,7 @@ pub fn encode_genesis_change_set(
         consensus_config,
         execution_config,
         gas_schedule,
+        supra_config_bytes,
     );
     initialize_features(
         &mut session,
@@ -439,6 +445,7 @@ fn initialize(
     consensus_config: &OnChainConsensusConfig,
     execution_config: &OnChainExecutionConfig,
     gas_schedule: &GasScheduleV2,
+    supra_config_bytes: Vec<u8>,
 ) {
     let gas_schedule_blob =
         bcs::to_bytes(gas_schedule).expect("Failure serializing genesis gas schedule");
@@ -472,6 +479,7 @@ fn initialize(
             MoveValue::U64(APTOS_MAX_KNOWN_VERSION.major),
             MoveValue::vector_u8(consensus_config_bytes),
             MoveValue::vector_u8(execution_config_bytes),
+            MoveValue::vector_u8(supra_config_bytes),
             MoveValue::U64(epoch_interval_usecs),
             MoveValue::U64(genesis_config.min_stake),
             MoveValue::U64(genesis_config.max_stake),
@@ -1124,6 +1132,7 @@ pub fn generate_test_genesis(
         &OnChainConsensusConfig::default_for_genesis(),
         &OnChainExecutionConfig::default_for_genesis(),
         &default_gas_schedule(),
+        Vec::new(),
     );
     (genesis, test_validators)
 }
@@ -1151,6 +1160,7 @@ pub fn generate_mainnet_genesis(
         &OnChainConsensusConfig::default_for_genesis(),
         &OnChainExecutionConfig::default_for_genesis(),
         &default_gas_schedule(),
+        Vec::new(),
     );
     (genesis, test_validators)
 }
@@ -1748,6 +1758,7 @@ pub fn test_mainnet_end_to_end() {
         aptos_cached_packages::head_release_bundle(),
         ChainId::mainnet(),
         &mainnet_genesis_config(),
+        Vec::new(),
     );
 
     let direct_writeset = if let Transaction::GenesisTransaction(direct_writeset) = transaction {

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -1132,7 +1132,7 @@ pub fn generate_test_genesis(
         &OnChainConsensusConfig::default_for_genesis(),
         &OnChainExecutionConfig::default_for_genesis(),
         &default_gas_schedule(),
-        Vec::new(),
+        b"test".to_vec(),
     );
     (genesis, test_validators)
 }
@@ -1160,7 +1160,7 @@ pub fn generate_mainnet_genesis(
         &OnChainConsensusConfig::default_for_genesis(),
         &OnChainExecutionConfig::default_for_genesis(),
         &default_gas_schedule(),
-        Vec::new(),
+        b"test".to_vec(),
     );
     (genesis, test_validators)
 }
@@ -1758,7 +1758,7 @@ pub fn test_mainnet_end_to_end() {
         aptos_cached_packages::head_release_bundle(),
         ChainId::mainnet(),
         &mainnet_genesis_config(),
-        Vec::new(),
+        b"test".to_vec(),
     );
 
     let direct_writeset = if let Transaction::GenesisTransaction(direct_writeset) = transaction {

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -165,6 +165,7 @@ impl GenesisInfo {
             &self.consensus_config,
             &self.execution_config,
             &self.gas_schedule,
+            Vec::new(),
         )
     }
 

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -165,7 +165,7 @@ impl GenesisInfo {
             &self.consensus_config,
             &self.execution_config,
             &self.gas_schedule,
-            Vec::new(),
+            b"test".to_vec(),
         )
     }
 

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -154,7 +154,7 @@ impl MainnetGenesisInfo {
                 randomness_config_override: self.randomness_config_override.clone(),
                 jwk_consensus_config_override: self.jwk_consensus_config_override.clone(),
             },
-            Vec::new(),
+            b"test".to_vec(),
         )
     }
 

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -154,6 +154,7 @@ impl MainnetGenesisInfo {
                 randomness_config_override: self.randomness_config_override.clone(),
                 jwk_consensus_config_override: self.jwk_consensus_config_override.clone(),
             },
+            Vec::new(),
         )
     }
 

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+ROOT="$(pwd)"
+cargo build --release
+cd ./aptos-move/framework/supra-framework && "$ROOT"/target/release/aptos move test || exit 1
+cd ..
+cargo test --release -p aptos-framework -- --skip prover || exit 2
+RUST_MIN_STACK=104857600 cargo nextest run -p e2e-move-tests || exit 3


### PR DESCRIPTION
See #83. Copied `consensus_config.move` and removed the unnecessary methods but otherwise made only minor changes to the contract. Its documentation can be improved in a future PR. I have integrated this change into `smr-moonshot` and confirmed that it works as expected.