### PR TITLE
fix comment and docs

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/overview.md
+++ b/aptos-move/framework/aptos-stdlib/doc/overview.md
@@ -1,5 +1,5 @@
 
-<a id="@Aptos_Standard_Library_0"></a>
+<a id="@Supra_Standard_Library_0"></a>
 
 # Supra Standard Library
 

--- a/aptos-move/framework/aptos-token-objects/doc/overview.md
+++ b/aptos-move/framework/aptos-token-objects/doc/overview.md
@@ -1,5 +1,5 @@
 
-<a id="@Aptos_Token_Framework_0"></a>
+<a id="@Supra_Token_Framework_0"></a>
 
 # Supra Token Framework
 

--- a/aptos-move/framework/aptos-token/doc/overview.md
+++ b/aptos-move/framework/aptos-token/doc/overview.md
@@ -1,5 +1,5 @@
 
-<a id="@Aptos_Token_Framework_0"></a>
+<a id="@Supra_Token_Framework_0"></a>
 
 # Supra Token Framework
 

--- a/aptos-move/framework/supra-framework/doc/supra_account.md
+++ b/aptos-move/framework/supra-framework/doc/supra_account.md
@@ -745,7 +745,7 @@ Address of SUPRA Primary Fungible Store
 
 <tr>
 <td>1</td>
-<td>During the creation of an Aptos account the following rules should hold: (1) the authentication key should be 32 bytes in length, (2) an Aptos account should not already exist for that authentication key, and (3) the address of the authentication key should not be equal to a reserved address (0x0, 0x1, or 0x3).</td>
+<td>During the creation of an Supra account the following rules should hold: (1) the authentication key should be 32 bytes in length, (2) an Supra account should not already exist for that authentication key, and (3) the address of the authentication key should not be equal to a reserved address (0x0, 0x1, or 0x3).</td>
 <td>Critical</td>
 <td>The authentication key which is passed in as an argument to create_account should satisfy all necessary conditions.</td>
 <td>Formally verified via <a href="#high-level-req-1">CreateAccountAbortsIf</a>.</td>
@@ -753,7 +753,7 @@ Address of SUPRA Primary Fungible Store
 
 <tr>
 <td>2</td>
-<td>After creating an Aptos account, the account should become registered to receive SupraCoin.</td>
+<td>After creating an Supra account, the account should become registered to receive SupraCoin.</td>
 <td>Critical</td>
 <td>The create_account function creates a new account for the particular address and registers SupraCoin.</td>
 <td>Formally verified via <a href="#high-level-req-2">create_account</a>.</td>
@@ -793,7 +793,7 @@ Address of SUPRA Primary Fungible Store
 
 <tr>
 <td>7</td>
-<td>When performing a batch transfer of Aptos Coin and/or a batch transfer of a custom coin type, it should ensure that the vector containing destination addresses and the vector containing the corresponding amounts are equal in length.</td>
+<td>When performing a batch transfer of Supra Coin and/or a batch transfer of a custom coin type, it should ensure that the vector containing destination addresses and the vector containing the corresponding amounts are equal in length.</td>
 <td>Low</td>
 <td>The batch_transfer and batch_transfer_coins functions verify that the length of the recipient addresses vector matches the length of the amount vector through an assertion.</td>
 <td>Formally verified via <a href="#high-level-req-7">batch_transfer_coins</a>.</td>

--- a/aptos-move/framework/supra-framework/doc/vesting_without_staking.md
+++ b/aptos-move/framework/supra-framework/doc/vesting_without_staking.md
@@ -1283,19 +1283,17 @@ Unlock any vested portion of the grant.
     <b>let</b> next_period_to_vest = last_vested_period + 1;
     <b>let</b> last_completed_period = (<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() - vesting_schedule.start_timestamp_secs)
         / vesting_schedule.period_duration;
+
     // Index is 0-based <b>while</b> period is 1-based so we need <b>to</b> subtract 1.
-    <b>while</b> (last_completed_period &gt;= next_period_to_vest && vesting_record.left_amount
-        &gt; 0) {
+    <b>while</b> (last_completed_period &gt;= next_period_to_vest && vesting_record.left_amount &gt; 0) {
         <b>let</b> schedule_index = next_period_to_vest - 1;
         <b>let</b> vesting_fraction = <b>if</b> (schedule_index &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(schedule)) {
             *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(schedule, schedule_index)
         } <b>else</b> {
             // Last <a href="vesting.md#0x1_vesting">vesting</a> schedule fraction will repeat until the grant runs out.
-            *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(schedule, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(schedule) - 1) };
+            *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(schedule, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(schedule) - 1)
+        };
         <a href="vesting_without_staking.md#0x1_vesting_without_staking_vest_transfer">vest_transfer</a>(vesting_record, signer_cap, beneficiary, vesting_fraction);
-        //<b>update</b> last_vested_period for the shareholder
-        vesting_record.last_vested_period = next_period_to_vest;
-        next_period_to_vest = next_period_to_vest + 1;
 
         emit_event(&<b>mut</b> vesting_contract.vest_events,
             <a href="vesting_without_staking.md#0x1_vesting_without_staking_VestEvent">VestEvent</a> {
@@ -1305,7 +1303,11 @@ Unlock any vested portion of the grant.
                 period_vested: next_period_to_vest,
             },
         );
+        next_period_to_vest = next_period_to_vest + 1;
     };
+
+    //<b>update</b> last_vested_period for the shareholder
+    vesting_record.last_vested_period = next_period_to_vest - 1;
 }
 </code></pre>
 
@@ -1743,8 +1745,7 @@ This address should be deterministic for the same admin and vesting contract cre
 
 
 <pre><code><b>fun</b> <a href="vesting_without_staking.md#0x1_vesting_without_staking_create_vesting_contract_account">create_vesting_contract_account</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,)
-    : (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    SignerCapability) <b>acquires</b> <a href="vesting_without_staking.md#0x1_vesting_without_staking_AdminStore">AdminStore</a> {
+    : (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, SignerCapability) <b>acquires</b> <a href="vesting_without_staking.md#0x1_vesting_without_staking_AdminStore">AdminStore</a> {
     <b>let</b> admin_store = <b>borrow_global_mut</b>&lt;<a href="vesting_without_staking.md#0x1_vesting_without_staking_AdminStore">AdminStore</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin));
     <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&admin_store.nonce));

--- a/aptos-move/framework/supra-framework/sources/coin.move
+++ b/aptos-move/framework/supra-framework/sources/coin.move
@@ -402,8 +402,8 @@ module supra_framework::coin {
         fungible_asset::mint_internal(metadata, amount)
     }
 
-    /// A public wrapper around `coin_to_fungible_asset_internal` for use by external tests.
     #[test_only]
+    /// A public wrapper around `coin_to_fungible_asset_internal` for use by external tests.
     public fun coin_to_fungible_asset_for_test<CoinType>(
         coin: Coin<CoinType>
     ): FungibleAsset acquires CoinConversionMap, CoinInfo {


### PR DESCRIPTION
Move parser is not able to infer that docstrings above macros
```
supra move tool compile --package-dir /supra/move_workspace/test3
Compiling, may take a little while to download git dependencies...
FETCHING GIT DEPENDENCY https://github.com/Entropy-Foundation/aptos-core.git
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
INCLUDING DEPENDENCY SupraFramework
BUILDING test3
warning[W01004]: invalid documentation comment
  ┌─ /root/.move/https___github_com_Entropy-Foundation_aptos-core_git_dev/aptos-move/framework/supra-framework/sources/coin.move:405:5
  │
405 │   /// A public wrapper around coin_to_fungible_asset_internal for use by external tests.
  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
{
 “Result”: []
} 
```