### PR TITLE
Handled automation-registry state update on new epoch

### DIFF
--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -130,7 +130,7 @@ fn check_successful_registration() {
     let result = view_output.values.expect("Valid result");
     assert_eq!(result.len(), 1);
     let next_task_id = bcs::from_bytes::<u64>(&result[0]).unwrap();
-    assert_eq!(next_task_id, 2);
+    assert_eq!(next_task_id, 1);
 }
 
 #[test]

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -149,7 +149,7 @@ pub enum EntryFunctionCall {
 
     /// Remove Automatioon task entry.
     AutomationRegistryRemoveTask {
-        registry_id: u64,
+        id: u64,
     },
 
     /// Update Automation gas limit
@@ -1202,9 +1202,7 @@ impl EntryFunctionCall {
                 new_public_key_bytes,
                 cap_update_table,
             ),
-            AutomationRegistryRemoveTask { registry_id } => {
-                automation_registry_remove_task(registry_id)
-            },
+            AutomationRegistryRemoveTask { id } => automation_registry_remove_task(id),
             AutomationRegistryUpdateAutomationGasLimit {
                 automation_gas_limit,
             } => automation_registry_update_automation_gas_limit(automation_gas_limit),
@@ -2151,7 +2149,7 @@ pub fn account_rotate_authentication_key_with_rotation_capability(
 }
 
 /// Remove Automatioon task entry.
-pub fn automation_registry_remove_task(registry_id: u64) -> TransactionPayload {
+pub fn automation_registry_remove_task(id: u64) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
             AccountAddress::new([
@@ -2162,7 +2160,7 @@ pub fn automation_registry_remove_task(registry_id: u64) -> TransactionPayload {
         ),
         ident_str!("remove_task").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&registry_id).unwrap()],
+        vec![bcs::to_bytes(&id).unwrap()],
     ))
 }
 
@@ -5386,7 +5384,7 @@ mod decoder {
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::AutomationRegistryRemoveTask {
-                registry_id: bcs::from_bytes(script.args().get(0)?).ok()?,
+                id: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
         } else {
             None

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -682,8 +682,7 @@ List all the automation task ids
 ## Function `get_task_details`
 
 Retrieves the details of a automation task entry by its ID.
-Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
-and the second element contains the <code>AutomationTaskMetaData</code> details.
+Error will be returned if entry with specified ID does not exist.
 
 
 <pre><code>#[view]

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -9,15 +9,11 @@ This contract is part of the Supra Framework and is designed to manage automated
 
 
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
--  [Struct `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
 -  [Struct `FeeWithdrawnAdmin`](#0x1_automation_registry_FeeWithdrawnAdmin)
 -  [Struct `RefundFeeUser`](#0x1_automation_registry_RefundFeeUser)
--  [Struct `UpdateAutomationGasLimit`](#0x1_automation_registry_UpdateAutomationGasLimit)
 -  [Struct `UpdateDurationUpperLimit`](#0x1_automation_registry_UpdateDurationUpperLimit)
--  [Struct `RemoveAutomationTask`](#0x1_automation_registry_RemoveAutomationTask)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
--  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `update_automation_gas_limit`](#0x1_automation_registry_update_automation_gas_limit)
@@ -30,13 +26,14 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
 -  [Function `get_active_task_ids`](#0x1_automation_registry_get_active_task_ids)
 -  [Function `get_task_details`](#0x1_automation_registry_get_task_details)
+-  [Function `has_active_task_with_id`](#0x1_automation_registry_has_active_task_with_id)
 -  [Function `get_registry_fee_address`](#0x1_automation_registry_get_registry_fee_address)
 -  [Function `get_gas_committed_for_next_epoch`](#0x1_automation_registry_get_gas_committed_for_next_epoch)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="automation_registry_state.md#0x1_automation_registry_state">0x1::automation_registry_state</a>;
 <b>use</b> <a href="block.md#0x1_block">0x1::block</a>;
-<b>use</b> <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map">0x1::enumerable_map</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
@@ -44,7 +41,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
 <b>use</b> <a href="transaction_context.md#0x1_transaction_context">0x1::transaction_context</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -66,18 +62,6 @@ It tracks entries both pending and completed, organized by unique indices.
 
 
 <dl>
-<dt>
-<code>current_index: u64</code>
-</dt>
-<dd>
- The current unique index counter for registered tasks. This value increments as new tasks are added.
-</dd>
-<dt>
-<code>automation_gas_limit: u64</code>
-</dt>
-<dd>
- Automation task gas limit.
-</dd>
 <dt>
 <code>duration_upper_limit: u64</code>
 </dt>
@@ -107,95 +91,6 @@ It tracks entries both pending and completed, organized by unique indices.
 </dt>
 <dd>
  Resource account signature capability
-</dd>
-<dt>
-<code>tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_EnumerableMap">enumerable_map::EnumerableMap</a>&lt;u64, <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>&gt;</code>
-</dt>
-<dd>
- A collection of automation task entries that are active state.
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_AutomationTaskMetaData"></a>
-
-## Struct `AutomationTaskMetaData`
-
-<code><a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a></code> represents a single automation task item, containing metadata.
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: u64</code>
-</dt>
-<dd>
- Automation task index in registry
-</dd>
-<dt>
-<code>owner: <b>address</b></code>
-</dt>
-<dd>
- The address of the task owner.
-</dd>
-<dt>
-<code>payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
-</dt>
-<dd>
- The function signature associated with the registry entry.
-</dd>
-<dt>
-<code>expiry_time: u64</code>
-</dt>
-<dd>
- Expiry of the task, represented in a timestamp in second.
-</dd>
-<dt>
-<code>tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
-</dt>
-<dd>
- The transaction hash of the request transaction.
-</dd>
-<dt>
-<code>max_gas_amount: u64</code>
-</dt>
-<dd>
- Max gas amount of automation task
-</dd>
-<dt>
-<code>gas_price_cap: u64</code>
-</dt>
-<dd>
- Maximum gas price cap for the task
-</dd>
-<dt>
-<code>registration_epoch: u64</code>
-</dt>
-<dd>
- Registration epoch number
-</dd>
-<dt>
-<code>registration_time: u64</code>
-</dt>
-<dd>
- Registration epoch time
-</dd>
-<dt>
-<code>is_active: bool</code>
-</dt>
-<dd>
- Flag indicating whether the task is active.
 </dd>
 </dl>
 
@@ -272,35 +167,6 @@ Withdraw user's registration fee event
 
 </details>
 
-<a id="0x1_automation_registry_UpdateAutomationGasLimit"></a>
-
-## Struct `UpdateAutomationGasLimit`
-
-Update automation gas limit event
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>automation_gas_limit: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x1_automation_registry_UpdateDurationUpperLimit"></a>
 
 ## Struct `UpdateDurationUpperLimit`
@@ -321,35 +187,6 @@ Update duration upper limit event
 <dl>
 <dt>
 <code>duration_upper_limit: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_RemoveAutomationTask"></a>
-
-## Struct `RemoveAutomationTask`
-
-Remove automation task registry event
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_RemoveAutomationTask">RemoveAutomationTask</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: u64</code>
 </dt>
 <dd>
 
@@ -394,22 +231,12 @@ The default upper limit duration for automation task, specified in seconds (30 d
 
 
 
-<a id="0x1_automation_registry_EAUTOMATION_TASK_NOT_EXIST"></a>
-
-Automation task not found
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 7;
-</code></pre>
-
-
-
 <a id="0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH"></a>
 
 Expiry time must be after the start of the next epoch
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 4;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 3;
 </code></pre>
 
 
@@ -419,17 +246,7 @@ Expiry time must be after the start of the next epoch
 Expiry time does not go beyond upper cap duration
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 3;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EGAS_AMOUNT_UPPER"></a>
-
-Gas amount does not go beyond upper cap limit
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 5;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 2;
 </code></pre>
 
 
@@ -439,7 +256,7 @@ Gas amount does not go beyond upper cap limit
 Invalid expiry time: it cannot be earlier than the current time
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 2;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 1;
 </code></pre>
 
 
@@ -449,27 +266,7 @@ Invalid expiry time: it cannot be earlier than the current time
 Invalid gas price: it cannot be zero
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 6;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EREGITRY_NOT_FOUND"></a>
-
-Registry Id not found
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>: u64 = 1;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER"></a>
-
-Unauthorized access: the caller is not the owner of the task
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 8;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 4;
 </code></pre>
 
 
@@ -511,6 +308,7 @@ Registry resource creation seed
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <a href="automation_registry_state.md#0x1_automation_registry_state_initialize">automation_registry_state::initialize</a>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_DEFAULT_AUTOMATION_GAS_LIMIT">DEFAULT_AUTOMATION_GAS_LIMIT</a>);
 
     <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(
         supra_framework,
@@ -518,65 +316,12 @@ Registry resource creation seed
     );
 
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-        current_index: 0,
-        automation_gas_limit: <a href="automation_registry.md#0x1_automation_registry_DEFAULT_AUTOMATION_GAS_LIMIT">DEFAULT_AUTOMATION_GAS_LIMIT</a>,
         duration_upper_limit: <a href="automation_registry.md#0x1_automation_registry_DEFAULT_DURATION_UPPER_LIMIT">DEFAULT_DURATION_UPPER_LIMIT</a>,
         gas_committed_for_next_epoch: 0,
         automation_unit_price: <a href="automation_registry.md#0x1_automation_registry_DEFAULT_AUTOMATION_UNIT_PRICE">DEFAULT_AUTOMATION_UNIT_PRICE</a>,
         registry_fee_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&registry_fee_resource_signer),
         registry_fee_address_signer_cap,
-        tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
     })
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_on_new_epoch"></a>
-
-## Function `on_new_epoch`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> epoch_interval = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
-    <b>let</b> expired_task_gas = 0;
-
-    // Perform clean up and updation of state
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
-
-        // Tasks that are active during this new epoch but will be already expired for the next epoch
-        <b>if</b> (task.expiry_time &lt; (current_time + epoch_interval)) {
-            expired_task_gas = expired_task_gas + task.max_gas_amount;
-        };
-
-        <b>if</b> (task.expiry_time &lt;= current_time) {
-            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
-        } <b>else</b> <b>if</b> (!task.is_active && task.expiry_time &gt; current_time) {
-            task.is_active = <b>true</b>;
-        }
-    });
-
-    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - expired_task_gas;
 }
 </code></pre>
 
@@ -663,13 +408,9 @@ Update Automation gas limit
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_automation_gas_limit">update_automation_gas_limit</a>(
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     automation_gas_limit: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_gas_limit = automation_gas_limit;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> { automation_gas_limit });
+    <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">automation_registry_state::update_automation_gas_limit</a>(supra_framework, automation_gas_limit)
 }
 </code></pre>
 
@@ -788,7 +529,7 @@ Registers a new automation task entry.
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
 
-    // todo : well formedness check of payload_tx
+    //Well formedness check of payload_tx is done in <b>native</b> layer beforehand.
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
     <b>assert</b>!(expiry_time &gt; current_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
@@ -800,32 +541,22 @@ Registers a new automation task entry.
     <b>let</b> last_epoch_time = <a href="automation_registry.md#0x1_automation_registry_get_last_epoch_time_second">get_last_epoch_time_second</a>();
     <b>assert</b>!(expiry_time &gt; (last_epoch_time + epoch_interval), <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>);
 
-    registry_data.gas_committed_for_next_epoch = registry_data.gas_committed_for_next_epoch + max_gas_amount;
-    <b>assert</b>!(registry_data.gas_committed_for_next_epoch &lt; registry_data.automation_gas_limit, <a href="automation_registry.md#0x1_automation_registry_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
 
     <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
 
     <b>let</b> fee = expiry_time_duration * registry_data.automation_unit_price;
     <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner, fee);
 
-    registry_data.current_index = registry_data.current_index + 1;
-
-    <b>let</b> automation_task_metadata = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> {
-        id: registry_data.current_index,
-        owner: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner),
+    <b>let</b> epoch = <a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>();
+    <b>let</b> parent_hash = <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">transaction_context::txn_app_hash</a>();
+    <a href="automation_registry_state.md#0x1_automation_registry_state_register">automation_registry_state::register</a>(
+        owner,
         payload_tx,
         expiry_time,
         max_gas_amount,
         gas_price_cap,
-        is_active: <b>false</b>,
-        registration_epoch: <a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>(),
-        registration_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
-        tx_hash: <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">transaction_context::txn_app_hash</a>()
-    };
-
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> registry_data.tasks, registry_data.current_index, automation_task_metadata);
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
+        epoch,
+        parent_hash);
 }
 </code></pre>
 
@@ -840,7 +571,7 @@ Registers a new automation task entry.
 Remove Automatioon task entry.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, registry_id: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64)
 </code></pre>
 
 
@@ -849,24 +580,10 @@ Remove Automatioon task entry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, registry_id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> user_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
-
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, registry_id), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
-
-    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, registry_id);
-    <b>assert</b>!(automation_task_metadata.owner == user_addr, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
-
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, registry_id);
-
-    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
-
-    // Calculate refund fee and transfer it <b>to</b> user
-    <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(user_addr, automation_task_metadata, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_unit_price);
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemoveAutomationTask">RemoveAutomationTask</a> { id: automation_task_metadata.id });
+    <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">automation_registry_state::remove_task</a>(owner, id);
+    <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), automation_task_metadata, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_unit_price);
 }
 </code></pre>
 
@@ -881,7 +598,7 @@ Remove Automatioon task entry.
 Refunds the automation task fee to the user who has removed their task registration from the list.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(user: <b>address</b>, automation_task_metadata: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, automation_unit_price: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(user: <b>address</b>, automation_task_metadata: <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>, automation_unit_price: u64)
 </code></pre>
 
 
@@ -892,11 +609,11 @@ Refunds the automation task fee to the user who has removed their task registrat
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(
     user: <b>address</b>,
-    automation_task_metadata: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a>,
+    automation_task_metadata: AutomationTaskMetaData,
     automation_unit_price: u64,
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> expiry_time_duration = automation_task_metadata.expiry_time - current_time;
+    <b>let</b> expiry_time_duration = <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">automation_registry_state::task_expiry_time</a>(&automation_task_metadata) - current_time;
 
     <b>let</b> refund_amount = expiry_time_duration * automation_unit_price;
     <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(user, refund_amount);
@@ -925,9 +642,8 @@ Returns next task index in registry
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_next_task_index">get_next_task_index</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index + 1
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_next_task_index">get_next_task_index</a>(): u64 {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">automation_registry_state::get_next_task_index</a>()
 }
 </code></pre>
 
@@ -952,19 +668,8 @@ List all the automation task ids
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-
-    <b>let</b> active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
-        <b>if</b> (task.is_active) {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
-        };
-    });
-    <b>return</b> active_task_ids
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">automation_registry_state::get_active_task_ids</a>()
 }
 </code></pre>
 
@@ -978,11 +683,11 @@ List all the automation task ids
 
 Retrieves the details of a automation task entry by its ID.
 Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
-and the second element contains the <code><a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a></code> details.
+and the second element contains the <code>AutomationTaskMetaData</code> details.
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
 </code></pre>
 
 
@@ -991,10 +696,34 @@ and the second element contains the <code><a href="automation_registry.md#0x1_au
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry.md#0x1_automation_registry_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>);
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): AutomationTaskMetaData {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">automation_registry_state::get_task_details</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_has_active_task_with_id"></a>
+
+## Function `has_active_task_with_id`
+
+Checks whether there is an active task in registry with specified input task id.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">automation_registry_state::has_active_task_with_id</a>(id)
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -536,8 +536,7 @@ List all the automation task ids
 ## Function `get_task_details`
 
 Retrieves the details of a automation task entry by its ID.
-Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
-and the second element contains the <code><a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a></code> details.
+Error will be returned if entry with specified ID does not exist.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -1,0 +1,622 @@
+
+<a id="0x1_automation_registry_state"></a>
+
+# Module `0x1::automation_registry_state`
+
+Supra Automation Registry State
+
+This contract is part of the Supra Framework and is designed to manage automated task entries
+
+
+-  [Resource `AutomationRegistryState`](#0x1_automation_registry_state_AutomationRegistryState)
+-  [Struct `AutomationTaskMetaData`](#0x1_automation_registry_state_AutomationTaskMetaData)
+-  [Struct `UpdateAutomationGasLimit`](#0x1_automation_registry_state_UpdateAutomationGasLimit)
+-  [Struct `RemoveAutomationTask`](#0x1_automation_registry_state_RemoveAutomationTask)
+-  [Constants](#@Constants_0)
+-  [Function `task_expiry_time`](#0x1_automation_registry_state_task_expiry_time)
+-  [Function `initialize`](#0x1_automation_registry_state_initialize)
+-  [Function `on_new_epoch`](#0x1_automation_registry_state_on_new_epoch)
+-  [Function `register`](#0x1_automation_registry_state_register)
+-  [Function `remove_task`](#0x1_automation_registry_state_remove_task)
+-  [Function `update_automation_gas_limit`](#0x1_automation_registry_state_update_automation_gas_limit)
+-  [Function `get_active_task_ids`](#0x1_automation_registry_state_get_active_task_ids)
+-  [Function `get_task_details`](#0x1_automation_registry_state_get_task_details)
+-  [Function `has_active_task_with_id`](#0x1_automation_registry_state_has_active_task_with_id)
+-  [Function `get_next_task_index`](#0x1_automation_registry_state_get_next_task_index)
+
+
+<pre><code><b>use</b> <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map">0x1::enumerable_map</a>;
+<b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+<b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_AutomationRegistryState"></a>
+
+## Resource `AutomationRegistryState`
+
+It tracks entries both pending and completed, organized by unique indices.
+
+
+<pre><code><b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_EnumerableMap">enumerable_map::EnumerableMap</a>&lt;u64, <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>&gt;</code>
+</dt>
+<dd>
+ A collection of automation task entries that are active state.
+</dd>
+<dt>
+<code>current_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_committed_for_next_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>automation_gas_limit: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_state_AutomationTaskMetaData"></a>
+
+## Struct `AutomationTaskMetaData`
+
+<code><a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a></code> represents a single automation task item, containing metadata.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: u64</code>
+</dt>
+<dd>
+ Automation task index in registry
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+ The address of the task owner.
+</dd>
+<dt>
+<code>payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The function signature associated with the registry entry.
+</dd>
+<dt>
+<code>expiry_time: u64</code>
+</dt>
+<dd>
+ Expiry of the task, represented in a timestamp in second.
+</dd>
+<dt>
+<code>tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The transaction hash of the request transaction.
+</dd>
+<dt>
+<code>max_gas_amount: u64</code>
+</dt>
+<dd>
+ Max gas amount of automation task
+</dd>
+<dt>
+<code>gas_price_cap: u64</code>
+</dt>
+<dd>
+ Maximum gas price cap for the task
+</dd>
+<dt>
+<code>registration_epoch: u64</code>
+</dt>
+<dd>
+ Registration epoch number
+</dd>
+<dt>
+<code>registration_time: u64</code>
+</dt>
+<dd>
+ Registration epoch time
+</dd>
+<dt>
+<code>is_active: bool</code>
+</dt>
+<dd>
+ Flag indicating whether the task is active.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_state_UpdateAutomationGasLimit"></a>
+
+## Struct `UpdateAutomationGasLimit`
+
+Update automation gas limit event
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>automation_gas_limit: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_state_RemoveAutomationTask"></a>
+
+## Struct `RemoveAutomationTask`
+
+Remove automation task registry event
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST"></a>
+
+Automation task not found
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EGAS_AMOUNT_UPPER"></a>
+
+Gas amount does not go beyond upper cap limit
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EREGITRY_NOT_FOUND"></a>
+
+Registry Id not found
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER"></a>
+
+Unauthorized access: the caller is not the owner of the task
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_task_expiry_time"></a>
+
+## Function `task_expiry_time`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a>): u64 {
+    task.expiry_time
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_initialize"></a>
+
+## Function `initialize`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+
+    <b>move_to</b>(supra_framework, <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+        tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
+        current_index: 0,
+        gas_committed_for_next_epoch: 0,
+        automation_gas_limit
+    })
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_on_new_epoch"></a>
+
+## Function `on_new_epoch`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval: u64) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&state.tasks);
+
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <b>let</b> expired_task_gas = 0;
+
+    // Perform clean up and updation of state
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> state.tasks, id);
+
+        // Tasks that are active during this new epoch but will be already expired for the next epoch
+        <b>if</b> (task.expiry_time &lt;= (current_time + epoch_interval)) {
+            expired_task_gas = expired_task_gas + task.max_gas_amount;
+        };
+
+        <b>if</b> (task.expiry_time &lt;= current_time) {
+            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
+        } <b>else</b> {
+            task.is_active = <b>true</b>;
+        }
+    });
+
+    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+    state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_register"></a>
+
+## Function `register`
+
+Registers a new automation task entry.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_register">register</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, expiry_time: u64, max_gas_amount: u64, gas_price_cap: u64, registration_epoch: u64, tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_register">register</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    expiry_time: u64,
+    max_gas_amount: u64,
+    gas_price_cap: u64,
+    registration_epoch: u64,
+    tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+
+    <b>let</b> committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
+    <b>assert</b>!(committed_gas &lt; registry_data.automation_gas_limit, <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
+    registry_data.gas_committed_for_next_epoch = committed_gas;
+    <b>let</b> task_index = registry_data.current_index;
+
+    <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> {
+        id: task_index,
+        owner: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner),
+        payload_tx,
+        expiry_time,
+        max_gas_amount,
+        gas_price_cap,
+        is_active: <b>false</b>,
+        registration_epoch,
+        registration_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+        tx_hash,
+    };
+
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> registry_data.tasks, task_index, automation_task_metadata);
+    registry_data.current_index = registry_data.current_index + 1;
+    <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_remove_task"></a>
+
+## Function `remove_task`
+
+Remove Automatioon task entry.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
+
+    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+    <b>assert</b>!(automation_task_metadata.owner == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
+
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+
+    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> { id: automation_task_metadata.id });
+    // todo : <b>return</b> refund amount <b>to</b> user
+    automation_task_metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_update_automation_gas_limit"></a>
+
+## Function `update_automation_gas_limit`
+
+Update Automation gas limit
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">update_automation_gas_limit</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">update_automation_gas_limit</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    automation_gas_limit: u64
+) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_gas_limit = automation_gas_limit;
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> { automation_gas_limit });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_active_task_ids"></a>
+
+## Function `get_active_task_ids`
+
+List all the automation task ids
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+
+    <b>let</b> active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+        <b>if</b> (task.is_active) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
+        };
+    });
+    <b>return</b> active_task_ids
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_task_details"></a>
+
+## Function `get_task_details`
+
+Retrieves the details of a automation task entry by its ID.
+Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
+and the second element contains the <code><a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a></code> details.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>);
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_has_active_task_with_id"></a>
+
+## Function `has_active_task_with_id`
+
+Checks whether there is an active task in registry with specified input task id.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id)) {
+        // TODO: uncomment when activation of the tasks on new epoch is enabled.
+        <b>let</b> value = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id);
+        value.is_active
+    } <b>else</b>  {
+        <b>false</b>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_next_task_index"></a>
+
+## Function `get_next_task_index`
+
+Returns next task index in registry
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">get_next_task_index</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">get_next_task_index</a>(): u64 <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> state = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    state.current_index
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/supra-framework/doc/block.md
+++ b/aptos-move/framework/supra-framework/doc/block.md
@@ -42,6 +42,7 @@ This module defines a struct storing the metadata of the block and new block eve
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="automation_registry_state.md#0x1_automation_registry_state">0x1::automation_registry_state</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
@@ -669,6 +670,7 @@ The runtime always runs this before executing the transactions in a block.
     <a href="randomness.md#0x1_randomness_on_new_block">randomness::on_new_block</a>(&vm, epoch, round, <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>());
     <b>if</b> (<a href="timestamp.md#0x1_timestamp">timestamp</a> - <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>() &gt;= epoch_interval) {
         <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();
+        <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">automation_registry_state::on_new_epoch</a>(epoch_interval);
     };
 }
 </code></pre>
@@ -718,6 +720,7 @@ The runtime always runs this before executing the transactions in a block.
 
     <b>if</b> (<a href="timestamp.md#0x1_timestamp">timestamp</a> - <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>() &gt;= epoch_interval) {
         <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_try_start">reconfiguration_with_dkg::try_start</a>();
+        <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">automation_registry_state::on_new_epoch</a>(epoch_interval);
     };
 }
 </code></pre>
@@ -1084,6 +1087,70 @@ The number of new events created does not exceed MAX_U64.
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
 <b>let</b> <a href="account.md#0x1_account">account</a> = <b>global</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
 <b>aborts_if</b> <a href="account.md#0x1_account">account</a>.guid_creation_num + 2 &gt;= <a href="account.md#0x1_account_MAX_GUID_CREATION_NUM">account::MAX_GUID_CREATION_NUM</a>;
+</code></pre>
+
+
+
+
+<a id="0x1_block_BlockRequirement"></a>
+
+
+<pre><code><b>schema</b> <a href="block.md#0x1_block_BlockRequirement">BlockRequirement</a> {
+    vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a>: <b>address</b>;
+    epoch: u64;
+    round: u64;
+    proposer: <b>address</b>;
+    failed_proposer_indices: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;;
+    previous_block_votes_bitvec: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <a href="timestamp.md#0x1_timestamp">timestamp</a>: u64;
+    <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+    <b>requires</b> <a href="system_addresses.md#0x1_system_addresses_is_vm">system_addresses::is_vm</a>(vm);
+    // This enforces <a id="high-level-req-4" href="#high-level-req">high-level requirement 4</a>:
+    <b>requires</b> proposer == @vm_reserved || <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">stake::spec_is_current_epoch_validator</a>(proposer);
+    <b>requires</b> (proposer == @vm_reserved) ==&gt; (<a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() == <a href="timestamp.md#0x1_timestamp">timestamp</a>);
+    <b>requires</b> (proposer != @vm_reserved) ==&gt; (<a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &lt; <a href="timestamp.md#0x1_timestamp">timestamp</a>);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@supra_framework);
+    <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;SupraCoin&gt;&gt;(@supra_framework);
+    <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+    <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
+}
+</code></pre>
+
+
+
+
+<a id="0x1_block_Initialize"></a>
+
+
+<pre><code><b>schema</b> <a href="block.md#0x1_block_Initialize">Initialize</a> {
+    supra_framework: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    epoch_interval_microsecs: u64;
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
+    // This enforces <a id="high-level-req-2.1" href="#high-level-req">high-level requirement 2</a>:
+    <b>aborts_if</b> addr != @supra_framework;
+    <b>aborts_if</b> epoch_interval_microsecs == 0;
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(addr);
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="block.md#0x1_block_CommitHistory">CommitHistory</a>&gt;(addr);
+    <b>ensures</b> <b>exists</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(addr);
+    <b>ensures</b> <b>exists</b>&lt;<a href="block.md#0x1_block_CommitHistory">CommitHistory</a>&gt;(addr);
+    <b>ensures</b> <b>global</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(addr).height == 0;
+}
+</code></pre>
+
+
+
+
+<a id="0x1_block_NewEventHandle"></a>
+
+
+<pre><code><b>schema</b> <a href="block.md#0x1_block_NewEventHandle">NewEventHandle</a> {
+    supra_framework: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
+    <b>let</b> <a href="account.md#0x1_account">account</a> = <b>global</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
+    <b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
+    <b>aborts_if</b> <a href="account.md#0x1_account">account</a>.guid_creation_num + 2 &gt; <a href="block.md#0x1_block_MAX_U64">MAX_U64</a>;
+}
 </code></pre>
 
 

--- a/aptos-move/framework/supra-framework/doc/overview.md
+++ b/aptos-move/framework/supra-framework/doc/overview.md
@@ -17,6 +17,7 @@ This is the reference documentation of the Supra framework.
 -  [`0x1::aggregator_factory`](aggregator_factory.md#0x1_aggregator_factory)
 -  [`0x1::aggregator_v2`](aggregator_v2.md#0x1_aggregator_v2)
 -  [`0x1::automation_registry`](automation_registry.md#0x1_automation_registry)
+-  [`0x1::automation_registry_state`](automation_registry_state.md#0x1_automation_registry_state)
 -  [`0x1::block`](block.md#0x1_block)
 -  [`0x1::chain_id`](chain_id.md#0x1_chain_id)
 -  [`0x1::chain_status`](chain_status.md#0x1_chain_status)

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -4,13 +4,12 @@
 module supra_framework::automation_registry {
 
     use std::signer;
-    use std::vector;
-
-    use supra_std::enumerable_map::{Self, EnumerableMap};
+    use supra_framework::event;
+    use supra_framework::automation_registry_state::AutomationTaskMetaData;
+    use supra_framework::automation_registry_state;
 
     use supra_framework::account::{Self, SignerCapability};
     use supra_framework::block;
-    use supra_framework::event;
     use supra_framework::reconfiguration;
     use supra_framework::supra_account;
     use supra_framework::system_addresses;
@@ -24,22 +23,14 @@ module supra_framework::automation_registry {
 
     friend supra_framework::genesis;
 
-    /// Registry Id not found
-    const EREGITRY_NOT_FOUND: u64 = 1;
     /// Invalid expiry time: it cannot be earlier than the current time
-    const EINVALID_EXPIRY_TIME: u64 = 2;
+    const EINVALID_EXPIRY_TIME: u64 = 1;
     /// Expiry time does not go beyond upper cap duration
-    const EEXPIRY_TIME_UPPER: u64 = 3;
+    const EEXPIRY_TIME_UPPER: u64 = 2;
     /// Expiry time must be after the start of the next epoch
-    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 4;
-    /// Gas amount does not go beyond upper cap limit
-    const EGAS_AMOUNT_UPPER: u64 = 5;
+    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 3;
     /// Invalid gas price: it cannot be zero
-    const EINVALID_GAS_PRICE: u64 = 6;
-    /// Automation task not found
-    const EAUTOMATION_TASK_NOT_EXIST: u64 = 7;
-    /// Unauthorized access: the caller is not the owner of the task
-    const EUNAUTHORIZED_TASK_OWNER: u64 = 8;
+    const EINVALID_GAS_PRICE: u64 = 4;
 
     /// The default automation task gas limit
     const DEFAULT_AUTOMATION_GAS_LIMIT: u64 = 100000000;
@@ -54,10 +45,6 @@ module supra_framework::automation_registry {
 
     /// It tracks entries both pending and completed, organized by unique indices.
     struct AutomationRegistry has key, store {
-        /// The current unique index counter for registered tasks. This value increments as new tasks are added.
-        current_index: u64,
-        /// Automation task gas limit.
-        automation_gas_limit: u64,
         /// Automation task duration upper limit.
         duration_upper_limit: u64,
         /// Gas committed for next epoch
@@ -68,34 +55,8 @@ module supra_framework::automation_registry {
         registry_fee_address: address,
         /// Resource account signature capability
         registry_fee_address_signer_cap: SignerCapability,
-        /// A collection of automation task entries that are active state.
-        tasks: EnumerableMap<u64, AutomationTaskMetaData>,
     }
 
-    #[event]
-    /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
-    struct AutomationTaskMetaData has copy, store, drop {
-        /// Automation task index in registry
-        id: u64,
-        /// The address of the task owner.
-        owner: address,
-        /// The function signature associated with the registry entry.
-        payload_tx: vector<u8>,
-        /// Expiry of the task, represented in a timestamp in second.
-        expiry_time: u64,
-        /// The transaction hash of the request transaction.
-        tx_hash: vector<u8>,
-        /// Max gas amount of automation task
-        max_gas_amount: u64,
-        /// Maximum gas price cap for the task
-        gas_price_cap: u64,
-        /// Registration epoch number
-        registration_epoch: u64,
-        /// Registration epoch time
-        registration_time: u64,
-        /// Flag indicating whether the task is active.
-        is_active: bool
-    }
 
     #[event]
     /// Withdraw user's registration fee event
@@ -111,11 +72,6 @@ module supra_framework::automation_registry {
         amount: u64
     }
 
-    #[event]
-    /// Update automation gas limit event
-    struct UpdateAutomationGasLimit has drop, store {
-        automation_gas_limit: u64
-    }
 
     #[event]
     /// Update duration upper limit event
@@ -123,15 +79,11 @@ module supra_framework::automation_registry {
         duration_upper_limit: u64
     }
 
-    #[event]
-    /// Remove automation task registry event
-    struct RemoveAutomationTask has drop, store {
-        id: u64
-    }
 
     // todo : this function should call during initialzation, but since we already done genesis in that case who can access the function
     public fun initialize(supra_framework: &signer) {
         system_addresses::assert_supra_framework(supra_framework);
+        automation_registry_state::initialize(supra_framework, DEFAULT_AUTOMATION_GAS_LIMIT);
 
         let (registry_fee_resource_signer, registry_fee_address_signer_cap) = account::create_resource_account(
             supra_framework,
@@ -139,46 +91,14 @@ module supra_framework::automation_registry {
         );
 
         move_to(supra_framework, AutomationRegistry {
-            current_index: 0,
-            automation_gas_limit: DEFAULT_AUTOMATION_GAS_LIMIT,
             duration_upper_limit: DEFAULT_DURATION_UPPER_LIMIT,
             gas_committed_for_next_epoch: 0,
             automation_unit_price: DEFAULT_AUTOMATION_UNIT_PRICE,
             registry_fee_address: signer::address_of(&registry_fee_resource_signer),
             registry_fee_address_signer_cap,
-            tasks: enumerable_map::new_map(),
         })
     }
 
-    public(friend) fun on_new_epoch(supra_framework: &signer) acquires AutomationRegistry {
-        system_addresses::assert_supra_framework(supra_framework);
-
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        let current_time = timestamp::now_seconds();
-        let epoch_interval = block::get_epoch_interval_secs();
-        let expired_task_gas = 0;
-
-        // Perform clean up and updation of state
-        vector::for_each(ids, |id| {
-            let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, id);
-
-            // Tasks that are active during this new epoch but will be already expired for the next epoch
-            if (task.expiry_time < (current_time + epoch_interval)) {
-                expired_task_gas = expired_task_gas + task.max_gas_amount;
-            };
-
-            if (task.expiry_time <= current_time) {
-                enumerable_map::remove_value(&mut automation_registry.tasks, id);
-            } else if (!task.is_active && task.expiry_time > current_time) {
-                task.is_active = true;
-            }
-        });
-
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - expired_task_gas;
-    }
 
     /// Withdraw accumulated automation task fees from the resource account - access by admin
     entry fun withdraw_automation_task_fees(
@@ -204,13 +124,9 @@ module supra_framework::automation_registry {
     public entry fun update_automation_gas_limit(
         supra_framework: &signer,
         automation_gas_limit: u64
-    ) acquires AutomationRegistry {
+    ) {
         system_addresses::assert_supra_framework(supra_framework);
-
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        automation_registry.automation_gas_limit = automation_gas_limit;
-
-        event::emit(UpdateAutomationGasLimit { automation_gas_limit });
+        automation_registry_state::update_automation_gas_limit(supra_framework, automation_gas_limit)
     }
 
     /// Update duration upper limit
@@ -249,7 +165,7 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry {
         let registry_data = borrow_global_mut<AutomationRegistry>(@supra_framework);
 
-        // todo : well formedness check of payload_tx
+        //Well formedness check of payload_tx is done in native layer beforehand.
 
         let current_time = timestamp::now_seconds();
         assert!(expiry_time > current_time, EINVALID_EXPIRY_TIME);
@@ -261,53 +177,29 @@ module supra_framework::automation_registry {
         let last_epoch_time = get_last_epoch_time_second();
         assert!(expiry_time > (last_epoch_time + epoch_interval), EEXPIRY_BEFORE_NEXT_EPOCH);
 
-        registry_data.gas_committed_for_next_epoch = registry_data.gas_committed_for_next_epoch + max_gas_amount;
-        assert!(registry_data.gas_committed_for_next_epoch < registry_data.automation_gas_limit, EGAS_AMOUNT_UPPER);
 
         assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
 
         let fee = expiry_time_duration * registry_data.automation_unit_price;
         charge_automation_fee_from_user(owner, fee);
 
-        registry_data.current_index = registry_data.current_index + 1;
-
-        let automation_task_metadata = AutomationTaskMetaData {
-            id: registry_data.current_index,
-            owner: signer::address_of(owner),
+        let epoch = reconfiguration::current_epoch();
+        let parent_hash = transaction_context::txn_app_hash();
+        automation_registry_state::register(
+            owner,
             payload_tx,
             expiry_time,
             max_gas_amount,
             gas_price_cap,
-            is_active: false,
-            registration_epoch: reconfiguration::current_epoch(),
-            registration_time: timestamp::now_seconds(),
-            tx_hash: transaction_context::txn_app_hash()
-        };
-
-        enumerable_map::add_value(&mut registry_data.tasks, registry_data.current_index, automation_task_metadata);
-
-        event::emit(automation_task_metadata);
+            epoch,
+            parent_hash);
     }
 
     /// Remove Automatioon task entry.
-    public entry fun remove_task(owner: &signer, registry_id: u64) acquires AutomationRegistry {
-        let user_addr = signer::address_of(owner);
-
+    public entry fun remove_task(owner: &signer, id: u64) acquires AutomationRegistry {
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_registry.tasks, registry_id), EAUTOMATION_TASK_NOT_EXIST);
-
-        let automation_task_metadata = enumerable_map::get_value(&automation_registry.tasks, registry_id);
-        assert!(automation_task_metadata.owner == user_addr, EUNAUTHORIZED_TASK_OWNER);
-
-        enumerable_map::remove_value(&mut automation_registry.tasks, registry_id);
-
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
-
-        // Calculate refund fee and transfer it to user
-        refund_automation_task_fee(user_addr, automation_task_metadata, automation_registry.automation_unit_price);
-
-        event::emit(RemoveAutomationTask { id: automation_task_metadata.id });
+        let automation_task_metadata = automation_registry_state::remove_task(owner, id);
+        refund_automation_task_fee(signer::address_of(owner), automation_task_metadata, automation_registry.automation_unit_price);
     }
 
     /// Refunds the automation task fee to the user who has removed their task registration from the list.
@@ -317,7 +209,7 @@ module supra_framework::automation_registry {
         automation_unit_price: u64,
     ) acquires AutomationRegistry {
         let current_time = timestamp::now_seconds();
-        let expiry_time_duration = automation_task_metadata.expiry_time - current_time;
+        let expiry_time_duration = automation_registry_state::task_expiry_time(&automation_task_metadata) - current_time;
 
         let refund_amount = expiry_time_duration * automation_unit_price;
         transfer_fee_to_account_internal(user, refund_amount);
@@ -326,36 +218,28 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Returns next task index in registry
-    public fun get_next_task_index(): u64 acquires AutomationRegistry {
-        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
-        automation_registry.current_index + 1
+    public fun get_next_task_index(): u64 {
+        automation_registry_state::get_next_task_index()
     }
 
     #[view]
     /// List all the automation task ids
-    public fun get_active_task_ids(): vector<u64> acquires AutomationRegistry {
-        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
-
-        let active_task_ids = vector[];
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        vector::for_each(ids, |id| {
-            let task = enumerable_map::get_value(&automation_registry.tasks, id);
-            if (task.is_active) {
-                vector::push_back(&mut active_task_ids, id);
-            };
-        });
-        return active_task_ids
+    public fun get_active_task_ids(): vector<u64> {
+        automation_registry_state::get_active_task_ids()
     }
 
     #[view]
     /// Retrieves the details of a automation task entry by its ID.
     /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
     /// and the second element contains the `AutomationTaskMetaData` details.
-    public fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);
-        enumerable_map::get_value(&automation_task_metadata.tasks, id)
+    public fun get_task_details(id: u64): AutomationTaskMetaData {
+        automation_registry_state::get_task_details(id)
+    }
+
+    #[view]
+    /// Checks whether there is an active task in registry with specified input task id.
+    public fun has_active_task_with_id(id: u64): bool {
+        automation_registry_state::has_active_task_with_id(id)
     }
 
     #[view]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -5,8 +5,7 @@ module supra_framework::automation_registry {
 
     use std::signer;
     use supra_framework::event;
-    use supra_framework::automation_registry_state::AutomationTaskMetaData;
-    use supra_framework::automation_registry_state;
+    use supra_framework::automation_registry_state::{Self, AutomationTaskMetaData};
 
     use supra_framework::account::{Self, SignerCapability};
     use supra_framework::block;
@@ -230,8 +229,7 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Retrieves the details of a automation task entry by its ID.
-    /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
-    /// and the second element contains the `AutomationTaskMetaData` details.
+    /// Error will be returned if entry with specified ID does not exist.
     public fun get_task_details(id: u64): AutomationTaskMetaData {
         automation_registry_state::get_task_details(id)
     }

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -12,7 +12,6 @@ module supra_framework::automation_registry_state {
     use supra_framework::system_addresses;
     use supra_framework::timestamp;
 
-    friend supra_framework::genesis;
     friend supra_framework::automation_registry;
     friend supra_framework::block;
 
@@ -197,8 +196,7 @@ module supra_framework::automation_registry_state {
     }
 
     /// Retrieves the details of a automation task entry by its ID.
-    /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
-    /// and the second element contains the `AutomationTaskMetaData` details.
+    /// Error will be returned if entry with specified ID does not exist.
     public (friend) fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
         let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
         assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -1,0 +1,226 @@
+/// Supra Automation Registry State
+///
+/// This contract is part of the Supra Framework and is designed to manage automated task entries
+module supra_framework::automation_registry_state {
+
+    use std::signer;
+    use std::vector;
+    use supra_framework::event;
+
+    use supra_std::enumerable_map::{Self, EnumerableMap};
+
+    use supra_framework::system_addresses;
+    use supra_framework::timestamp;
+
+    friend supra_framework::genesis;
+    friend supra_framework::automation_registry;
+    friend supra_framework::block;
+
+    /// Registry Id not found
+    const EREGITRY_NOT_FOUND: u64 = 1;
+    /// Gas amount does not go beyond upper cap limit
+    const EGAS_AMOUNT_UPPER: u64 = 2;
+    /// Automation task not found
+    const EAUTOMATION_TASK_NOT_EXIST: u64 = 3;
+    /// Unauthorized access: the caller is not the owner of the task
+    const EUNAUTHORIZED_TASK_OWNER: u64 = 4;
+
+    /// It tracks entries both pending and completed, organized by unique indices.
+    struct AutomationRegistryState has key, store {
+        /// A collection of automation task entries that are active state.
+        tasks: EnumerableMap<u64, AutomationTaskMetaData>,
+        current_index: u64,
+        gas_committed_for_next_epoch: u64,
+        automation_gas_limit: u64,
+    }
+
+    #[event]
+    /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
+    struct AutomationTaskMetaData has copy, store, drop {
+        /// Automation task index in registry
+        id: u64,
+        /// The address of the task owner.
+        owner: address,
+        /// The function signature associated with the registry entry.
+        payload_tx: vector<u8>,
+        /// Expiry of the task, represented in a timestamp in second.
+        expiry_time: u64,
+        /// The transaction hash of the request transaction.
+        tx_hash: vector<u8>,
+        /// Max gas amount of automation task
+        max_gas_amount: u64,
+        /// Maximum gas price cap for the task
+        gas_price_cap: u64,
+        /// Registration epoch number
+        registration_epoch: u64,
+        /// Registration epoch time
+        registration_time: u64,
+        /// Flag indicating whether the task is active.
+        is_active: bool
+    }
+
+    #[event]
+    /// Update automation gas limit event
+    struct UpdateAutomationGasLimit has drop, store {
+        automation_gas_limit: u64
+    }
+
+    #[event]
+    /// Remove automation task registry event
+    struct RemoveAutomationTask has drop, store {
+        id: u64
+    }
+
+    public fun task_expiry_time(task: &AutomationTaskMetaData): u64 {
+        task.expiry_time
+    }
+
+    // todo : this function should call during initialzation, but since we already done genesis in that case who can access the function
+    public(friend) fun initialize(supra_framework: &signer, automation_gas_limit: u64) {
+        system_addresses::assert_supra_framework(supra_framework);
+
+        move_to(supra_framework, AutomationRegistryState {
+            tasks: enumerable_map::new_map(),
+            current_index: 0,
+            gas_committed_for_next_epoch: 0,
+            automation_gas_limit
+        })
+    }
+    public(friend) fun on_new_epoch(epoch_interval: u64) acquires AutomationRegistryState {
+        let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        let ids = enumerable_map::get_map_list(&state.tasks);
+
+        let current_time = timestamp::now_seconds();
+        let expired_task_gas = 0;
+
+        // Perform clean up and updation of state
+        vector::for_each(ids, |id| {
+            let task = enumerable_map::get_value_mut(&mut state.tasks, id);
+
+            // Tasks that are active during this new epoch but will be already expired for the next epoch
+            if (task.expiry_time <= (current_time + epoch_interval)) {
+                expired_task_gas = expired_task_gas + task.max_gas_amount;
+            };
+
+            if (task.expiry_time <= current_time) {
+                enumerable_map::remove_value(&mut state.tasks, id);
+            } else {
+                task.is_active = true;
+            }
+        });
+
+        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+        state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
+    }
+
+
+    /// Registers a new automation task entry.
+    public(friend) fun register(
+        owner: &signer,
+        payload_tx: vector<u8>,
+        expiry_time: u64,
+        max_gas_amount: u64,
+        gas_price_cap: u64,
+        registration_epoch: u64,
+        tx_hash: vector<u8>,
+    ) acquires AutomationRegistryState {
+        let registry_data = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+
+        let committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
+        assert!(committed_gas < registry_data.automation_gas_limit, EGAS_AMOUNT_UPPER);
+        registry_data.gas_committed_for_next_epoch = committed_gas;
+        let task_index = registry_data.current_index;
+
+        let automation_task_metadata = AutomationTaskMetaData {
+            id: task_index,
+            owner: signer::address_of(owner),
+            payload_tx,
+            expiry_time,
+            max_gas_amount,
+            gas_price_cap,
+            is_active: false,
+            registration_epoch,
+            registration_time: timestamp::now_seconds(),
+            tx_hash,
+        };
+
+        enumerable_map::add_value(&mut registry_data.tasks, task_index, automation_task_metadata);
+        registry_data.current_index = registry_data.current_index + 1;
+        event::emit(automation_task_metadata);
+    }
+
+    /// Remove Automatioon task entry.
+    public (friend) fun remove_task(owner: &signer, id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
+        let automation_registry = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_registry.tasks, id), EAUTOMATION_TASK_NOT_EXIST);
+
+        let automation_task_metadata = enumerable_map::get_value(&automation_registry.tasks, id);
+        assert!(automation_task_metadata.owner == signer::address_of(owner), EUNAUTHORIZED_TASK_OWNER);
+
+        enumerable_map::remove_value(&mut automation_registry.tasks, id);
+
+        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+
+        event::emit(RemoveAutomationTask { id: automation_task_metadata.id });
+        // todo : return refund amount to user
+        automation_task_metadata
+    }
+
+    /// Update Automation gas limit
+    public (friend) fun update_automation_gas_limit(
+        supra_framework: &signer,
+        automation_gas_limit: u64
+    ) acquires AutomationRegistryState {
+        system_addresses::assert_supra_framework(supra_framework);
+
+        let automation_registry = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        automation_registry.automation_gas_limit = automation_gas_limit;
+
+        event::emit(UpdateAutomationGasLimit { automation_gas_limit });
+    }
+
+    /// List all the automation task ids
+    public(friend) fun get_active_task_ids(): vector<u64> acquires AutomationRegistryState {
+        let automation_registry = borrow_global<AutomationRegistryState>(@supra_framework);
+
+        let active_task_ids = vector[];
+        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+
+        vector::for_each(ids, |id| {
+            let task = enumerable_map::get_value(&automation_registry.tasks, id);
+            if (task.is_active) {
+                vector::push_back(&mut active_task_ids, id);
+            };
+        });
+        return active_task_ids
+    }
+
+    /// Retrieves the details of a automation task entry by its ID.
+    /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
+    /// and the second element contains the `AutomationTaskMetaData` details.
+    public (friend) fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
+        let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);
+        enumerable_map::get_value(&automation_task_metadata.tasks, id)
+    }
+
+    /// Checks whether there is an active task in registry with specified input task id.
+    public fun has_active_task_with_id(id: u64): bool acquires AutomationRegistryState {
+        let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
+        if (enumerable_map::contains(&automation_task_metadata.tasks, id)) {
+            // TODO: uncomment when activation of the tasks on new epoch is enabled.
+            let value = enumerable_map::get_value(&automation_task_metadata.tasks, id);
+            value.is_active
+        } else  {
+            false
+        }
+    }
+
+    /// Returns next task index in registry
+    public (friend) fun get_next_task_index(): u64 acquires AutomationRegistryState {
+        let state = borrow_global<AutomationRegistryState>(@supra_framework);
+        state.current_index
+    }
+
+}

--- a/aptos-move/framework/supra-framework/sources/block.move
+++ b/aptos-move/framework/supra-framework/sources/block.move
@@ -6,6 +6,7 @@ module supra_framework::block {
     use std::option;
     use aptos_std::table_with_length::{Self, TableWithLength};
     use std::option::Option;
+    use supra_framework::automation_registry_state;
     use supra_framework::randomness;
 
     use supra_framework::account;
@@ -235,6 +236,7 @@ module supra_framework::block {
         randomness::on_new_block(&vm, epoch, round, option::none());
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
             reconfiguration::reconfigure();
+            automation_registry_state::on_new_epoch(epoch_interval);
         };
     }
 
@@ -264,6 +266,7 @@ module supra_framework::block {
 
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
             reconfiguration_with_dkg::try_start();
+            automation_registry_state::on_new_epoch(epoch_interval);
         };
     }
 


### PR DESCRIPTION
- split automation registry external API and internal state to avoid circular dependencies
- enabled automation-registry-state update on new epoch from block module.