### PR TITLE
Ensured that the mint capability held by the framework account is destroyed when genesis ends.

### DIFF
--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -374,6 +374,8 @@ module supra_framework::genesis {
         });
     }
 
+    /// DEPRECATED
+    /// 
     fun create_initialize_validators_with_commission(
         supra_framework: &signer,
         use_staking_contract: bool,
@@ -383,12 +385,10 @@ module supra_framework::genesis {
             let validator: &ValidatorConfigurationWithCommission = validator;
             create_initialize_validator(supra_framework, validator, use_staking_contract);
         });
-
-        // Destroy the aptos framework account's ability to mint coins now that we're done with setting up the initial
-        // validators.
-        supra_coin::destroy_mint_cap(supra_framework);
     }
 
+    /// DEPRECATED
+    /// 
     /// Sets up the initial validator set for the network.
     /// The validator "owner" accounts, and their authentication
     /// Addresses (and keys) are encoded in the `owners`

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -612,6 +612,10 @@ module supra_framework::genesis {
 
     /// The last step of genesis.
     fun set_genesis_end(supra_framework: &signer) {
+        // Destroy the mint capability owned by the framework account. The stake and transaction_fee
+        // modules should be the only holders of this capability, which they will use to
+        // mint block rewards and storage refunds, respectively.
+        supra_coin::destroy_mint_cap(supra_framework);
         stake::on_new_epoch();
         chain_status::set_genesis_end(supra_framework);
     }


### PR DESCRIPTION
See #99. This was previously done via `create_initialize_validators_with_commission`, but we no longer use this function.