### PR TITLE
Add pool owner's stake after initializing PBO pools

### DIFF
--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -138,6 +138,8 @@ impl GenesisInfo {
         aptos_vm_genesis::encode_genesis_transaction_for_testnet(
             self.root_key.clone(),
             &self.validators,
+            None,
+            0,
             &[],
             &[],
             &[],

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -131,6 +131,7 @@ impl MainnetGenesisInfo {
             &[],
             None,
             &[],
+            0,
             &[],
             &[],
             &self.framework,


### PR DESCRIPTION
Genesis transaction updates for https://github.com/Entropy-Foundation/smr-moonshot/issues/1280. 

`0x1::pbo_delegation_pool::add_stake` method is invoked after the delegation pools are created, facilitating owner's of the pools to add stake to their own pools without being subjected to the unlocking schedule. 