### PR TITLE
 Ensured that `Coin`s cannot be converted to `FungibleAsset`s and vice-versa

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
@@ -168,8 +168,10 @@ fn test_basic_fungible_token() {
     assert_eq!(alice_store, bob_store);
 }
 
+// TODO: Reactivate once we fully support Fungible Assets.
+//
 // A simple test to verify gas paying still work for prologue and epilogue.
-#[test]
+// #[test]
 fn test_coin_to_fungible_asset_migration() {
     let mut h = MoveHarness::new();
 

--- a/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
@@ -171,7 +171,8 @@ fn test_basic_fungible_token() {
 // TODO: Reactivate once we fully support Fungible Assets.
 //
 // A simple test to verify gas paying still work for prologue and epilogue.
-// #[test]
+#[ignore]
+#[test]
 fn test_coin_to_fungible_asset_migration() {
     let mut h = MoveHarness::new();
 

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -156,13 +156,8 @@ pub enum EntryFunctionCall {
 
     CoinCreateCoinConversionMap {},
 
-    /// Create SUPRA pairing by passing `AptosCoin`.
+    /// Create SUPRA pairing by passing `SupraCoin`.
     CoinCreatePairing {
-        coin_type: TypeTag,
-    },
-
-    /// Voluntarily migrate to fungible store for `CoinType` if not yet.
-    CoinMigrateToFungibleStore {
         coin_type: TypeTag,
     },
 
@@ -1164,7 +1159,6 @@ impl EntryFunctionCall {
             } => code_publish_package_txn(metadata_serialized, code),
             CoinCreateCoinConversionMap {} => coin_create_coin_conversion_map(),
             CoinCreatePairing { coin_type } => coin_create_pairing(coin_type),
-            CoinMigrateToFungibleStore { coin_type } => coin_migrate_to_fungible_store(coin_type),
             CoinTransfer {
                 coin_type,
                 to,
@@ -2099,7 +2093,7 @@ pub fn coin_create_coin_conversion_map() -> TransactionPayload {
     ))
 }
 
-/// Create SUPRA pairing by passing `AptosCoin`.
+/// Create SUPRA pairing by passing `SupraCoin`.
 pub fn coin_create_pairing(coin_type: TypeTag) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2110,22 +2104,6 @@ pub fn coin_create_pairing(coin_type: TypeTag) -> TransactionPayload {
             ident_str!("coin").to_owned(),
         ),
         ident_str!("create_pairing").to_owned(),
-        vec![coin_type],
-        vec![],
-    ))
-}
-
-/// Voluntarily migrate to fungible store for `CoinType` if not yet.
-pub fn coin_migrate_to_fungible_store(coin_type: TypeTag) -> TransactionPayload {
-    TransactionPayload::EntryFunction(EntryFunction::new(
-        ModuleId::new(
-            AccountAddress::new([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1,
-            ]),
-            ident_str!("coin").to_owned(),
-        ),
-        ident_str!("migrate_to_fungible_store").to_owned(),
         vec![coin_type],
         vec![],
     ))
@@ -5173,18 +5151,6 @@ mod decoder {
         }
     }
 
-    pub fn coin_migrate_to_fungible_store(
-        payload: &TransactionPayload,
-    ) -> Option<EntryFunctionCall> {
-        if let TransactionPayload::EntryFunction(script) = payload {
-            Some(EntryFunctionCall::CoinMigrateToFungibleStore {
-                coin_type: script.ty_args().get(0)?.clone(),
-            })
-        } else {
-            None
-        }
-    }
-
     pub fn coin_transfer(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::CoinTransfer {
@@ -6953,10 +6919,6 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "coin_create_pairing".to_string(),
             Box::new(decoder::coin_create_pairing),
-        );
-        map.insert(
-            "coin_migrate_to_fungible_store".to_string(),
-            Box::new(decoder::coin_migrate_to_fungible_store),
         );
         map.insert(
             "coin_transfer".to_string(),

--- a/aptos-move/framework/supra-framework/sources/coin.move
+++ b/aptos-move/framework/supra-framework/sources/coin.move
@@ -378,17 +378,36 @@ module supra_framework::coin {
         }
     }
 
-    // TODO: Return this function to `public` once we have full support for Fungible Assets.
-    // Also uncomment `tests/supra_coin_tests.move` at this time. This function should not
-    // be called by any production code until we have full support for FAs.
-    //
     /// Conversion from coin to fungible asset
-    public(friend) fun coin_to_fungible_asset<CoinType>(
+    public fun coin_to_fungible_asset<CoinType>(
+        coin: Coin<CoinType>
+    ): FungibleAsset acquires CoinConversionMap, CoinInfo {
+        // TODO: Replace the below code with a call to `coin_to_fungible_asset_internal`
+        // once we fully support `FungibleAsset`s. The below guard is used because we need to
+        // preserve the function signature but want to keep the feature flag active to avoid
+        // breaking the tests. The `else` branch will never be taken in the production code
+        // as this feature is set by default.
+        if (features::coin_to_fungible_asset_migration_feature_enabled()) {
+            abort error::unavailable(ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED)
+        } else {
+            coin_to_fungible_asset_internal(coin)
+        }
+    }
+
+    fun coin_to_fungible_asset_internal<CoinType>(
         coin: Coin<CoinType>
     ): FungibleAsset acquires CoinConversionMap, CoinInfo {
         let metadata = ensure_paired_metadata<CoinType>();
         let amount = burn_internal(coin);
         fungible_asset::mint_internal(metadata, amount)
+    }
+
+    /// A public wrapper around `coin_to_fungible_asset_internal` for use by external tests.
+    #[test_only]
+    public fun coin_to_fungible_asset_for_test<CoinType>(
+        coin: Coin<CoinType>
+    ): FungibleAsset acquires CoinConversionMap, CoinInfo {
+        coin_to_fungible_asset_internal(coin)
     }
 
     /// Conversion from fungible asset to coin. Not public to push the migration to FA.
@@ -690,7 +709,7 @@ module supra_framework::coin {
             if (coin.value == 0) {
                 destroy_zero(coin);
             } else {
-                fungible_asset::deposit(store, coin_to_fungible_asset(coin));
+                fungible_asset::deposit(store, coin_to_fungible_asset_internal(coin));
             };
             // Note:
             // It is possible the primary fungible store may already exist before this function call.
@@ -706,11 +725,23 @@ module supra_framework::coin {
         }
     }
 
-    // TODO: Return this function to `public entry` once we have full support for Fungible Assets.
-    // This function should not be called by any production code until we have full support for FAs.
-    //
     /// Voluntarily migrate to fungible store for `CoinType` if not yet.
-    public(friend) fun migrate_to_fungible_store<CoinType>(
+    public entry fun migrate_to_fungible_store<CoinType>(
+        account: &signer
+    ) acquires CoinStore, CoinConversionMap, CoinInfo {
+        // TODO: Replace the below code with a call to `migrate_to_fungible_store_internal`
+        // once we fully support `FungibleAsset`s. The below guard is used because we need to
+        // preserve the function signature but want to keep the feature flag active to avoid
+        // breaking the tests. The `else` branch will never be taken in the production code
+        // as this feature is set by default.
+        if (features::coin_to_fungible_asset_migration_feature_enabled()) {
+            abort error::unavailable(ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED)
+        } else {
+            migrate_to_fungible_store_internal<CoinType>(account)
+        }
+    }
+
+    fun migrate_to_fungible_store_internal<CoinType>(
         account: &signer
     ) acquires CoinStore, CoinConversionMap, CoinInfo {
         maybe_convert_to_fungible_store<CoinType>(signer::address_of(account));
@@ -916,7 +947,7 @@ module supra_framework::coin {
                 account_addr,
                 option::destroy_some(metadata)
             )) {
-                primary_fungible_store::deposit(account_addr, coin_to_fungible_asset(coin));
+                primary_fungible_store::deposit(account_addr, coin_to_fungible_asset_internal(coin));
             } else {
                 abort error::not_found(ECOIN_STORE_NOT_PUBLISHED)
             };
@@ -949,7 +980,7 @@ module supra_framework::coin {
                 account_addr,
                 option::destroy_some(metadata)
             )) {
-                let fa = coin_to_fungible_asset(coin);
+                let fa = coin_to_fungible_asset_internal(coin);
                 let metadata = fungible_asset::asset_metadata(&fa);
                 let store = primary_fungible_store::primary_store(account_addr, metadata);
                 fungible_asset::deposit_internal(object::object_address(&store), fa);
@@ -1550,7 +1581,7 @@ module supra_framework::coin {
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         deposit(source_addr, coins_minted);
-        let fa_minted = coin_to_fungible_asset(mint<FakeMoney>(200, &mint_cap));
+        let fa_minted = coin_to_fungible_asset_internal(mint<FakeMoney>(200, &mint_cap));
         primary_fungible_store::deposit(source_addr, fa_minted);
 
         // Burn coin only with both stores
@@ -1805,7 +1836,7 @@ module supra_framework::coin {
     #[test(other = @0x123)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
     fun test_migration_coin_store_with_non_coin_type(other: signer) acquires CoinConversionMap, CoinStore, CoinInfo {
-        migrate_to_fungible_store<String>(&other);
+        migrate_to_fungible_store_internal<String>(&other);
     }
 
     #[test(framework = @supra_framework)]
@@ -1903,7 +1934,7 @@ module supra_framework::coin {
         let aggregatable_coin = initialize_aggregatable_coin<FakeMoney>(&framework);
         collect_into_aggregatable_coin<FakeMoney>(framework_addr, 50, &mut aggregatable_coin);
 
-        let fa_minted = coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap));
+        let fa_minted = coin_to_fungible_asset_internal(mint<FakeMoney>(100, &mint_cap));
         primary_fungible_store::deposit(framework_addr, fa_minted);
         assert!(balance<FakeMoney>(framework_addr) == 150, 0);
         assert!(*option::borrow(&supply<FakeMoney>()) == 200, 0);
@@ -1968,7 +1999,7 @@ module supra_framework::coin {
         assert!(fungible_asset::decimals(ensure_paired_metadata<FakeMoney>()) == decimals<FakeMoney>(), 0);
 
         let minted_coin = mint(100, &mint_cap);
-        let converted_fa = coin_to_fungible_asset(minted_coin);
+        let converted_fa = coin_to_fungible_asset_internal(minted_coin);
 
         // check and get refs
         assert!(paired_mint_ref_exists<FakeMoney>(), 0);
@@ -1998,7 +2029,7 @@ module supra_framework::coin {
         assert!(balance<FakeMoney>(account_addr) == 199, 0);
         assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 199, 0);
 
-        let fa = coin_to_fungible_asset(withdrawn_coin);
+        let fa = coin_to_fungible_asset_internal(withdrawn_coin);
         fungible_asset::burn(&burn_ref, fa);
 
         // Return and check the refs
@@ -2028,7 +2059,7 @@ module supra_framework::coin {
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         create_coin_store<FakeMoney>(aaron);
         let coin = mint(100, &mint_cap);
-        let fa = coin_to_fungible_asset(mint(100, &mint_cap));
+        let fa = coin_to_fungible_asset_internal(mint(100, &mint_cap));
         primary_fungible_store::deposit(aaron_addr, fa);
         deposit_to_coin_store(aaron_addr, coin);
         assert!(coin_balance<FakeMoney>(aaron_addr) == 100, 0);
@@ -2088,7 +2119,7 @@ module supra_framework::coin {
         assert!(coin_balance<FakeMoney>(account_addr) == 100, 0);
         assert!(balance<FakeMoney>(account_addr) == 100, 0);
 
-        let fa = coin_to_fungible_asset(coin);
+        let fa = coin_to_fungible_asset_internal(coin);
         primary_fungible_store::deposit(account_addr, fa);
         assert!(coin_store_exists<FakeMoney>(account_addr), 0);
         assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 100, 0);
@@ -2132,7 +2163,7 @@ module supra_framework::coin {
         assert!(supply<FakeMoney>() == option::some(150), 0);
         assert!(coin_supply<FakeMoney>() == option::some(100), 0);
         assert!(fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(50), 0);
-        let fa_from_coin = coin_to_fungible_asset(coin);
+        let fa_from_coin = coin_to_fungible_asset_internal(coin);
         assert!(supply<FakeMoney>() == option::some(150), 0);
         assert!(coin_supply<FakeMoney>() == option::some(0), 0);
         assert!(fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(150), 0);
@@ -2217,7 +2248,7 @@ module supra_framework::coin {
         assert!(is_account_registered<FakeMoney>(account_addr), 0);
 
         // Deposit FA to bob to created primary fungible store without `MigrationFlag`.
-        primary_fungible_store::deposit(bob_addr, coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap)));
+        primary_fungible_store::deposit(bob_addr, coin_to_fungible_asset_internal(mint<FakeMoney>(100, &mint_cap)));
         assert!(!coin_store_exists<FakeMoney>(bob_addr), 0);
         register<FakeMoney>(bob);
         assert!(coin_store_exists<FakeMoney>(bob_addr), 0);
@@ -2242,7 +2273,7 @@ module supra_framework::coin {
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
 
         let coin = mint<FakeMoney>(100, &mint_cap);
-        primary_fungible_store::deposit(account_addr, coin_to_fungible_asset(coin));
+        primary_fungible_store::deposit(account_addr, coin_to_fungible_asset_internal(coin));
         assert!(coin_balance<FakeMoney>(account_addr) == 0, 0);
         assert!(balance<FakeMoney>(account_addr) == 100, 0);
         let coin = withdraw<FakeMoney>(account, 50);

--- a/aptos-move/framework/supra-framework/sources/coin.move
+++ b/aptos-move/framework/supra-framework/sources/coin.move
@@ -21,8 +21,8 @@ module supra_framework::coin {
     use aptos_std::type_info::{Self, TypeInfo, type_name};
     use supra_framework::create_signer;
 
-	friend supra_framework::supra_coin;
     friend supra_framework::genesis;
+    friend supra_framework::supra_coin;
     friend supra_framework::transaction_fee;
 
     //
@@ -294,7 +294,7 @@ module supra_framework::coin {
         };
     }
 
-    /// Create SUPRA pairing by passing `AptosCoin`.
+    /// Create SUPRA pairing by passing `SupraCoin`.
     public entry fun create_pairing<CoinType>(
         supra_framework: &signer
     ) acquires CoinConversionMap, CoinInfo {
@@ -378,8 +378,12 @@ module supra_framework::coin {
         }
     }
 
+    // TODO: Return this function to `public` once we have full support for Fungible Assets.
+    // Also uncomment `tests/supra_coin_tests.move` at this time. This function should not
+    // be called by any production code until we have full support for FAs.
+    //
     /// Conversion from coin to fungible asset
-    public fun coin_to_fungible_asset<CoinType>(
+    public(friend) fun coin_to_fungible_asset<CoinType>(
         coin: Coin<CoinType>
     ): FungibleAsset acquires CoinConversionMap, CoinInfo {
         let metadata = ensure_paired_metadata<CoinType>();
@@ -567,8 +571,7 @@ module supra_framework::coin {
         AggregatableCoin<CoinType> {
             value: aggregator,
         }
-    }
-	
+    }    
 
     /// Returns true if the value of aggregatable coin is zero.
     public(friend) fun is_aggregatable_coin_zero<CoinType>(coin: &AggregatableCoin<CoinType>): bool {
@@ -703,8 +706,11 @@ module supra_framework::coin {
         }
     }
 
+    // TODO: Return this function to `public entry` once we have full support for Fungible Assets.
+    // This function should not be called by any production code until we have full support for FAs.
+    //
     /// Voluntarily migrate to fungible store for `CoinType` if not yet.
-    public entry fun migrate_to_fungible_store<CoinType>(
+    public(friend) fun migrate_to_fungible_store<CoinType>(
         account: &signer
     ) acquires CoinStore, CoinConversionMap, CoinInfo {
         maybe_convert_to_fungible_store<CoinType>(signer::address_of(account));
@@ -1062,14 +1068,14 @@ module supra_framework::coin {
         system_addresses::assert_supra_framework(account);
         initialize_internal(account, name, symbol, decimals, monitor_supply, true)
     }
-	
-	public(friend) fun initialize_with_parallelizable_supply_with_limit<CoinType>(
+    
+    public(friend) fun initialize_with_parallelizable_supply_with_limit<CoinType>(
         account: &signer,
         name: string::String,
         symbol: string::String,
         decimals: u8,
         monitor_supply: bool,
-		limit: u128,
+        limit: u128,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
         system_addresses::assert_supra_framework(account);
         initialize_internal_with_limit(account, name, symbol, decimals, monitor_supply, true, limit)
@@ -1108,14 +1114,15 @@ module supra_framework::coin {
 
         (BurnCapability<CoinType> {}, FreezeCapability<CoinType> {}, MintCapability<CoinType> {})
     }
-	 fun initialize_internal_with_limit<CoinType>(
+
+     fun initialize_internal_with_limit<CoinType>(
         account: &signer,
         name: string::String,
         symbol: string::String,
         decimals: u8,
         monitor_supply: bool,
         parallelizable: bool,
-		limit: u128,
+        limit: u128,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
         let account_addr = signer::address_of(account);
 

--- a/aptos-move/framework/supra-framework/sources/supra_coin.move
+++ b/aptos-move/framework/supra-framework/sources/supra_coin.move
@@ -164,7 +164,7 @@ module supra_framework::supra_coin {
     #[test_only]
     public fun mint_apt_fa_for_test(amount: u64): FungibleAsset acquires MintCapStore {
         ensure_initialized_with_apt_fa_metadata_for_test();
-        coin::coin_to_fungible_asset(
+        coin::coin_to_fungible_asset_for_test(
             coin::mint(
                 amount,
                 &borrow_global<MintCapStore>(@supra_framework).mint_cap

--- a/aptos-move/framework/supra-framework/sources/vesting_without_staking.move
+++ b/aptos-move/framework/supra-framework/sources/vesting_without_staking.move
@@ -628,8 +628,7 @@ module supra_framework::vesting_without_staking {
     /// Create a salt for generating the resource accounts that will be holding the VestingContract.
     /// This address should be deterministic for the same admin and vesting contract creation nonce.
     fun create_vesting_contract_account(admin: &signer, contract_creation_seed: vector<u8>,)
-        : (signer,
-        SignerCapability) acquires AdminStore {
+        : (signer, SignerCapability) acquires AdminStore {
         let admin_store = borrow_global_mut<AdminStore>(signer::address_of(admin));
         let seed = bcs::to_bytes(&signer::address_of(admin));
         vector::append(&mut seed, bcs::to_bytes(&admin_store.nonce));

--- a/aptos-move/framework/supra-framework/tests/supra_coin_tests.move
+++ b/aptos-move/framework/supra-framework/tests/supra_coin_tests.move
@@ -1,52 +1,50 @@
-// TODO: Reactivate once `coin::coin_to_fungible_asset` is made `public` again.
-//
-// #[test_only]
-// module supra_framework::supra_coin_tests {
-//     use std::features;
-//     use supra_framework::supra_coin;
-//     use supra_framework::coin;
-//     use supra_framework::fungible_asset::{Self, FungibleStore, Metadata};
-//     use supra_framework::primary_fungible_store;
-//     use supra_framework::object::{Self, Object};
+#[test_only]
+module supra_framework::supra_coin_tests {
+    use std::features;
+    use supra_framework::supra_coin;
+    use supra_framework::coin;
+    use supra_framework::fungible_asset::{Self, FungibleStore, Metadata};
+    use supra_framework::primary_fungible_store;
+    use supra_framework::object::{Self, Object};
 
-//     public fun mint_apt_fa_to_for_test<T: key>(store: Object<T>, amount: u64) {
-//         fungible_asset::deposit(store, supra_coin::mint_apt_fa_for_test(amount));
-//     }
+    public fun mint_apt_fa_to_for_test<T: key>(store: Object<T>, amount: u64) {
+        fungible_asset::deposit(store, supra_coin::mint_apt_fa_for_test(amount));
+    }
 
-//     public fun mint_apt_fa_to_primary_fungible_store_for_test(
-//         owner: address,
-//         amount: u64,
-//     ) {
-//         primary_fungible_store::deposit(owner, supra_coin::mint_apt_fa_for_test(amount));
-//     }
+    public fun mint_apt_fa_to_primary_fungible_store_for_test(
+        owner: address,
+        amount: u64,
+    ) {
+        primary_fungible_store::deposit(owner, supra_coin::mint_apt_fa_for_test(amount));
+    }
 
-//     #[test(supra_framework = @supra_framework)]
-//     fun test_apt_setup_and_mint(supra_framework: &signer) {
-//         let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
-//         let coin = coin::mint(100, &mint_cap);
-//         let fa = coin::coin_to_fungible_asset(coin);
-//         primary_fungible_store::deposit(@supra_framework, fa);
-//         assert!(
-//             primary_fungible_store::balance(
-//                 @supra_framework,
-//                 object::address_to_object<Metadata>(@aptos_fungible_asset)
-//             ) == 100,
-//             0
-//         );
-//         coin::destroy_mint_cap(mint_cap);
-//         coin::destroy_burn_cap(burn_cap);
-//     }
+    #[test(supra_framework = @supra_framework)]
+    fun test_apt_setup_and_mint(supra_framework: &signer) {
+        let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
+        let coin = coin::mint(100, &mint_cap);
+        let fa = coin::coin_to_fungible_asset_for_test(coin);
+        primary_fungible_store::deposit(@supra_framework, fa);
+        assert!(
+            primary_fungible_store::balance(
+                @supra_framework,
+                object::address_to_object<Metadata>(@aptos_fungible_asset)
+            ) == 100,
+            0
+        );
+        coin::destroy_mint_cap(mint_cap);
+        coin::destroy_burn_cap(burn_cap);
+    }
 
-//     #[test]
-//     fun test_fa_helpers_for_test() {
-//         assert!(!object::object_exists<Metadata>(@aptos_fungible_asset), 0);
-//         supra_coin::ensure_initialized_with_apt_fa_metadata_for_test();
-//         assert!(object::object_exists<Metadata>(@aptos_fungible_asset), 0);
-//         mint_apt_fa_to_primary_fungible_store_for_test(@supra_framework, 100);
-//         let metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
-//         assert!(primary_fungible_store::balance(@supra_framework, metadata) == 100, 0);
-//         let store_addr = primary_fungible_store::primary_store_address(@supra_framework, metadata);
-//         mint_apt_fa_to_for_test(object::address_to_object<FungibleStore>(store_addr), 100);
-//         assert!(primary_fungible_store::balance(@supra_framework, metadata) == 200, 0);
-//     }
-// }
+    #[test]
+    fun test_fa_helpers_for_test() {
+        assert!(!object::object_exists<Metadata>(@aptos_fungible_asset), 0);
+        supra_coin::ensure_initialized_with_apt_fa_metadata_for_test();
+        assert!(object::object_exists<Metadata>(@aptos_fungible_asset), 0);
+        mint_apt_fa_to_primary_fungible_store_for_test(@supra_framework, 100);
+        let metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
+        assert!(primary_fungible_store::balance(@supra_framework, metadata) == 100, 0);
+        let store_addr = primary_fungible_store::primary_store_address(@supra_framework, metadata);
+        mint_apt_fa_to_for_test(object::address_to_object<FungibleStore>(store_addr), 100);
+        assert!(primary_fungible_store::balance(@supra_framework, metadata) == 200, 0);
+    }
+}

--- a/aptos-move/framework/supra-framework/tests/supra_coin_tests.move
+++ b/aptos-move/framework/supra-framework/tests/supra_coin_tests.move
@@ -1,49 +1,52 @@
-#[test_only]
-module supra_framework::supra_coin_tests {
-    use supra_framework::supra_coin;
-    use supra_framework::coin;
-    use supra_framework::fungible_asset::{Self, FungibleStore, Metadata};
-    use supra_framework::primary_fungible_store;
-    use supra_framework::object::{Self, Object};
+// TODO: Reactivate once `coin::coin_to_fungible_asset` is made `public` again.
+//
+// #[test_only]
+// module supra_framework::supra_coin_tests {
+//     use std::features;
+//     use supra_framework::supra_coin;
+//     use supra_framework::coin;
+//     use supra_framework::fungible_asset::{Self, FungibleStore, Metadata};
+//     use supra_framework::primary_fungible_store;
+//     use supra_framework::object::{Self, Object};
 
-    public fun mint_apt_fa_to_for_test<T: key>(store: Object<T>, amount: u64) {
-        fungible_asset::deposit(store, supra_coin::mint_apt_fa_for_test(amount));
-    }
+//     public fun mint_apt_fa_to_for_test<T: key>(store: Object<T>, amount: u64) {
+//         fungible_asset::deposit(store, supra_coin::mint_apt_fa_for_test(amount));
+//     }
 
-    public fun mint_apt_fa_to_primary_fungible_store_for_test(
-        owner: address,
-        amount: u64,
-    ) {
-        primary_fungible_store::deposit(owner, supra_coin::mint_apt_fa_for_test(amount));
-    }
+//     public fun mint_apt_fa_to_primary_fungible_store_for_test(
+//         owner: address,
+//         amount: u64,
+//     ) {
+//         primary_fungible_store::deposit(owner, supra_coin::mint_apt_fa_for_test(amount));
+//     }
 
-    #[test(supra_framework = @supra_framework)]
-    fun test_apt_setup_and_mint(supra_framework: &signer) {
-        let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
-        let coin = coin::mint(100, &mint_cap);
-        let fa = coin::coin_to_fungible_asset(coin);
-        primary_fungible_store::deposit(@supra_framework, fa);
-        assert!(
-            primary_fungible_store::balance(
-                @supra_framework,
-                object::address_to_object<Metadata>(@aptos_fungible_asset)
-            ) == 100,
-            0
-        );
-        coin::destroy_mint_cap(mint_cap);
-        coin::destroy_burn_cap(burn_cap);
-    }
+//     #[test(supra_framework = @supra_framework)]
+//     fun test_apt_setup_and_mint(supra_framework: &signer) {
+//         let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
+//         let coin = coin::mint(100, &mint_cap);
+//         let fa = coin::coin_to_fungible_asset(coin);
+//         primary_fungible_store::deposit(@supra_framework, fa);
+//         assert!(
+//             primary_fungible_store::balance(
+//                 @supra_framework,
+//                 object::address_to_object<Metadata>(@aptos_fungible_asset)
+//             ) == 100,
+//             0
+//         );
+//         coin::destroy_mint_cap(mint_cap);
+//         coin::destroy_burn_cap(burn_cap);
+//     }
 
-    #[test]
-    fun test_fa_helpers_for_test() {
-        assert!(!object::object_exists<Metadata>(@aptos_fungible_asset), 0);
-        supra_coin::ensure_initialized_with_apt_fa_metadata_for_test();
-        assert!(object::object_exists<Metadata>(@aptos_fungible_asset), 0);
-        mint_apt_fa_to_primary_fungible_store_for_test(@supra_framework, 100);
-        let metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
-        assert!(primary_fungible_store::balance(@supra_framework, metadata) == 100, 0);
-        let store_addr = primary_fungible_store::primary_store_address(@supra_framework, metadata);
-        mint_apt_fa_to_for_test(object::address_to_object<FungibleStore>(store_addr), 100);
-        assert!(primary_fungible_store::balance(@supra_framework, metadata) == 200, 0);
-    }
-}
+//     #[test]
+//     fun test_fa_helpers_for_test() {
+//         assert!(!object::object_exists<Metadata>(@aptos_fungible_asset), 0);
+//         supra_coin::ensure_initialized_with_apt_fa_metadata_for_test();
+//         assert!(object::object_exists<Metadata>(@aptos_fungible_asset), 0);
+//         mint_apt_fa_to_primary_fungible_store_for_test(@supra_framework, 100);
+//         let metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
+//         assert!(primary_fungible_store::balance(@supra_framework, metadata) == 100, 0);
+//         let store_addr = primary_fungible_store::primary_store_address(@supra_framework, metadata);
+//         mint_apt_fa_to_for_test(object::address_to_object<FungibleStore>(store_addr), 100);
+//         assert!(primary_fungible_store::balance(@supra_framework, metadata) == 200, 0);
+//     }
+// }


### PR DESCRIPTION
See #91.

QA: The backwards compatibility of this feature should be verified by starting a local network running `smr-moonshot` `v6.3.0`, then compiling and deploying the new version of the framework. The deployment should succeed, and once it does, the following CLI command should return a transaction execution log that contains an error indicating that the related function is not available: `./supra move simulate run --function-id 0x1::coin::migrate_to_fungible_store --type-args 0x1::supra_coin::SupraCoin`