### PR TITLE
[AN-Issue-1409] Handled automation-registry state update on new epoch

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -270,7 +270,6 @@ crate::gas_schedule::macros::define_gas_parameters!(
 
         [transaction_context_get_txn_hash_base: InternalGas, { 10.. => "transaction_context.get_txn_hash.base" }, 735],
         [transaction_context_get_script_hash_base: InternalGas, "transaction_context.get_script_hash.base", 735],
-        [transaction_context_get_txn_app_hash_base: InternalGas, "transaction_context.get_txn_app_hash.base", 735],
         // Based on SHA3-256's cost
         [transaction_context_generate_unique_address_base: InternalGas, { 10.. => "transaction_context.generate_unique_address.base" }, 14704],
         [transaction_context_sender_base: InternalGas, {RELEASE_V1_12.. => "transaction_context.sender.base"}, 735],

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -921,6 +921,7 @@ impl AptosVM {
                 traversal_context,
                 txn_data.sender(),
                 registration_params,
+                txn_data
             )
         })?;
 
@@ -958,6 +959,7 @@ impl AptosVM {
         traversal_context: &mut TraversalContext,
         sender: AccountAddress,
         registration_params: &RegistrationParams,
+        txn_metadata: &TransactionMetadata,
     ) -> Result<(), VMStatus> {
         // Note: Feature gating is needed here because the traversal of the dependencies could
         //       result in shallow-loading of the modules and therefore subtle changes in
@@ -972,7 +974,8 @@ impl AptosVM {
                 [(module_id.address(), module_id.name())],
             )?;
         }
-        let args = registration_params.serialized_args_with_sender(sender);
+        let args = registration_params
+            .serialized_args_with_sender_and_parent_hash(sender, txn_metadata.txn_app_hash.clone());
 
         session.execute_function_bypass_visibility(
             registration_params.module_id(),

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -173,7 +173,6 @@ impl TransactionMetadata {
             self.gas_unit_price.into(),
             self.chain_id.id(),
             payload_type_reference,
-            self.txn_app_hash.clone(),
         )
     }
 }

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -130,7 +130,7 @@ fn check_successful_registration() {
     let result = view_output.values.expect("Valid result");
     assert_eq!(result.len(), 1);
     let next_task_id = bcs::from_bytes::<u64>(&result[0]).unwrap();
-    assert_eq!(next_task_id, 2);
+    assert_eq!(next_task_id, 1);
 }
 
 #[test]

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -148,12 +148,18 @@ pub enum EntryFunctionCall {
     },
 
     /// Cancel Automation task with specified id.
-    /// Only existing task can be cancled and only by task onwer.
+    /// Only existing task, which is PENDING or ACTIVE, can be cancled and only by task onwer.
+    /// If the task is
+    ///   - active, its state is updated to be CANCELLED.
+    ///   - pending, it is removed form the list.
+    ///   - cancelled, an error is reported
+    /// Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
     AutomationRegistryCancelTask {
         id: u64,
     },
 
-    /// Update Automation gas limit
+    /// Update Automation gas limit.
+    /// If the committed gas amount for the next epoch is greater then the new gas limit, then error is reported.
     AutomationRegistryUpdateAutomationGasLimit {
         automation_gas_limit: u64,
     },
@@ -161,12 +167,6 @@ pub enum EntryFunctionCall {
     /// Update duration upper limit
     AutomationRegistryUpdateDurationUpperLimit {
         duration_upper_limit: u64,
-    },
-
-    /// Withdraw accumulated automation task fees from the resource account - access by admin
-    AutomationRegistryWithdrawAutomationTaskFees {
-        to: AccountAddress,
-        amount: u64,
     },
 
     /// Same as `publish_package` but as an entry function which can be called as a transaction. Because
@@ -1210,9 +1210,6 @@ impl EntryFunctionCall {
             AutomationRegistryUpdateDurationUpperLimit {
                 duration_upper_limit,
             } => automation_registry_update_duration_upper_limit(duration_upper_limit),
-            AutomationRegistryWithdrawAutomationTaskFees { to, amount } => {
-                automation_registry_withdraw_automation_task_fees(to, amount)
-            },
             CodePublishPackageTxn {
                 metadata_serialized,
                 code,
@@ -2150,7 +2147,12 @@ pub fn account_rotate_authentication_key_with_rotation_capability(
 }
 
 /// Cancel Automation task with specified id.
-/// Only existing task can be cancled and only by task onwer.
+/// Only existing task, which is PENDING or ACTIVE, can be cancled and only by task onwer.
+/// If the task is
+///   - active, its state is updated to be CANCELLED.
+///   - pending, it is removed form the list.
+///   - cancelled, an error is reported
+/// Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
 pub fn automation_registry_cancel_task(id: u64) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2166,7 +2168,8 @@ pub fn automation_registry_cancel_task(id: u64) -> TransactionPayload {
     ))
 }
 
-/// Update Automation gas limit
+/// Update Automation gas limit.
+/// If the committed gas amount for the next epoch is greater then the new gas limit, then error is reported.
 pub fn automation_registry_update_automation_gas_limit(
     automation_gas_limit: u64,
 ) -> TransactionPayload {
@@ -2199,25 +2202,6 @@ pub fn automation_registry_update_duration_upper_limit(
         ident_str!("update_duration_upper_limit").to_owned(),
         vec![],
         vec![bcs::to_bytes(&duration_upper_limit).unwrap()],
-    ))
-}
-
-/// Withdraw accumulated automation task fees from the resource account - access by admin
-pub fn automation_registry_withdraw_automation_task_fees(
-    to: AccountAddress,
-    amount: u64,
-) -> TransactionPayload {
-    TransactionPayload::EntryFunction(EntryFunction::new(
-        ModuleId::new(
-            AccountAddress::new([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1,
-            ]),
-            ident_str!("automation_registry").to_owned(),
-        ),
-        ident_str!("withdraw_automation_task_fees").to_owned(),
-        vec![],
-        vec![bcs::to_bytes(&to).unwrap(), bcs::to_bytes(&amount).unwrap()],
     ))
 }
 
@@ -5421,21 +5405,6 @@ mod decoder {
         }
     }
 
-    pub fn automation_registry_withdraw_automation_task_fees(
-        payload: &TransactionPayload,
-    ) -> Option<EntryFunctionCall> {
-        if let TransactionPayload::EntryFunction(script) = payload {
-            Some(
-                EntryFunctionCall::AutomationRegistryWithdrawAutomationTaskFees {
-                    to: bcs::from_bytes(script.args().get(0)?).ok()?,
-                    amount: bcs::from_bytes(script.args().get(1)?).ok()?,
-                },
-            )
-        } else {
-            None
-        }
-    }
-
     pub fn code_publish_package_txn(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::CodePublishPackageTxn {
@@ -7300,10 +7269,6 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "automation_registry_update_duration_upper_limit".to_string(),
             Box::new(decoder::automation_registry_update_duration_upper_limit),
-        );
-        map.insert(
-            "automation_registry_withdraw_automation_task_fees".to_string(),
-            Box::new(decoder::automation_registry_withdraw_automation_task_fees),
         );
         map.insert(
             "code_publish_package_txn".to_string(),

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -147,8 +147,9 @@ pub enum EntryFunctionCall {
         cap_update_table: Vec<u8>,
     },
 
-    /// Remove Automatioon task entry.
-    AutomationRegistryRemoveTask {
+    /// Cancel Automation task with specified id.
+    /// Only existing task can be cancled and only by task onwer.
+    AutomationRegistryCancelTask {
         id: u64,
     },
 
@@ -1202,7 +1203,7 @@ impl EntryFunctionCall {
                 new_public_key_bytes,
                 cap_update_table,
             ),
-            AutomationRegistryRemoveTask { id } => automation_registry_remove_task(id),
+            AutomationRegistryCancelTask { id } => automation_registry_cancel_task(id),
             AutomationRegistryUpdateAutomationGasLimit {
                 automation_gas_limit,
             } => automation_registry_update_automation_gas_limit(automation_gas_limit),
@@ -2148,8 +2149,9 @@ pub fn account_rotate_authentication_key_with_rotation_capability(
     ))
 }
 
-/// Remove Automatioon task entry.
-pub fn automation_registry_remove_task(id: u64) -> TransactionPayload {
+/// Cancel Automation task with specified id.
+/// Only existing task can be cancled and only by task onwer.
+pub fn automation_registry_cancel_task(id: u64) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
             AccountAddress::new([
@@ -2158,7 +2160,7 @@ pub fn automation_registry_remove_task(id: u64) -> TransactionPayload {
             ]),
             ident_str!("automation_registry").to_owned(),
         ),
-        ident_str!("remove_task").to_owned(),
+        ident_str!("cancel_task").to_owned(),
         vec![],
         vec![bcs::to_bytes(&id).unwrap()],
     ))
@@ -5379,11 +5381,11 @@ mod decoder {
         }
     }
 
-    pub fn automation_registry_remove_task(
+    pub fn automation_registry_cancel_task(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
-            Some(EntryFunctionCall::AutomationRegistryRemoveTask {
+            Some(EntryFunctionCall::AutomationRegistryCancelTask {
                 id: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
         } else {
@@ -7288,8 +7290,8 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
             Box::new(decoder::account_rotate_authentication_key_with_rotation_capability),
         );
         map.insert(
-            "automation_registry_remove_task".to_string(),
-            Box::new(decoder::automation_registry_remove_task),
+            "automation_registry_cancel_task".to_string(),
+            Box::new(decoder::automation_registry_cancel_task),
         );
         map.insert(
             "automation_registry_update_automation_gas_limit".to_string(),

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -149,7 +149,7 @@ pub enum EntryFunctionCall {
 
     /// Remove Automatioon task entry.
     AutomationRegistryRemoveTask {
-        registry_id: u64,
+        id: u64,
     },
 
     /// Update Automation gas limit
@@ -1202,9 +1202,7 @@ impl EntryFunctionCall {
                 new_public_key_bytes,
                 cap_update_table,
             ),
-            AutomationRegistryRemoveTask { registry_id } => {
-                automation_registry_remove_task(registry_id)
-            },
+            AutomationRegistryRemoveTask { id } => automation_registry_remove_task(id),
             AutomationRegistryUpdateAutomationGasLimit {
                 automation_gas_limit,
             } => automation_registry_update_automation_gas_limit(automation_gas_limit),
@@ -2151,7 +2149,7 @@ pub fn account_rotate_authentication_key_with_rotation_capability(
 }
 
 /// Remove Automatioon task entry.
-pub fn automation_registry_remove_task(registry_id: u64) -> TransactionPayload {
+pub fn automation_registry_remove_task(id: u64) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
             AccountAddress::new([
@@ -2162,7 +2160,7 @@ pub fn automation_registry_remove_task(registry_id: u64) -> TransactionPayload {
         ),
         ident_str!("remove_task").to_owned(),
         vec![],
-        vec![bcs::to_bytes(&registry_id).unwrap()],
+        vec![bcs::to_bytes(&id).unwrap()],
     ))
 }
 
@@ -5386,7 +5384,7 @@ mod decoder {
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::AutomationRegistryRemoveTask {
-                registry_id: bcs::from_bytes(script.args().get(0)?).ok()?,
+                id: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
         } else {
             None

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -238,31 +238,6 @@ fn native_chain_id_internal(
     }
 }
 
-/***************************************************************************************************
- * native fun get_txn_app_hash
- *
- *   gas cost: base_cost
- *
- **************************************************************************************************/
-fn native_txn_app_hash_internal(
-    context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
-    _args: VecDeque<Value>,
-) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    context.charge(TRANSACTION_CONTEXT_GET_TXN_APP_HASH_BASE)?;
-
-    let user_transaction_context_opt = get_user_transaction_context_opt_from_context(context);
-    if let Some(transaction_context) = user_transaction_context_opt {
-        Ok(smallvec![Value::vector_u8(
-            transaction_context.txn_app_hash()
-        )])
-    } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
-    }
-}
-
 fn create_option_some_value(value: Value) -> Value {
     Value::struct_(Struct::pack(vec![create_singleton_vector(value)]))
 }
@@ -431,7 +406,6 @@ pub fn make_all(
             "multisig_payload_internal",
             native_multisig_payload_internal,
         ),
-        ("txn_app_hash_internal", native_txn_app_hash_internal),
     ];
 
     builder.make_named_natives(natives)

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -21,7 +21,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `charge_automation_fee_from_user`](#0x1_automation_registry_charge_automation_fee_from_user)
 -  [Function `get_last_epoch_time_second`](#0x1_automation_registry_get_last_epoch_time_second)
 -  [Function `register`](#0x1_automation_registry_register)
--  [Function `remove_task`](#0x1_automation_registry_remove_task)
+-  [Function `cancel_task`](#0x1_automation_registry_cancel_task)
 -  [Function `refund_automation_task_fee`](#0x1_automation_registry_refund_automation_task_fee)
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
 -  [Function `get_active_task_ids`](#0x1_automation_registry_get_active_task_ids)
@@ -200,6 +200,16 @@ Update duration upper limit event
 ## Constants
 
 
+<a id="0x1_automation_registry_EINVALID_EXPIRY_TIME"></a>
+
+Invalid expiry time: it cannot be earlier than the current time
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 1;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_DEFAULT_AUTOMATION_GAS_LIMIT"></a>
 
 The default automation task gas limit
@@ -235,7 +245,7 @@ The default upper limit duration for automation task, specified in seconds (30 d
 Expiry time must be after the start of the next epoch
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 2;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 3;
 </code></pre>
 
 
@@ -245,7 +255,7 @@ Expiry time must be after the start of the next epoch
 Expiry time does not go beyond upper cap duration
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 1;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 2;
 </code></pre>
 
 
@@ -512,9 +522,11 @@ Registers a new automation task entry.
     //Well formedness check of payload_tx is done in <b>native</b> layer beforehand.
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <b>assert</b>!(expiry_time &gt; current_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
     <b>let</b> task_duration = expiry_time - current_time;
     <b>assert</b>!(task_duration &lt; registry_data.duration_upper_limit, <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>);
 
+    // Check that task is valid at least in the next epoch
     <b>let</b> epoch_interval = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <b>let</b> last_epoch_time = <a href="automation_registry.md#0x1_automation_registry_get_last_epoch_time_second">get_last_epoch_time_second</a>();
     <b>assert</b>!(expiry_time &gt; (last_epoch_time + epoch_interval), <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>);
@@ -541,14 +553,15 @@ Registers a new automation task entry.
 
 </details>
 
-<a id="0x1_automation_registry_remove_task"></a>
+<a id="0x1_automation_registry_cancel_task"></a>
 
-## Function `remove_task`
+## Function `cancel_task`
 
-Remove Automatioon task entry.
+Cancel Automation task with specified id.
+Only existing task can be cancled and only by task onwer.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64)
 </code></pre>
 
 
@@ -557,8 +570,8 @@ Remove Automatioon task entry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">automation_registry_state::remove_task</a>(owner, id);
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_cancel_task">automation_registry_state::cancel_task</a>(owner, id);
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), automation_task_metadata, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_unit_price);
 }
@@ -737,7 +750,7 @@ Get registry fee resource account address
 
 ## Function `get_gas_committed_for_next_epoch`
 
-Ge gas committed for next epoch
+Get gas committed for next epoch
 
 
 <pre><code>#[view]

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -682,8 +682,7 @@ List all the automation task ids
 ## Function `get_task_details`
 
 Retrieves the details of a automation task entry by its ID.
-Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
-and the second element contains the <code>AutomationTaskMetaData</code> details.
+Error will be returned if entry with specified ID does not exist.
 
 
 <pre><code>#[view]

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -40,7 +40,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 <b>use</b> <a href="supra_account.md#0x1_supra_account">0x1::supra_account</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
-<b>use</b> <a href="transaction_context.md#0x1_transaction_context">0x1::transaction_context</a>;
 </code></pre>
 
 
@@ -236,7 +235,7 @@ The default upper limit duration for automation task, specified in seconds (30 d
 Expiry time must be after the start of the next epoch
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 3;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 2;
 </code></pre>
 
 
@@ -246,27 +245,7 @@ Expiry time must be after the start of the next epoch
 Expiry time does not go beyond upper cap duration
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 2;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EINVALID_EXPIRY_TIME"></a>
-
-Invalid expiry time: it cannot be earlier than the current time
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 1;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EINVALID_GAS_PRICE"></a>
-
-Invalid gas price: it cannot be zero
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 4;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 1;
 </code></pre>
 
 
@@ -458,7 +437,7 @@ Update duration upper limit
 Deducts the automation fee from the user's account based on the selected expiry time.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, fee: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_unit_price: u64, task_duration: u64, registry_fee_address: <b>address</b>)
 </code></pre>
 
 
@@ -467,10 +446,10 @@ Deducts the automation fee from the user's account based on the selected expiry 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, fee: u64) {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_unit_price: u64, task_duration: u64, registry_fee_address: <b>address</b>) {
+    <b>let</b> automation_base_fee = task_duration * automation_unit_price;
     // todo : dynamic price calculation is pending
-    <b>let</b> registry_fee_address = <a href="automation_registry.md#0x1_automation_registry_get_registry_fee_address">get_registry_fee_address</a>();
-    <a href="supra_account.md#0x1_supra_account_transfer">supra_account::transfer</a>(owner, registry_fee_address, fee);
+    <a href="supra_account.md#0x1_supra_account_transfer">supra_account::transfer</a>(owner, registry_fee_address, automation_base_fee);
 }
 </code></pre>
 
@@ -511,7 +490,7 @@ Get last epoch time in second
 Registers a new automation task entry.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_register">register</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, expiry_time: u64, max_gas_amount: u64, gas_price_cap: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_register">register</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, expiry_time: u64, max_gas_amount: u64, gas_price_cap: u64, parent_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -525,30 +504,22 @@ Registers a new automation task entry.
     payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     expiry_time: u64,
     max_gas_amount: u64,
-    gas_price_cap: u64
+    gas_price_cap: u64,
+    parent_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
 
     //Well formedness check of payload_tx is done in <b>native</b> layer beforehand.
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>assert</b>!(expiry_time &gt; current_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
-
-    <b>let</b> expiry_time_duration = expiry_time - current_time;
-    <b>assert</b>!(expiry_time_duration &lt; registry_data.duration_upper_limit, <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>);
+    <b>let</b> task_duration = expiry_time - current_time;
+    <b>assert</b>!(task_duration &lt; registry_data.duration_upper_limit, <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>);
 
     <b>let</b> epoch_interval = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <b>let</b> last_epoch_time = <a href="automation_registry.md#0x1_automation_registry_get_last_epoch_time_second">get_last_epoch_time_second</a>();
     <b>assert</b>!(expiry_time &gt; (last_epoch_time + epoch_interval), <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>);
 
-
-    <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
-
-    <b>let</b> fee = expiry_time_duration * registry_data.automation_unit_price;
-    <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner, fee);
-
     <b>let</b> epoch = <a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>();
-    <b>let</b> parent_hash = <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">transaction_context::txn_app_hash</a>();
     <a href="automation_registry_state.md#0x1_automation_registry_state_register">automation_registry_state::register</a>(
         owner,
         payload_tx,
@@ -557,6 +528,12 @@ Registers a new automation task entry.
         gas_price_cap,
         epoch,
         parent_hash);
+
+    <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(
+        owner,
+        registry_data.automation_unit_price,
+        task_duration,
+        registry_data.registry_fee_address);
 }
 </code></pre>
 
@@ -581,8 +558,8 @@ Remove Automatioon task entry.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">automation_registry_state::remove_task</a>(owner, id);
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), automation_task_metadata, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_unit_price);
 }
 </code></pre>
@@ -773,9 +750,8 @@ Ge gas committed for next epoch
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_gas_committed_for_next_epoch">get_gas_committed_for_next_epoch</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    automation_task_metadata.gas_committed_for_next_epoch
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_gas_committed_for_next_epoch">get_gas_committed_for_next_epoch</a>(): u64 {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_gas_committed_for_next_epoch">automation_registry_state::get_gas_committed_for_next_epoch</a>()
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -325,7 +325,7 @@ Registry resource creation seed
 Withdraw accumulated automation task fees from the resource account - access by admin
 
 
-<pre><code>entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
 </code></pre>
 
 
@@ -334,7 +334,7 @@ Withdraw accumulated automation task fees from the resource account - access by 
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <b>to</b>: <b>address</b>,
     amount: u64
@@ -382,7 +382,8 @@ Transfers the specified fee amount from the resource account to the target accou
 
 ## Function `update_automation_gas_limit`
 
-Update Automation gas limit
+Update Automation gas limit.
+If the committed gas amount for the next epoch is greater then the new gas limit, then error is reported.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_automation_gas_limit">update_automation_gas_limit</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64)
@@ -519,7 +520,7 @@ Registers a new automation task entry.
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
 
-    //Well formedness check of payload_tx is done in <b>native</b> layer beforehand.
+    //Well-formedness check of payload_tx is done in <b>native</b> layer beforehand.
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
     <b>assert</b>!(expiry_time &gt; current_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
@@ -558,7 +559,12 @@ Registers a new automation task entry.
 ## Function `cancel_task`
 
 Cancel Automation task with specified id.
-Only existing task can be cancled and only by task onwer.
+Only existing task, which is PENDING or ACTIVE, can be cancled and only by task onwer.
+If the task is
+- active, its state is updated to be CANCELLED.
+- pending, it is removed form the list.
+- cancelled, an error is reported
+Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64)
@@ -645,7 +651,9 @@ Returns next task index in registry
 
 ## Function `get_active_task_ids`
 
-List all the automation task ids
+List all active automation task ids for the current epoch.
+Note that the tasks with CANCELLED state are still considered active for the current epoch,
+as cancellation takes effect in the next epoch only.
 
 
 <pre><code>#[view]

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -9,15 +9,11 @@ This contract is part of the Supra Framework and is designed to manage automated
 
 
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
--  [Struct `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
 -  [Struct `FeeWithdrawnAdmin`](#0x1_automation_registry_FeeWithdrawnAdmin)
 -  [Struct `RefundFeeUser`](#0x1_automation_registry_RefundFeeUser)
--  [Struct `UpdateAutomationGasLimit`](#0x1_automation_registry_UpdateAutomationGasLimit)
 -  [Struct `UpdateDurationUpperLimit`](#0x1_automation_registry_UpdateDurationUpperLimit)
--  [Struct `RemoveAutomationTask`](#0x1_automation_registry_RemoveAutomationTask)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
--  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `update_automation_gas_limit`](#0x1_automation_registry_update_automation_gas_limit)
@@ -30,13 +26,14 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
 -  [Function `get_active_task_ids`](#0x1_automation_registry_get_active_task_ids)
 -  [Function `get_task_details`](#0x1_automation_registry_get_task_details)
+-  [Function `has_active_task_with_id`](#0x1_automation_registry_has_active_task_with_id)
 -  [Function `get_registry_fee_address`](#0x1_automation_registry_get_registry_fee_address)
 -  [Function `get_gas_committed_for_next_epoch`](#0x1_automation_registry_get_gas_committed_for_next_epoch)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="automation_registry_state.md#0x1_automation_registry_state">0x1::automation_registry_state</a>;
 <b>use</b> <a href="block.md#0x1_block">0x1::block</a>;
-<b>use</b> <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map">0x1::enumerable_map</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
@@ -44,7 +41,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
 <b>use</b> <a href="transaction_context.md#0x1_transaction_context">0x1::transaction_context</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -66,18 +62,6 @@ It tracks entries both pending and completed, organized by unique indices.
 
 
 <dl>
-<dt>
-<code>current_index: u64</code>
-</dt>
-<dd>
- The current unique index counter for registered tasks. This value increments as new tasks are added.
-</dd>
-<dt>
-<code>automation_gas_limit: u64</code>
-</dt>
-<dd>
- Automation task gas limit.
-</dd>
 <dt>
 <code>duration_upper_limit: u64</code>
 </dt>
@@ -107,95 +91,6 @@ It tracks entries both pending and completed, organized by unique indices.
 </dt>
 <dd>
  Resource account signature capability
-</dd>
-<dt>
-<code>tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_EnumerableMap">enumerable_map::EnumerableMap</a>&lt;u64, <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>&gt;</code>
-</dt>
-<dd>
- A collection of automation task entries that are active state.
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_AutomationTaskMetaData"></a>
-
-## Struct `AutomationTaskMetaData`
-
-<code><a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a></code> represents a single automation task item, containing metadata.
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: u64</code>
-</dt>
-<dd>
- Automation task index in registry
-</dd>
-<dt>
-<code>owner: <b>address</b></code>
-</dt>
-<dd>
- The address of the task owner.
-</dd>
-<dt>
-<code>payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
-</dt>
-<dd>
- The function signature associated with the registry entry.
-</dd>
-<dt>
-<code>expiry_time: u64</code>
-</dt>
-<dd>
- Expiry of the task, represented in a timestamp in second.
-</dd>
-<dt>
-<code>tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
-</dt>
-<dd>
- The transaction hash of the request transaction.
-</dd>
-<dt>
-<code>max_gas_amount: u64</code>
-</dt>
-<dd>
- Max gas amount of automation task
-</dd>
-<dt>
-<code>gas_price_cap: u64</code>
-</dt>
-<dd>
- Maximum gas price cap for the task
-</dd>
-<dt>
-<code>registration_epoch: u64</code>
-</dt>
-<dd>
- Registration epoch number
-</dd>
-<dt>
-<code>registration_time: u64</code>
-</dt>
-<dd>
- Registration epoch time
-</dd>
-<dt>
-<code>is_active: bool</code>
-</dt>
-<dd>
- Flag indicating whether the task is active.
 </dd>
 </dl>
 
@@ -272,35 +167,6 @@ Withdraw user's registration fee event
 
 </details>
 
-<a id="0x1_automation_registry_UpdateAutomationGasLimit"></a>
-
-## Struct `UpdateAutomationGasLimit`
-
-Update automation gas limit event
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>automation_gas_limit: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x1_automation_registry_UpdateDurationUpperLimit"></a>
 
 ## Struct `UpdateDurationUpperLimit`
@@ -321,35 +187,6 @@ Update duration upper limit event
 <dl>
 <dt>
 <code>duration_upper_limit: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_RemoveAutomationTask"></a>
-
-## Struct `RemoveAutomationTask`
-
-Remove automation task registry event
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_RemoveAutomationTask">RemoveAutomationTask</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: u64</code>
 </dt>
 <dd>
 
@@ -394,22 +231,12 @@ The default upper limit duration for automation task, specified in seconds (30 d
 
 
 
-<a id="0x1_automation_registry_EAUTOMATION_TASK_NOT_EXIST"></a>
-
-Automation task not found
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 7;
-</code></pre>
-
-
-
 <a id="0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH"></a>
 
 Expiry time must be after the start of the next epoch
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 4;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 3;
 </code></pre>
 
 
@@ -419,17 +246,7 @@ Expiry time must be after the start of the next epoch
 Expiry time does not go beyond upper cap duration
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 3;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EGAS_AMOUNT_UPPER"></a>
-
-Gas amount does not go beyond upper cap limit
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 5;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>: u64 = 2;
 </code></pre>
 
 
@@ -439,7 +256,7 @@ Gas amount does not go beyond upper cap limit
 Invalid expiry time: it cannot be earlier than the current time
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 2;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 1;
 </code></pre>
 
 
@@ -449,27 +266,7 @@ Invalid expiry time: it cannot be earlier than the current time
 Invalid gas price: it cannot be zero
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 6;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EREGITRY_NOT_FOUND"></a>
-
-Registry Id not found
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>: u64 = 1;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER"></a>
-
-Unauthorized access: the caller is not the owner of the task
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 8;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 4;
 </code></pre>
 
 
@@ -511,6 +308,7 @@ Registry resource creation seed
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <a href="automation_registry_state.md#0x1_automation_registry_state_initialize">automation_registry_state::initialize</a>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_DEFAULT_AUTOMATION_GAS_LIMIT">DEFAULT_AUTOMATION_GAS_LIMIT</a>);
 
     <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(
         supra_framework,
@@ -518,65 +316,12 @@ Registry resource creation seed
     );
 
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-        current_index: 0,
-        automation_gas_limit: <a href="automation_registry.md#0x1_automation_registry_DEFAULT_AUTOMATION_GAS_LIMIT">DEFAULT_AUTOMATION_GAS_LIMIT</a>,
         duration_upper_limit: <a href="automation_registry.md#0x1_automation_registry_DEFAULT_DURATION_UPPER_LIMIT">DEFAULT_DURATION_UPPER_LIMIT</a>,
         gas_committed_for_next_epoch: 0,
         automation_unit_price: <a href="automation_registry.md#0x1_automation_registry_DEFAULT_AUTOMATION_UNIT_PRICE">DEFAULT_AUTOMATION_UNIT_PRICE</a>,
         registry_fee_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&registry_fee_resource_signer),
         registry_fee_address_signer_cap,
-        tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
     })
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_on_new_epoch"></a>
-
-## Function `on_new_epoch`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> epoch_interval = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
-    <b>let</b> expired_task_gas = 0;
-
-    // Perform clean up and updation of state
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
-
-        // Tasks that are active during this new epoch but will be already expired for the next epoch
-        <b>if</b> (task.expiry_time &lt; (current_time + epoch_interval)) {
-            expired_task_gas = expired_task_gas + task.max_gas_amount;
-        };
-
-        <b>if</b> (task.expiry_time &lt;= current_time) {
-            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
-        } <b>else</b> <b>if</b> (!task.is_active && task.expiry_time &gt; current_time) {
-            task.is_active = <b>true</b>;
-        }
-    });
-
-    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - expired_task_gas;
 }
 </code></pre>
 
@@ -663,13 +408,9 @@ Update Automation gas limit
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_automation_gas_limit">update_automation_gas_limit</a>(
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     automation_gas_limit: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_gas_limit = automation_gas_limit;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> { automation_gas_limit });
+    <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">automation_registry_state::update_automation_gas_limit</a>(supra_framework, automation_gas_limit)
 }
 </code></pre>
 
@@ -788,7 +529,7 @@ Registers a new automation task entry.
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
 
-    // todo : well formedness check of payload_tx
+    //Well formedness check of payload_tx is done in <b>native</b> layer beforehand.
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
     <b>assert</b>!(expiry_time &gt; current_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
@@ -800,32 +541,22 @@ Registers a new automation task entry.
     <b>let</b> last_epoch_time = <a href="automation_registry.md#0x1_automation_registry_get_last_epoch_time_second">get_last_epoch_time_second</a>();
     <b>assert</b>!(expiry_time &gt; (last_epoch_time + epoch_interval), <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>);
 
-    registry_data.gas_committed_for_next_epoch = registry_data.gas_committed_for_next_epoch + max_gas_amount;
-    <b>assert</b>!(registry_data.gas_committed_for_next_epoch &lt; registry_data.automation_gas_limit, <a href="automation_registry.md#0x1_automation_registry_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
 
     <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
 
     <b>let</b> fee = expiry_time_duration * registry_data.automation_unit_price;
     <a href="automation_registry.md#0x1_automation_registry_charge_automation_fee_from_user">charge_automation_fee_from_user</a>(owner, fee);
 
-    registry_data.current_index = registry_data.current_index + 1;
-
-    <b>let</b> automation_task_metadata = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> {
-        id: registry_data.current_index,
-        owner: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner),
+    <b>let</b> epoch = <a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>();
+    <b>let</b> parent_hash = <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">transaction_context::txn_app_hash</a>();
+    <a href="automation_registry_state.md#0x1_automation_registry_state_register">automation_registry_state::register</a>(
+        owner,
         payload_tx,
         expiry_time,
         max_gas_amount,
         gas_price_cap,
-        is_active: <b>false</b>,
-        registration_epoch: <a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>(),
-        registration_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
-        tx_hash: <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">transaction_context::txn_app_hash</a>()
-    };
-
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> registry_data.tasks, registry_data.current_index, automation_task_metadata);
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
+        epoch,
+        parent_hash);
 }
 </code></pre>
 
@@ -840,7 +571,7 @@ Registers a new automation task entry.
 Remove Automatioon task entry.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, registry_id: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64)
 </code></pre>
 
 
@@ -849,24 +580,10 @@ Remove Automatioon task entry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, registry_id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> user_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
-
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, registry_id), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
-
-    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, registry_id);
-    <b>assert</b>!(automation_task_metadata.owner == user_addr, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
-
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, registry_id);
-
-    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
-
-    // Calculate refund fee and transfer it <b>to</b> user
-    <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(user_addr, automation_task_metadata, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_unit_price);
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemoveAutomationTask">RemoveAutomationTask</a> { id: automation_task_metadata.id });
+    <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">automation_registry_state::remove_task</a>(owner, id);
+    <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), automation_task_metadata, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_unit_price);
 }
 </code></pre>
 
@@ -881,7 +598,7 @@ Remove Automatioon task entry.
 Refunds the automation task fee to the user who has removed their task registration from the list.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(user: <b>address</b>, automation_task_metadata: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, automation_unit_price: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(user: <b>address</b>, automation_task_metadata: <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>, automation_unit_price: u64)
 </code></pre>
 
 
@@ -892,11 +609,11 @@ Refunds the automation task fee to the user who has removed their task registrat
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_automation_task_fee">refund_automation_task_fee</a>(
     user: <b>address</b>,
-    automation_task_metadata: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a>,
+    automation_task_metadata: AutomationTaskMetaData,
     automation_unit_price: u64,
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> expiry_time_duration = automation_task_metadata.expiry_time - current_time;
+    <b>let</b> expiry_time_duration = <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">automation_registry_state::task_expiry_time</a>(&automation_task_metadata) - current_time;
 
     <b>let</b> refund_amount = expiry_time_duration * automation_unit_price;
     <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(user, refund_amount);
@@ -925,9 +642,8 @@ Returns next task index in registry
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_next_task_index">get_next_task_index</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index + 1
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_next_task_index">get_next_task_index</a>(): u64 {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">automation_registry_state::get_next_task_index</a>()
 }
 </code></pre>
 
@@ -952,19 +668,8 @@ List all the automation task ids
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-
-    <b>let</b> active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
-        <b>if</b> (task.is_active) {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
-        };
-    });
-    <b>return</b> active_task_ids
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">automation_registry_state::get_active_task_ids</a>()
 }
 </code></pre>
 
@@ -978,11 +683,11 @@ List all the automation task ids
 
 Retrieves the details of a automation task entry by its ID.
 Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
-and the second element contains the <code><a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a></code> details.
+and the second element contains the <code>AutomationTaskMetaData</code> details.
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
 </code></pre>
 
 
@@ -991,10 +696,34 @@ and the second element contains the <code><a href="automation_registry.md#0x1_au
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry.md#0x1_automation_registry_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>);
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details">get_task_details</a>(id: u64): AutomationTaskMetaData {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">automation_registry_state::get_task_details</a>(id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_has_active_task_with_id"></a>
+
+## Function `has_active_task_with_id`
+
+Checks whether there is an active task in registry with specified input task id.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool {
+    <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">automation_registry_state::has_active_task_with_id</a>(id)
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -23,6 +23,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `get_task_details`](#0x1_automation_registry_state_get_task_details)
 -  [Function `has_active_task_with_id`](#0x1_automation_registry_state_has_active_task_with_id)
 -  [Function `get_next_task_index`](#0x1_automation_registry_state_get_next_task_index)
+-  [Function `get_gas_committed_for_next_epoch`](#0x1_automation_registry_state_get_gas_committed_for_next_epoch)
 
 
 <pre><code><b>use</b> <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map">0x1::enumerable_map</a>;
@@ -232,7 +233,7 @@ Remove automation task registry event
 Automation task not found
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 3;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 6;
 </code></pre>
 
 
@@ -242,7 +243,7 @@ Automation task not found
 Gas amount does not go beyond upper cap limit
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 2;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 5;
 </code></pre>
 
 
@@ -253,17 +254,69 @@ Upon new epoch entry failed to propertly calculated committed gas for the next e
 It is greater than current epoch committed gas.
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>: u64 = 5;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>: u64 = 8;
 </code></pre>
 
 
 
-<a id="0x1_automation_registry_state_EREGITRY_NOT_FOUND"></a>
+<a id="0x1_automation_registry_state_EINVALID_EXPIRY_TIME"></a>
 
-Registry Id not found
+Invalid expiry time: it cannot be earlier than the current time
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>: u64 = 1;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EINVALID_GAS_PRICE"></a>
+
+Invalid gas price: it cannot be zero
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EINVALID_MAX_GAS_AMOUNT"></a>
+
+Invalid max gas amount for automated task: it cannot be zero
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EINVALID_PAYLOAD"></a>
+
+Transactoin hash that registring current task is invalid. Lenght should be 32.
+It is greater than current epoch committed gas.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_PAYLOAD">EINVALID_PAYLOAD</a>: u64 = 10;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EINVALID_TXN_HASH"></a>
+
+Transactoin hash that registring current task is invalid. Lenght should be 32.
+It is greater than current epoch committed gas.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>: u64 = 9;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_ETASK_NOT_FOUND"></a>
+
+Task with provided Id not found
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_ETASK_NOT_FOUND">ETASK_NOT_FOUND</a>: u64 = 4;
 </code></pre>
 
 
@@ -273,7 +326,7 @@ Registry Id not found
 Unauthorized access: the caller is not the owner of the task
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 4;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 7;
 </code></pre>
 
 
@@ -284,6 +337,16 @@ Conversion factor between microseconds and second
 
 
 <pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_MICROSECS_CONVERSION_FACTOR">MICROSECS_CONVERSION_FACTOR</a>: u64 = 1000000;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_TXN_HASH_LENGTH"></a>
+
+The lenght of the transaction hash.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_TXN_HASH_LENGTH">TXN_HASH_LENGTH</a>: u64 = 32;
 </code></pre>
 
 
@@ -418,6 +481,13 @@ Registers a new automation task entry.
     tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>let</b> registration_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+
+    <b>assert</b>!(expiry_time &gt; registration_time, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
+    <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
+    <b>assert</b>!(max_gas_amount &gt; 0, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>);
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&tx_hash) == <a href="automation_registry_state.md#0x1_automation_registry_state_TXN_HASH_LENGTH">TXN_HASH_LENGTH</a>, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>);
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&payload_tx), <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_PAYLOAD">EINVALID_PAYLOAD</a>);
 
     <b>let</b> committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
     <b>assert</b>!(committed_gas &lt; registry_data.automation_gas_limit, <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
@@ -433,7 +503,7 @@ Registers a new automation task entry.
         gas_price_cap,
         is_active: <b>false</b>,
         registration_epoch,
-        registration_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+        registration_time,
         tx_hash,
     };
 
@@ -464,16 +534,16 @@ Remove Automatioon task entry.
 
 
 <pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
+    <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&state.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
 
-    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&state.tasks, id);
     <b>assert</b>!(automation_task_metadata.owner == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
 
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
 
     // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+    state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> { id: automation_task_metadata.id });
     // todo : <b>return</b> refund amount <b>to</b> user
@@ -507,8 +577,8 @@ Update Automation gas limit
 ) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_gas_limit = automation_gas_limit;
+    <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    state.automation_gas_limit = automation_gas_limit;
 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> { automation_gas_limit });
 }
@@ -535,13 +605,13 @@ List all the automation task ids
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>let</b> state = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
 
     <b>let</b> active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&state.tasks);
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&state.tasks, id);
         <b>if</b> (task.is_active) {
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
         };
@@ -573,7 +643,7 @@ Error will be returned if entry with specified ID does not exist.
 
 <pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_ETASK_NOT_FOUND">ETASK_NOT_FOUND</a>);
     <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id)
 }
 </code></pre>
@@ -633,6 +703,32 @@ Returns next task index in registry
 <pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">get_next_task_index</a>(): u64 <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> state = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
     state.current_index
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_gas_committed_for_next_epoch"></a>
+
+## Function `get_gas_committed_for_next_epoch`
+
+Ge gas committed for next epoch
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_gas_committed_for_next_epoch">get_gas_committed_for_next_epoch</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_gas_committed_for_next_epoch">get_gas_committed_for_next_epoch</a>(): u64 <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> state = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    state.gas_committed_for_next_epoch
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -536,8 +536,7 @@ List all the automation task ids
 ## Function `get_task_details`
 
 Retrieves the details of a automation task entry by its ID.
-Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
-and the second element contains the <code><a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a></code> details.
+Error will be returned if entry with specified ID does not exist.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -11,13 +11,13 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `AutomationRegistryState`](#0x1_automation_registry_state_AutomationRegistryState)
 -  [Struct `AutomationTaskMetaData`](#0x1_automation_registry_state_AutomationTaskMetaData)
 -  [Struct `UpdateAutomationGasLimit`](#0x1_automation_registry_state_UpdateAutomationGasLimit)
--  [Struct `RemoveAutomationTask`](#0x1_automation_registry_state_RemoveAutomationTask)
+-  [Struct `CanclledAutomationTask`](#0x1_automation_registry_state_CanclledAutomationTask)
 -  [Constants](#@Constants_0)
 -  [Function `task_expiry_time`](#0x1_automation_registry_state_task_expiry_time)
 -  [Function `initialize`](#0x1_automation_registry_state_initialize)
 -  [Function `on_new_epoch`](#0x1_automation_registry_state_on_new_epoch)
 -  [Function `register`](#0x1_automation_registry_state_register)
--  [Function `remove_task`](#0x1_automation_registry_state_remove_task)
+-  [Function `cancel_task`](#0x1_automation_registry_state_cancel_task)
 -  [Function `update_automation_gas_limit`](#0x1_automation_registry_state_update_automation_gas_limit)
 -  [Function `get_active_task_ids`](#0x1_automation_registry_state_get_active_task_ids)
 -  [Function `get_task_details`](#0x1_automation_registry_state_get_task_details)
@@ -155,10 +155,10 @@ It tracks entries both pending and completed, organized by unique indices.
  Registration epoch time
 </dd>
 <dt>
-<code>is_active: bool</code>
+<code>state: u8</code>
 </dt>
 <dd>
- Flag indicating whether the task is active.
+ Flag indicating whether the task is active, canclled or pending.
 </dd>
 </dl>
 
@@ -194,15 +194,15 @@ Update automation gas limit event
 
 </details>
 
-<a id="0x1_automation_registry_state_RemoveAutomationTask"></a>
+<a id="0x1_automation_registry_state_CanclledAutomationTask"></a>
 
-## Struct `RemoveAutomationTask`
+## Struct `CanclledAutomationTask`
 
 Remove automation task registry event
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> <b>has</b> drop, store
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_CanclledAutomationTask">CanclledAutomationTask</a> <b>has</b> drop, store
 </code></pre>
 
 
@@ -228,12 +228,30 @@ Remove automation task registry event
 ## Constants
 
 
-<a id="0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST"></a>
-
-Automation task not found
+<a id="0x1_automation_registry_state_CANCELLED"></a>
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 6;
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>: u8 = 2;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_ACTIVE"></a>
+
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_ACTIVE">ACTIVE</a>: u8 = 1;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EAUTOMATION_TASK_NOT_FOUND"></a>
+
+Task with provided Id not found
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>: u64 = 4;
 </code></pre>
 
 
@@ -248,13 +266,23 @@ Gas amount does not go beyond upper cap limit
 
 
 
+<a id="0x1_automation_registry_state_EINVALID_CANCELLATION"></a>
+
+Trying to cancel a task which is already cancelled.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_CANCELLATION">EINVALID_CANCELLATION</a>: u64 = 10;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION"></a>
 
 Upon new epoch entry failed to propertly calculated committed gas for the next epoch.
 It is greater than current epoch committed gas.
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>: u64 = 8;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>: u64 = 7;
 </code></pre>
 
 
@@ -289,34 +317,22 @@ Invalid max gas amount for automated task: it cannot be zero
 
 
 
-<a id="0x1_automation_registry_state_EINVALID_PAYLOAD"></a>
-
-Transactoin hash that registring current task is invalid. Lenght should be 32.
-It is greater than current epoch committed gas.
-
-
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_PAYLOAD">EINVALID_PAYLOAD</a>: u64 = 10;
-</code></pre>
-
-
-
 <a id="0x1_automation_registry_state_EINVALID_TXN_HASH"></a>
 
 Transactoin hash that registring current task is invalid. Lenght should be 32.
-It is greater than current epoch committed gas.
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>: u64 = 9;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>: u64 = 8;
 </code></pre>
 
 
 
-<a id="0x1_automation_registry_state_ETASK_NOT_FOUND"></a>
+<a id="0x1_automation_registry_state_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT"></a>
 
-Task with provided Id not found
+Current committed gas amount is greater than the automation gas limit.
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_ETASK_NOT_FOUND">ETASK_NOT_FOUND</a>: u64 = 4;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT">EUNACCEPTABLE_AUTOMATION_GAS_LIMIT</a>: u64 = 9;
 </code></pre>
 
 
@@ -326,7 +342,7 @@ Task with provided Id not found
 Unauthorized access: the caller is not the owner of the task
 
 
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 7;
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 6;
 </code></pre>
 
 
@@ -337,6 +353,16 @@ Conversion factor between microseconds and second
 
 
 <pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_MICROSECS_CONVERSION_FACTOR">MICROSECS_CONVERSION_FACTOR</a>: u64 = 1000000;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_PENDING"></a>
+
+Constants describing task state.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>: u8 = 0;
 </code></pre>
 
 
@@ -427,27 +453,26 @@ The lenght of the transaction hash.
 
     <b>let</b> epoch_interval_secs = epoch_interval_micro / <a href="automation_registry_state.md#0x1_automation_registry_state_MICROSECS_CONVERSION_FACTOR">MICROSECS_CONVERSION_FACTOR</a>;
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> expired_task_gas = 0;
+    <b>let</b> gas_committed_for_next_epoch = 0;
 
     // Perform clean up and updation of state
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
         <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> state.tasks, id);
 
-        // Tasks that are active during this new epoch but will be already expired for the next epoch
-        <b>if</b> (task.expiry_time &lt;= (current_time + epoch_interval_secs)) {
-            expired_task_gas = expired_task_gas + task.max_gas_amount;
+        // Tasks that are active during next epoch and are not cancled
+        <b>if</b> (task.state != <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a> && task.expiry_time &gt; (current_time + epoch_interval_secs) ) {
+            gas_committed_for_next_epoch = gas_committed_for_next_epoch + task.max_gas_amount;
         };
 
-        <b>if</b> (task.expiry_time &lt;= current_time) {
+        // Drop or activate task
+        <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>) {
             <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
         } <b>else</b> {
-            task.is_active = <b>true</b>;
+            task.state = <a href="automation_registry_state.md#0x1_automation_registry_state_ACTIVE">ACTIVE</a>;
         }
     });
-    <b>assert</b>!(expired_task_gas &lt;= state.gas_committed_for_next_epoch, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>);
 
-    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-    state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
+    state.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
 }
 </code></pre>
 
@@ -487,7 +512,6 @@ Registers a new automation task entry.
     <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
     <b>assert</b>!(max_gas_amount &gt; 0, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&tx_hash) == <a href="automation_registry_state.md#0x1_automation_registry_state_TXN_HASH_LENGTH">TXN_HASH_LENGTH</a>, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>);
-    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&payload_tx), <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_PAYLOAD">EINVALID_PAYLOAD</a>);
 
     <b>let</b> committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
     <b>assert</b>!(committed_gas &lt; registry_data.automation_gas_limit, <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
@@ -501,7 +525,7 @@ Registers a new automation task entry.
         expiry_time,
         max_gas_amount,
         gas_price_cap,
-        is_active: <b>false</b>,
+        state: <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>,
         registration_epoch,
         registration_time,
         tx_hash,
@@ -517,14 +541,17 @@ Registers a new automation task entry.
 
 </details>
 
-<a id="0x1_automation_registry_state_remove_task"></a>
+<a id="0x1_automation_registry_state_cancel_task"></a>
 
-## Function `remove_task`
+## Function `cancel_task`
 
-Remove Automatioon task entry.
+Cancel Automation task with specified id.
+If the task was active its state is updated to be CANCELLED. Otherwise task is removed form the list.
+Committed gas-limit is updated accordingly.
+Only existing task can be cancled and only by task onwer.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_cancel_task">cancel_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
 </code></pre>
 
 
@@ -533,20 +560,24 @@ Remove Automatioon task entry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_cancel_task">cancel_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&state.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&state.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
 
     <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&state.tasks, id);
     <b>assert</b>!(automation_task_metadata.owner == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
+    <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_CANCELLATION">EINVALID_CANCELLATION</a>);
+    <b>if</b> (automation_task_metadata.state == <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>) {
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
+    } <b>else</b> <b>if</b> (automation_task_metadata.state == <a href="automation_registry_state.md#0x1_automation_registry_state_ACTIVE">ACTIVE</a>) {
+        automation_task_metadata.state = <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>;
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_update_value">enumerable_map::update_value</a>(&<b>mut</b> state.tasks, id, automation_task_metadata);
+    };
 
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
-
-    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+    // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
     state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> { id: automation_task_metadata.id });
-    // todo : <b>return</b> refund amount <b>to</b> user
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_CanclledAutomationTask">CanclledAutomationTask</a> { id: automation_task_metadata.id });
     automation_task_metadata
 }
 </code></pre>
@@ -578,6 +609,8 @@ Update Automation gas limit
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
     <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>assert</b>!(state.gas_committed_for_next_epoch &lt; automation_gas_limit, <a href="automation_registry_state.md#0x1_automation_registry_state_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT">EUNACCEPTABLE_AUTOMATION_GAS_LIMIT</a>);
+
     state.automation_gas_limit = automation_gas_limit;
 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> { automation_gas_limit });
@@ -612,7 +645,7 @@ List all the automation task ids
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
         <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&state.tasks, id);
-        <b>if</b> (task.is_active) {
+        <b>if</b> (task.state != <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>) {
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
         };
     });
@@ -643,7 +676,7 @@ Error will be returned if entry with specified ID does not exist.
 
 <pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_ETASK_NOT_FOUND">ETASK_NOT_FOUND</a>);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
     <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id)
 }
 </code></pre>
@@ -659,7 +692,7 @@ Error will be returned if entry with specified ID does not exist.
 Checks whether there is an active task in registry with specified input task id.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool
 </code></pre>
 
 
@@ -668,12 +701,11 @@ Checks whether there is an active task in registry with specified input task id.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
     <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id)) {
-        // TODO: uncomment when activation of the tasks on new epoch is enabled.
         <b>let</b> value = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id);
-        value.is_active
+        value.state != <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>
     } <b>else</b>  {
         <b>false</b>
     }

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -246,6 +246,16 @@ Remove automation task registry event
 
 
 
+<a id="0x1_automation_registry_state_EALREADY_CANCELLED"></a>
+
+Task is already cancelled.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EALREADY_CANCELLED">EALREADY_CANCELLED</a>: u64 = 10;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_state_EAUTOMATION_TASK_NOT_FOUND"></a>
 
 Task with provided Id not found
@@ -262,16 +272,6 @@ Gas amount does not go beyond upper cap limit
 
 
 <pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 5;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_state_EINVALID_CANCELLATION"></a>
-
-Trying to cancel a task which is already cancelled.
-
-
-<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_CANCELLATION">EINVALID_CANCELLATION</a>: u64 = 10;
 </code></pre>
 
 
@@ -460,11 +460,12 @@ The lenght of the transaction hash.
         <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> state.tasks, id);
 
         // Tasks that are active during next epoch and are not cancled
+        // current_time shows the start time of the current new epoch.
         <b>if</b> (task.state != <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a> && task.expiry_time &gt; (current_time + epoch_interval_secs) ) {
             gas_committed_for_next_epoch = gas_committed_for_next_epoch + task.max_gas_amount;
         };
 
-        // Drop or activate task
+        // Drop or activate task for this current epoch.
         <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>) {
             <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
         } <b>else</b> {
@@ -546,9 +547,12 @@ Registers a new automation task entry.
 ## Function `cancel_task`
 
 Cancel Automation task with specified id.
-If the task was active its state is updated to be CANCELLED. Otherwise task is removed form the list.
-Committed gas-limit is updated accordingly.
-Only existing task can be cancled and only by task onwer.
+Only existing task, which is PENDING or ACTIVE, can be cancled and only by task onwer.
+If the task is
+- active, its state is updated to be CANCELLED.
+- pending, it is removed form the list.
+- cancelled, an error is reported
+Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_cancel_task">cancel_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
@@ -566,7 +570,7 @@ Only existing task can be cancled and only by task onwer.
 
     <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&state.tasks, id);
     <b>assert</b>!(automation_task_metadata.owner == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
-    <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_CANCELLATION">EINVALID_CANCELLATION</a>);
+    <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry_state.md#0x1_automation_registry_state_CANCELLED">CANCELLED</a>, <a href="automation_registry_state.md#0x1_automation_registry_state_EALREADY_CANCELLED">EALREADY_CANCELLED</a>);
     <b>if</b> (automation_task_metadata.state == <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>) {
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
     } <b>else</b> <b>if</b> (automation_task_metadata.state == <a href="automation_registry_state.md#0x1_automation_registry_state_ACTIVE">ACTIVE</a>) {
@@ -590,7 +594,8 @@ Only existing task can be cancled and only by task onwer.
 
 ## Function `update_automation_gas_limit`
 
-Update Automation gas limit
+Update Automation gas limit.
+If the committed gas amount for the next epoch is greater then the new gas limit, then error is reported.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">update_automation_gas_limit</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64)
@@ -625,7 +630,9 @@ Update Automation gas limit
 
 ## Function `get_active_task_ids`
 
-List all the automation task ids
+List all active automation task ids for the current epoch.
+Note that the tasks with CANCELLED state are still considered active for the current epoch,
+as cancellation takes effect in the next epoch only.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
@@ -644,7 +651,7 @@ List all the automation task ids
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&state.tasks);
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&state.tasks, id);
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&state.tasks, id);
         <b>if</b> (task.state != <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>) {
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
         };

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -1,0 +1,622 @@
+
+<a id="0x1_automation_registry_state"></a>
+
+# Module `0x1::automation_registry_state`
+
+Supra Automation Registry State
+
+This contract is part of the Supra Framework and is designed to manage automated task entries
+
+
+-  [Resource `AutomationRegistryState`](#0x1_automation_registry_state_AutomationRegistryState)
+-  [Struct `AutomationTaskMetaData`](#0x1_automation_registry_state_AutomationTaskMetaData)
+-  [Struct `UpdateAutomationGasLimit`](#0x1_automation_registry_state_UpdateAutomationGasLimit)
+-  [Struct `RemoveAutomationTask`](#0x1_automation_registry_state_RemoveAutomationTask)
+-  [Constants](#@Constants_0)
+-  [Function `task_expiry_time`](#0x1_automation_registry_state_task_expiry_time)
+-  [Function `initialize`](#0x1_automation_registry_state_initialize)
+-  [Function `on_new_epoch`](#0x1_automation_registry_state_on_new_epoch)
+-  [Function `register`](#0x1_automation_registry_state_register)
+-  [Function `remove_task`](#0x1_automation_registry_state_remove_task)
+-  [Function `update_automation_gas_limit`](#0x1_automation_registry_state_update_automation_gas_limit)
+-  [Function `get_active_task_ids`](#0x1_automation_registry_state_get_active_task_ids)
+-  [Function `get_task_details`](#0x1_automation_registry_state_get_task_details)
+-  [Function `has_active_task_with_id`](#0x1_automation_registry_state_has_active_task_with_id)
+-  [Function `get_next_task_index`](#0x1_automation_registry_state_get_next_task_index)
+
+
+<pre><code><b>use</b> <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map">0x1::enumerable_map</a>;
+<b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+<b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_AutomationRegistryState"></a>
+
+## Resource `AutomationRegistryState`
+
+It tracks entries both pending and completed, organized by unique indices.
+
+
+<pre><code><b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_EnumerableMap">enumerable_map::EnumerableMap</a>&lt;u64, <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>&gt;</code>
+</dt>
+<dd>
+ A collection of automation task entries that are active state.
+</dd>
+<dt>
+<code>current_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_committed_for_next_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>automation_gas_limit: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_state_AutomationTaskMetaData"></a>
+
+## Struct `AutomationTaskMetaData`
+
+<code><a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a></code> represents a single automation task item, containing metadata.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: u64</code>
+</dt>
+<dd>
+ Automation task index in registry
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+ The address of the task owner.
+</dd>
+<dt>
+<code>payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The function signature associated with the registry entry.
+</dd>
+<dt>
+<code>expiry_time: u64</code>
+</dt>
+<dd>
+ Expiry of the task, represented in a timestamp in second.
+</dd>
+<dt>
+<code>tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The transaction hash of the request transaction.
+</dd>
+<dt>
+<code>max_gas_amount: u64</code>
+</dt>
+<dd>
+ Max gas amount of automation task
+</dd>
+<dt>
+<code>gas_price_cap: u64</code>
+</dt>
+<dd>
+ Maximum gas price cap for the task
+</dd>
+<dt>
+<code>registration_epoch: u64</code>
+</dt>
+<dd>
+ Registration epoch number
+</dd>
+<dt>
+<code>registration_time: u64</code>
+</dt>
+<dd>
+ Registration epoch time
+</dd>
+<dt>
+<code>is_active: bool</code>
+</dt>
+<dd>
+ Flag indicating whether the task is active.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_state_UpdateAutomationGasLimit"></a>
+
+## Struct `UpdateAutomationGasLimit`
+
+Update automation gas limit event
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>automation_gas_limit: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_state_RemoveAutomationTask"></a>
+
+## Struct `RemoveAutomationTask`
+
+Remove automation task registry event
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST"></a>
+
+Automation task not found
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EGAS_AMOUNT_UPPER"></a>
+
+Gas amount does not go beyond upper cap limit
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EREGITRY_NOT_FOUND"></a>
+
+Registry Id not found
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER"></a>
+
+Unauthorized access: the caller is not the owner of the task
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_task_expiry_time"></a>
+
+## Function `task_expiry_time`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a>): u64 {
+    task.expiry_time
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_initialize"></a>
+
+## Function `initialize`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+
+    <b>move_to</b>(supra_framework, <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+        tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
+        current_index: 0,
+        gas_committed_for_next_epoch: 0,
+        automation_gas_limit
+    })
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_on_new_epoch"></a>
+
+## Function `on_new_epoch`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval: u64) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&state.tasks);
+
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <b>let</b> expired_task_gas = 0;
+
+    // Perform clean up and updation of state
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> state.tasks, id);
+
+        // Tasks that are active during this new epoch but will be already expired for the next epoch
+        <b>if</b> (task.expiry_time &lt;= (current_time + epoch_interval)) {
+            expired_task_gas = expired_task_gas + task.max_gas_amount;
+        };
+
+        <b>if</b> (task.expiry_time &lt;= current_time) {
+            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> state.tasks, id);
+        } <b>else</b> {
+            task.is_active = <b>true</b>;
+        }
+    });
+
+    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+    state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_register"></a>
+
+## Function `register`
+
+Registers a new automation task entry.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_register">register</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, expiry_time: u64, max_gas_amount: u64, gas_price_cap: u64, registration_epoch: u64, tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_register">register</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    expiry_time: u64,
+    max_gas_amount: u64,
+    gas_price_cap: u64,
+    registration_epoch: u64,
+    tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> registry_data = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+
+    <b>let</b> committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
+    <b>assert</b>!(committed_gas &lt; registry_data.automation_gas_limit, <a href="automation_registry_state.md#0x1_automation_registry_state_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
+    registry_data.gas_committed_for_next_epoch = committed_gas;
+    <b>let</b> task_index = registry_data.current_index;
+
+    <b>let</b> automation_task_metadata = <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> {
+        id: task_index,
+        owner: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner),
+        payload_tx,
+        expiry_time,
+        max_gas_amount,
+        gas_price_cap,
+        is_active: <b>false</b>,
+        registration_epoch,
+        registration_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+        tx_hash,
+    };
+
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> registry_data.tasks, task_index, automation_task_metadata);
+    registry_data.current_index = registry_data.current_index + 1;
+    <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_remove_task"></a>
+
+## Function `remove_task`
+
+Remove Automatioon task entry.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_remove_task">remove_task</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EAUTOMATION_TASK_NOT_EXIST">EAUTOMATION_TASK_NOT_EXIST</a>);
+
+    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+    <b>assert</b>!(automation_task_metadata.owner == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
+
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+
+    // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_RemoveAutomationTask">RemoveAutomationTask</a> { id: automation_task_metadata.id });
+    // todo : <b>return</b> refund amount <b>to</b> user
+    automation_task_metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_update_automation_gas_limit"></a>
+
+## Function `update_automation_gas_limit`
+
+Update Automation gas limit
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">update_automation_gas_limit</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_gas_limit: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_update_automation_gas_limit">update_automation_gas_limit</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    automation_gas_limit: u64
+) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.automation_gas_limit = automation_gas_limit;
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_UpdateAutomationGasLimit">UpdateAutomationGasLimit</a> { automation_gas_limit });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_active_task_ids"></a>
+
+## Function `get_active_task_ids`
+
+List all the automation task ids
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_active_task_ids">get_active_task_ids</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+
+    <b>let</b> active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |id| {
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, id);
+        <b>if</b> (task.is_active) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> active_task_ids, id);
+        };
+    });
+    <b>return</b> active_task_ids
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_task_details"></a>
+
+## Function `get_task_details`
+
+Retrieves the details of a automation task entry by its ID.
+Returns a tuple where the first element indicates if the registry is completed/failed (<code><b>true</b></code>) or pending (<code><b>false</b></code>),
+and the second element contains the <code><a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a></code> details.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_task_details">get_task_details</a>(id: u64): <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a> <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id), <a href="automation_registry_state.md#0x1_automation_registry_state_EREGITRY_NOT_FOUND">EREGITRY_NOT_FOUND</a>);
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_has_active_task_with_id"></a>
+
+## Function `has_active_task_with_id`
+
+Checks whether there is an active task in registry with specified input task id.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id)) {
+        // TODO: uncomment when activation of the tasks on new epoch is enabled.
+        <b>let</b> value = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id);
+        value.is_active
+    } <b>else</b>  {
+        <b>false</b>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_state_get_next_task_index"></a>
+
+## Function `get_next_task_index`
+
+Returns next task index in registry
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">get_next_task_index</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> (<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_get_next_task_index">get_next_task_index</a>(): u64 <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+    <b>let</b> state = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
+    state.current_index
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -11,7 +11,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `AutomationRegistryState`](#0x1_automation_registry_state_AutomationRegistryState)
 -  [Struct `AutomationTaskMetaData`](#0x1_automation_registry_state_AutomationTaskMetaData)
 -  [Struct `UpdateAutomationGasLimit`](#0x1_automation_registry_state_UpdateAutomationGasLimit)
--  [Struct `CanclledAutomationTask`](#0x1_automation_registry_state_CanclledAutomationTask)
+-  [Struct `CancelledAutomationTask`](#0x1_automation_registry_state_CancelledAutomationTask)
 -  [Constants](#@Constants_0)
 -  [Function `task_expiry_time`](#0x1_automation_registry_state_task_expiry_time)
 -  [Function `initialize`](#0x1_automation_registry_state_initialize)
@@ -194,15 +194,15 @@ Update automation gas limit event
 
 </details>
 
-<a id="0x1_automation_registry_state_CanclledAutomationTask"></a>
+<a id="0x1_automation_registry_state_CancelledAutomationTask"></a>
 
-## Struct `CanclledAutomationTask`
+## Struct `CancelledAutomationTask`
 
-Remove automation task registry event
+Cancelled automation task registry event
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_CanclledAutomationTask">CanclledAutomationTask</a> <b>has</b> drop, store
+<b>struct</b> <a href="automation_registry_state.md#0x1_automation_registry_state_CancelledAutomationTask">CancelledAutomationTask</a> <b>has</b> drop, store
 </code></pre>
 
 
@@ -581,7 +581,7 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
     // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
     state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_CanclledAutomationTask">CanclledAutomationTask</a> { id: automation_task_metadata.id });
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry_state.md#0x1_automation_registry_state_CancelledAutomationTask">CancelledAutomationTask</a> { id: automation_task_metadata.id });
     automation_task_metadata
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -383,7 +383,7 @@ The lenght of the transaction hash.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">automation_registry_state::AutomationTaskMetaData</a>): u64
 </code></pre>
 
 
@@ -392,7 +392,7 @@ The lenght of the transaction hash.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_task_expiry_time">task_expiry_time</a>(task: &<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationTaskMetaData">AutomationTaskMetaData</a>): u64 {
     task.expiry_time
 }
 </code></pre>
@@ -711,7 +711,7 @@ Checks whether there is an active task in registry with specified input task id.
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_has_active_task_with_id">has_active_task_with_id</a>(id: u64): bool <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
     <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, id)) {
-        <b>let</b> value = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, id);
+        <b>let</b> value = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&automation_task_metadata.tasks, id);
         value.state != <a href="automation_registry_state.md#0x1_automation_registry_state_PENDING">PENDING</a>
     } <b>else</b>  {
         <b>false</b>

--- a/aptos-move/framework/supra-framework/doc/automation_registry_state.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry_state.md
@@ -247,6 +247,17 @@ Gas amount does not go beyond upper cap limit
 
 
 
+<a id="0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION"></a>
+
+Upon new epoch entry failed to propertly calculated committed gas for the next epoch.
+It is greater than current epoch committed gas.
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>: u64 = 5;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_state_EREGITRY_NOT_FOUND"></a>
 
 Registry Id not found
@@ -263,6 +274,16 @@ Unauthorized access: the caller is not the owner of the task
 
 
 <pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_state_MICROSECS_CONVERSION_FACTOR"></a>
+
+Conversion factor between microseconds and second
+
+
+<pre><code><b>const</b> <a href="automation_registry_state.md#0x1_automation_registry_state_MICROSECS_CONVERSION_FACTOR">MICROSECS_CONVERSION_FACTOR</a>: u64 = 1000000;
 </code></pre>
 
 
@@ -328,7 +349,7 @@ Unauthorized access: the caller is not the owner of the task
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval_micro: u64)
 </code></pre>
 
 
@@ -337,10 +358,11 @@ Unauthorized access: the caller is not the owner of the task
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval: u64) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">on_new_epoch</a>(epoch_interval_micro: u64) <b>acquires</b> <a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a> {
     <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="automation_registry_state.md#0x1_automation_registry_state_AutomationRegistryState">AutomationRegistryState</a>&gt;(@supra_framework);
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&state.tasks);
 
+    <b>let</b> epoch_interval_secs = epoch_interval_micro / <a href="automation_registry_state.md#0x1_automation_registry_state_MICROSECS_CONVERSION_FACTOR">MICROSECS_CONVERSION_FACTOR</a>;
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
     <b>let</b> expired_task_gas = 0;
 
@@ -349,7 +371,7 @@ Unauthorized access: the caller is not the owner of the task
         <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> state.tasks, id);
 
         // Tasks that are active during this new epoch but will be already expired for the next epoch
-        <b>if</b> (task.expiry_time &lt;= (current_time + epoch_interval)) {
+        <b>if</b> (task.expiry_time &lt;= (current_time + epoch_interval_secs)) {
             expired_task_gas = expired_task_gas + task.max_gas_amount;
         };
 
@@ -359,6 +381,7 @@ Unauthorized access: the caller is not the owner of the task
             task.is_active = <b>true</b>;
         }
     });
+    <b>assert</b>!(expired_task_gas &lt;= state.gas_committed_for_next_epoch, <a href="automation_registry_state.md#0x1_automation_registry_state_EINVALID_COMMITTED_GAS_CALCULATION">EINVALID_COMMITTED_GAS_CALCULATION</a>);
 
     // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
     state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;

--- a/aptos-move/framework/supra-framework/doc/block.md
+++ b/aptos-move/framework/supra-framework/doc/block.md
@@ -42,6 +42,7 @@ This module defines a struct storing the metadata of the block and new block eve
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="automation_registry_state.md#0x1_automation_registry_state">0x1::automation_registry_state</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
@@ -669,6 +670,7 @@ The runtime always runs this before executing the transactions in a block.
     <a href="randomness.md#0x1_randomness_on_new_block">randomness::on_new_block</a>(&vm, epoch, round, <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>());
     <b>if</b> (<a href="timestamp.md#0x1_timestamp">timestamp</a> - <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>() &gt;= epoch_interval) {
         <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();
+        <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">automation_registry_state::on_new_epoch</a>(epoch_interval);
     };
 }
 </code></pre>
@@ -718,6 +720,7 @@ The runtime always runs this before executing the transactions in a block.
 
     <b>if</b> (<a href="timestamp.md#0x1_timestamp">timestamp</a> - <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>() &gt;= epoch_interval) {
         <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_try_start">reconfiguration_with_dkg::try_start</a>();
+        <a href="automation_registry_state.md#0x1_automation_registry_state_on_new_epoch">automation_registry_state::on_new_epoch</a>(epoch_interval);
     };
 }
 </code></pre>
@@ -1084,6 +1087,70 @@ The number of new events created does not exceed MAX_U64.
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
 <b>let</b> <a href="account.md#0x1_account">account</a> = <b>global</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
 <b>aborts_if</b> <a href="account.md#0x1_account">account</a>.guid_creation_num + 2 &gt;= <a href="account.md#0x1_account_MAX_GUID_CREATION_NUM">account::MAX_GUID_CREATION_NUM</a>;
+</code></pre>
+
+
+
+
+<a id="0x1_block_BlockRequirement"></a>
+
+
+<pre><code><b>schema</b> <a href="block.md#0x1_block_BlockRequirement">BlockRequirement</a> {
+    vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a>: <b>address</b>;
+    epoch: u64;
+    round: u64;
+    proposer: <b>address</b>;
+    failed_proposer_indices: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;;
+    previous_block_votes_bitvec: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <a href="timestamp.md#0x1_timestamp">timestamp</a>: u64;
+    <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+    <b>requires</b> <a href="system_addresses.md#0x1_system_addresses_is_vm">system_addresses::is_vm</a>(vm);
+    // This enforces <a id="high-level-req-4" href="#high-level-req">high-level requirement 4</a>:
+    <b>requires</b> proposer == @vm_reserved || <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">stake::spec_is_current_epoch_validator</a>(proposer);
+    <b>requires</b> (proposer == @vm_reserved) ==&gt; (<a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() == <a href="timestamp.md#0x1_timestamp">timestamp</a>);
+    <b>requires</b> (proposer != @vm_reserved) ==&gt; (<a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &lt; <a href="timestamp.md#0x1_timestamp">timestamp</a>);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@supra_framework);
+    <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;SupraCoin&gt;&gt;(@supra_framework);
+    <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+    <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
+}
+</code></pre>
+
+
+
+
+<a id="0x1_block_Initialize"></a>
+
+
+<pre><code><b>schema</b> <a href="block.md#0x1_block_Initialize">Initialize</a> {
+    supra_framework: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    epoch_interval_microsecs: u64;
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
+    // This enforces <a id="high-level-req-2.1" href="#high-level-req">high-level requirement 2</a>:
+    <b>aborts_if</b> addr != @supra_framework;
+    <b>aborts_if</b> epoch_interval_microsecs == 0;
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(addr);
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="block.md#0x1_block_CommitHistory">CommitHistory</a>&gt;(addr);
+    <b>ensures</b> <b>exists</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(addr);
+    <b>ensures</b> <b>exists</b>&lt;<a href="block.md#0x1_block_CommitHistory">CommitHistory</a>&gt;(addr);
+    <b>ensures</b> <b>global</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(addr).height == 0;
+}
+</code></pre>
+
+
+
+
+<a id="0x1_block_NewEventHandle"></a>
+
+
+<pre><code><b>schema</b> <a href="block.md#0x1_block_NewEventHandle">NewEventHandle</a> {
+    supra_framework: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
+    <b>let</b> <a href="account.md#0x1_account">account</a> = <b>global</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
+    <b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
+    <b>aborts_if</b> <a href="account.md#0x1_account">account</a>.guid_creation_num + 2 &gt; <a href="block.md#0x1_block_MAX_U64">MAX_U64</a>;
+}
 </code></pre>
 
 

--- a/aptos-move/framework/supra-framework/doc/overview.md
+++ b/aptos-move/framework/supra-framework/doc/overview.md
@@ -17,6 +17,7 @@ This is the reference documentation of the Supra framework.
 -  [`0x1::aggregator_factory`](aggregator_factory.md#0x1_aggregator_factory)
 -  [`0x1::aggregator_v2`](aggregator_v2.md#0x1_aggregator_v2)
 -  [`0x1::automation_registry`](automation_registry.md#0x1_automation_registry)
+-  [`0x1::automation_registry_state`](automation_registry_state.md#0x1_automation_registry_state)
 -  [`0x1::block`](block.md#0x1_block)
 -  [`0x1::chain_id`](chain_id.md#0x1_chain_id)
 -  [`0x1::chain_status`](chain_status.md#0x1_chain_status)

--- a/aptos-move/framework/supra-framework/doc/pbo_delegation_pool.md
+++ b/aptos-move/framework/supra-framework/doc/pbo_delegation_pool.md
@@ -157,6 +157,7 @@ transferred to A
 -  [Function `calculate_and_update_delegator_voter`](#0x1_pbo_delegation_pool_calculate_and_update_delegator_voter)
 -  [Function `get_expected_stake_pool_address`](#0x1_pbo_delegation_pool_get_expected_stake_pool_address)
 -  [Function `min_remaining_secs_for_commission_change`](#0x1_pbo_delegation_pool_min_remaining_secs_for_commission_change)
+-  [Function `initialize_delegation_pool_with_amount`](#0x1_pbo_delegation_pool_initialize_delegation_pool_with_amount)
 -  [Function `initialize_delegation_pool`](#0x1_pbo_delegation_pool_initialize_delegation_pool)
 -  [Function `fund_delegators_with_locked_stake`](#0x1_pbo_delegation_pool_fund_delegators_with_locked_stake)
 -  [Function `fund_delegators_with_stake`](#0x1_pbo_delegation_pool_fund_delegators_with_stake)
@@ -1367,6 +1368,16 @@ Requested amount too high, the balance would fall below principle stake after un
 
 
 
+<a id="0x1_pbo_delegation_pool_EBALANCE_NOT_SUFFICIENT"></a>
+
+Balance is not enough.
+
+
+<pre><code><b>const</b> <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_EBALANCE_NOT_SUFFICIENT">EBALANCE_NOT_SUFFICIENT</a>: u64 = 38;
+</code></pre>
+
+
+
 <a id="0x1_pbo_delegation_pool_ECOIN_VALUE_NOT_SAME_AS_PRINCIPAL_STAKE"></a>
 
 Coin value is not the same with principle stake.
@@ -2289,6 +2300,61 @@ Return the minimum remaining time in seconds for commission change, which is one
 <pre><code><b>public</b> <b>fun</b> <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_min_remaining_secs_for_commission_change">min_remaining_secs_for_commission_change</a>(): u64 {
     <b>let</b> config = <a href="staking_config.md#0x1_staking_config_get">staking_config::get</a>();
     <a href="staking_config.md#0x1_staking_config_get_recurring_lockup_duration">staking_config::get_recurring_lockup_duration</a>(&config) / 4
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_pbo_delegation_pool_initialize_delegation_pool_with_amount"></a>
+
+## Function `initialize_delegation_pool_with_amount`
+
+Initialize a delegation pool without actual coin but withdraw from the owner's account.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_initialize_delegation_pool_with_amount">initialize_delegation_pool_with_amount</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, multisig_admin: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;, amount: u64, operator_commission_percentage: u64, delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, delegator_address: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, principle_stake: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, unlock_numerators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, unlock_denominator: u64, unlock_start_time: u64, unlock_duration: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_initialize_delegation_pool_with_amount">initialize_delegation_pool_with_amount</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    multisig_admin: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;,
+    amount: u64,
+    operator_commission_percentage: u64,
+    delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    delegator_address: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
+    principle_stake: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;,
+    unlock_numerators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;,
+    unlock_denominator: u64,
+    unlock_start_time: u64,
+    unlock_duration: u64
+) <b>acquires</b> <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_DelegationPool">DelegationPool</a>, <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_GovernanceRecords">GovernanceRecords</a>, <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>, <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_NextCommissionPercentage">NextCommissionPercentage</a> {
+    <b>assert</b>!(
+        <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)) &gt;= amount,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_EBALANCE_NOT_SUFFICIENT">EBALANCE_NOT_SUFFICIENT</a>)
+    );
+    <b>let</b> <a href="coin.md#0x1_coin">coin</a> = <a href="coin.md#0x1_coin_withdraw">coin::withdraw</a>&lt;SupraCoin&gt;(owner, amount);
+
+    <a href="pbo_delegation_pool.md#0x1_pbo_delegation_pool_initialize_delegation_pool">initialize_delegation_pool</a>(
+        owner,
+        multisig_admin,
+        operator_commission_percentage,
+        delegation_pool_creation_seed,
+        delegator_address,
+        principle_stake,
+        <a href="coin.md#0x1_coin">coin</a>,
+        unlock_numerators,
+        unlock_denominator,
+        unlock_start_time,
+        unlock_duration
+    )
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/transaction_context.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_context.md
@@ -30,8 +30,6 @@
 -  [Function `chain_id_internal`](#0x1_transaction_context_chain_id_internal)
 -  [Function `entry_function_payload`](#0x1_transaction_context_entry_function_payload)
 -  [Function `entry_function_payload_internal`](#0x1_transaction_context_entry_function_payload_internal)
--  [Function `txn_app_hash`](#0x1_transaction_context_txn_app_hash)
--  [Function `txn_app_hash_internal`](#0x1_transaction_context_txn_app_hash_internal)
 -  [Function `account_address`](#0x1_transaction_context_account_address)
 -  [Function `module_name`](#0x1_transaction_context_module_name)
 -  [Function `function_name`](#0x1_transaction_context_function_name)
@@ -730,55 +728,6 @@ This function aborts if called outside of the transaction prologue, execution, o
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_entry_function_payload_internal">entry_function_payload_internal</a>(): Option&lt;<a href="transaction_context.md#0x1_transaction_context_EntryFunctionPayload">EntryFunctionPayload</a>&gt;;
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_transaction_context_txn_app_hash"></a>
-
-## Function `txn_app_hash`
-
-Returns the original transaction hash calculated on the raw-bytes.
-This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">txn_app_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_txn_app_hash">txn_app_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_context_extension_enabled">features::transaction_context_extension_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_context.md#0x1_transaction_context_ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED">ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED</a>));
-    <a href="transaction_context.md#0x1_transaction_context_txn_app_hash_internal">txn_app_hash_internal</a>()
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_transaction_context_txn_app_hash_internal"></a>
-
-## Function `txn_app_hash_internal`
-
-
-
-<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_txn_app_hash_internal">txn_app_hash_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_txn_app_hash_internal">txn_app_hash_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -14,6 +14,8 @@ module supra_framework::automation_registry {
     use supra_framework::system_addresses;
     use supra_framework::timestamp;
     use supra_framework::transaction_context;
+    #[test_only]
+    use std::vector;
 
     #[test_only]
     use supra_framework::coin;
@@ -22,14 +24,10 @@ module supra_framework::automation_registry {
 
     friend supra_framework::genesis;
 
-    /// Invalid expiry time: it cannot be earlier than the current time
-    const EINVALID_EXPIRY_TIME: u64 = 1;
     /// Expiry time does not go beyond upper cap duration
-    const EEXPIRY_TIME_UPPER: u64 = 2;
+    const EEXPIRY_TIME_UPPER: u64 = 1;
     /// Expiry time must be after the start of the next epoch
-    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 3;
-    /// Invalid gas price: it cannot be zero
-    const EINVALID_GAS_PRICE: u64 = 4;
+    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 2;
 
     /// The default automation task gas limit
     const DEFAULT_AUTOMATION_GAS_LIMIT: u64 = 100000000;
@@ -142,10 +140,10 @@ module supra_framework::automation_registry {
     }
 
     /// Deducts the automation fee from the user's account based on the selected expiry time.
-    fun charge_automation_fee_from_user(owner: &signer, fee: u64) {
+    fun charge_automation_fee_from_user(owner: &signer, automation_unit_price: u64, task_duration: u64, registry_fee_address: address) {
+        let automation_base_fee = task_duration * automation_unit_price;
         // todo : dynamic price calculation is pending
-        let registry_fee_address = get_registry_fee_address();
-        supra_account::transfer(owner, registry_fee_address, fee);
+        supra_account::transfer(owner, registry_fee_address, automation_base_fee);
     }
 
     /// Get last epoch time in second
@@ -160,30 +158,22 @@ module supra_framework::automation_registry {
         payload_tx: vector<u8>,
         expiry_time: u64,
         max_gas_amount: u64,
-        gas_price_cap: u64
+        gas_price_cap: u64,
+        parent_hash: vector<u8>
     ) acquires AutomationRegistry {
         let registry_data = borrow_global_mut<AutomationRegistry>(@supra_framework);
 
         //Well formedness check of payload_tx is done in native layer beforehand.
 
         let current_time = timestamp::now_seconds();
-        assert!(expiry_time > current_time, EINVALID_EXPIRY_TIME);
-
-        let expiry_time_duration = expiry_time - current_time;
-        assert!(expiry_time_duration < registry_data.duration_upper_limit, EEXPIRY_TIME_UPPER);
+        let task_duration = expiry_time - current_time;
+        assert!(task_duration < registry_data.duration_upper_limit, EEXPIRY_TIME_UPPER);
 
         let epoch_interval = block::get_epoch_interval_secs();
         let last_epoch_time = get_last_epoch_time_second();
         assert!(expiry_time > (last_epoch_time + epoch_interval), EEXPIRY_BEFORE_NEXT_EPOCH);
 
-
-        assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
-
-        let fee = expiry_time_duration * registry_data.automation_unit_price;
-        charge_automation_fee_from_user(owner, fee);
-
         let epoch = reconfiguration::current_epoch();
-        let parent_hash = transaction_context::txn_app_hash();
         automation_registry_state::register(
             owner,
             payload_tx,
@@ -192,12 +182,18 @@ module supra_framework::automation_registry {
             gas_price_cap,
             epoch,
             parent_hash);
+
+        charge_automation_fee_from_user(
+            owner,
+            registry_data.automation_unit_price,
+            task_duration,
+            registry_data.registry_fee_address);
     }
 
     /// Remove Automatioon task entry.
     public entry fun remove_task(owner: &signer, id: u64) acquires AutomationRegistry {
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let automation_task_metadata = automation_registry_state::remove_task(owner, id);
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         refund_automation_task_fee(signer::address_of(owner), automation_task_metadata, automation_registry.automation_unit_price);
     }
 
@@ -272,11 +268,11 @@ module supra_framework::automation_registry {
     }
 
     #[test(supra_framework = @supra_framework, user = @0x1cafe)]
-    #[expected_failure(abort_code=196609, location=transaction_context)]
     fun test_registry(supra_framework: &signer, user: &signer) acquires AutomationRegistry {
         initialize_registry_test(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f4041424344";
-        register(user, payload, 86400, 1000, 100000);
+        let parent_hash = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+        register(user, payload, 86400, 1000, 100000, parent_hash);
     }
 }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -4,13 +4,12 @@
 module supra_framework::automation_registry {
 
     use std::signer;
-    use std::vector;
-
-    use supra_std::enumerable_map::{Self, EnumerableMap};
+    use supra_framework::event;
+    use supra_framework::automation_registry_state::AutomationTaskMetaData;
+    use supra_framework::automation_registry_state;
 
     use supra_framework::account::{Self, SignerCapability};
     use supra_framework::block;
-    use supra_framework::event;
     use supra_framework::reconfiguration;
     use supra_framework::supra_account;
     use supra_framework::system_addresses;
@@ -24,22 +23,14 @@ module supra_framework::automation_registry {
 
     friend supra_framework::genesis;
 
-    /// Registry Id not found
-    const EREGITRY_NOT_FOUND: u64 = 1;
     /// Invalid expiry time: it cannot be earlier than the current time
-    const EINVALID_EXPIRY_TIME: u64 = 2;
+    const EINVALID_EXPIRY_TIME: u64 = 1;
     /// Expiry time does not go beyond upper cap duration
-    const EEXPIRY_TIME_UPPER: u64 = 3;
+    const EEXPIRY_TIME_UPPER: u64 = 2;
     /// Expiry time must be after the start of the next epoch
-    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 4;
-    /// Gas amount does not go beyond upper cap limit
-    const EGAS_AMOUNT_UPPER: u64 = 5;
+    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 3;
     /// Invalid gas price: it cannot be zero
-    const EINVALID_GAS_PRICE: u64 = 6;
-    /// Automation task not found
-    const EAUTOMATION_TASK_NOT_EXIST: u64 = 7;
-    /// Unauthorized access: the caller is not the owner of the task
-    const EUNAUTHORIZED_TASK_OWNER: u64 = 8;
+    const EINVALID_GAS_PRICE: u64 = 4;
 
     /// The default automation task gas limit
     const DEFAULT_AUTOMATION_GAS_LIMIT: u64 = 100000000;
@@ -54,10 +45,6 @@ module supra_framework::automation_registry {
 
     /// It tracks entries both pending and completed, organized by unique indices.
     struct AutomationRegistry has key, store {
-        /// The current unique index counter for registered tasks. This value increments as new tasks are added.
-        current_index: u64,
-        /// Automation task gas limit.
-        automation_gas_limit: u64,
         /// Automation task duration upper limit.
         duration_upper_limit: u64,
         /// Gas committed for next epoch
@@ -68,34 +55,8 @@ module supra_framework::automation_registry {
         registry_fee_address: address,
         /// Resource account signature capability
         registry_fee_address_signer_cap: SignerCapability,
-        /// A collection of automation task entries that are active state.
-        tasks: EnumerableMap<u64, AutomationTaskMetaData>,
     }
 
-    #[event]
-    /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
-    struct AutomationTaskMetaData has copy, store, drop {
-        /// Automation task index in registry
-        id: u64,
-        /// The address of the task owner.
-        owner: address,
-        /// The function signature associated with the registry entry.
-        payload_tx: vector<u8>,
-        /// Expiry of the task, represented in a timestamp in second.
-        expiry_time: u64,
-        /// The transaction hash of the request transaction.
-        tx_hash: vector<u8>,
-        /// Max gas amount of automation task
-        max_gas_amount: u64,
-        /// Maximum gas price cap for the task
-        gas_price_cap: u64,
-        /// Registration epoch number
-        registration_epoch: u64,
-        /// Registration epoch time
-        registration_time: u64,
-        /// Flag indicating whether the task is active.
-        is_active: bool
-    }
 
     #[event]
     /// Withdraw user's registration fee event
@@ -111,11 +72,6 @@ module supra_framework::automation_registry {
         amount: u64
     }
 
-    #[event]
-    /// Update automation gas limit event
-    struct UpdateAutomationGasLimit has drop, store {
-        automation_gas_limit: u64
-    }
 
     #[event]
     /// Update duration upper limit event
@@ -123,15 +79,11 @@ module supra_framework::automation_registry {
         duration_upper_limit: u64
     }
 
-    #[event]
-    /// Remove automation task registry event
-    struct RemoveAutomationTask has drop, store {
-        id: u64
-    }
 
     // todo : this function should call during initialzation, but since we already done genesis in that case who can access the function
     public fun initialize(supra_framework: &signer) {
         system_addresses::assert_supra_framework(supra_framework);
+        automation_registry_state::initialize(supra_framework, DEFAULT_AUTOMATION_GAS_LIMIT);
 
         let (registry_fee_resource_signer, registry_fee_address_signer_cap) = account::create_resource_account(
             supra_framework,
@@ -139,46 +91,14 @@ module supra_framework::automation_registry {
         );
 
         move_to(supra_framework, AutomationRegistry {
-            current_index: 0,
-            automation_gas_limit: DEFAULT_AUTOMATION_GAS_LIMIT,
             duration_upper_limit: DEFAULT_DURATION_UPPER_LIMIT,
             gas_committed_for_next_epoch: 0,
             automation_unit_price: DEFAULT_AUTOMATION_UNIT_PRICE,
             registry_fee_address: signer::address_of(&registry_fee_resource_signer),
             registry_fee_address_signer_cap,
-            tasks: enumerable_map::new_map(),
         })
     }
 
-    public(friend) fun on_new_epoch(supra_framework: &signer) acquires AutomationRegistry {
-        system_addresses::assert_supra_framework(supra_framework);
-
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        let current_time = timestamp::now_seconds();
-        let epoch_interval = block::get_epoch_interval_secs();
-        let expired_task_gas = 0;
-
-        // Perform clean up and updation of state
-        vector::for_each(ids, |id| {
-            let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, id);
-
-            // Tasks that are active during this new epoch but will be already expired for the next epoch
-            if (task.expiry_time < (current_time + epoch_interval)) {
-                expired_task_gas = expired_task_gas + task.max_gas_amount;
-            };
-
-            if (task.expiry_time <= current_time) {
-                enumerable_map::remove_value(&mut automation_registry.tasks, id);
-            } else if (!task.is_active && task.expiry_time > current_time) {
-                task.is_active = true;
-            }
-        });
-
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - expired_task_gas;
-    }
 
     /// Withdraw accumulated automation task fees from the resource account - access by admin
     entry fun withdraw_automation_task_fees(
@@ -204,13 +124,9 @@ module supra_framework::automation_registry {
     public entry fun update_automation_gas_limit(
         supra_framework: &signer,
         automation_gas_limit: u64
-    ) acquires AutomationRegistry {
+    ) {
         system_addresses::assert_supra_framework(supra_framework);
-
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        automation_registry.automation_gas_limit = automation_gas_limit;
-
-        event::emit(UpdateAutomationGasLimit { automation_gas_limit });
+        automation_registry_state::update_automation_gas_limit(supra_framework, automation_gas_limit)
     }
 
     /// Update duration upper limit
@@ -249,7 +165,7 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry {
         let registry_data = borrow_global_mut<AutomationRegistry>(@supra_framework);
 
-        // todo : well formedness check of payload_tx
+        //Well formedness check of payload_tx is done in native layer beforehand.
 
         let current_time = timestamp::now_seconds();
         assert!(expiry_time > current_time, EINVALID_EXPIRY_TIME);
@@ -261,53 +177,29 @@ module supra_framework::automation_registry {
         let last_epoch_time = get_last_epoch_time_second();
         assert!(expiry_time > (last_epoch_time + epoch_interval), EEXPIRY_BEFORE_NEXT_EPOCH);
 
-        registry_data.gas_committed_for_next_epoch = registry_data.gas_committed_for_next_epoch + max_gas_amount;
-        assert!(registry_data.gas_committed_for_next_epoch < registry_data.automation_gas_limit, EGAS_AMOUNT_UPPER);
 
         assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
 
         let fee = expiry_time_duration * registry_data.automation_unit_price;
         charge_automation_fee_from_user(owner, fee);
 
-        registry_data.current_index = registry_data.current_index + 1;
-
-        let automation_task_metadata = AutomationTaskMetaData {
-            id: registry_data.current_index,
-            owner: signer::address_of(owner),
+        let epoch = reconfiguration::current_epoch();
+        let parent_hash = transaction_context::txn_app_hash();
+        automation_registry_state::register(
+            owner,
             payload_tx,
             expiry_time,
             max_gas_amount,
             gas_price_cap,
-            is_active: false,
-            registration_epoch: reconfiguration::current_epoch(),
-            registration_time: timestamp::now_seconds(),
-            tx_hash: transaction_context::txn_app_hash()
-        };
-
-        enumerable_map::add_value(&mut registry_data.tasks, registry_data.current_index, automation_task_metadata);
-
-        event::emit(automation_task_metadata);
+            epoch,
+            parent_hash);
     }
 
     /// Remove Automatioon task entry.
-    public entry fun remove_task(owner: &signer, registry_id: u64) acquires AutomationRegistry {
-        let user_addr = signer::address_of(owner);
-
+    public entry fun remove_task(owner: &signer, id: u64) acquires AutomationRegistry {
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_registry.tasks, registry_id), EAUTOMATION_TASK_NOT_EXIST);
-
-        let automation_task_metadata = enumerable_map::get_value(&automation_registry.tasks, registry_id);
-        assert!(automation_task_metadata.owner == user_addr, EUNAUTHORIZED_TASK_OWNER);
-
-        enumerable_map::remove_value(&mut automation_registry.tasks, registry_id);
-
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
-
-        // Calculate refund fee and transfer it to user
-        refund_automation_task_fee(user_addr, automation_task_metadata, automation_registry.automation_unit_price);
-
-        event::emit(RemoveAutomationTask { id: automation_task_metadata.id });
+        let automation_task_metadata = automation_registry_state::remove_task(owner, id);
+        refund_automation_task_fee(signer::address_of(owner), automation_task_metadata, automation_registry.automation_unit_price);
     }
 
     /// Refunds the automation task fee to the user who has removed their task registration from the list.
@@ -317,7 +209,7 @@ module supra_framework::automation_registry {
         automation_unit_price: u64,
     ) acquires AutomationRegistry {
         let current_time = timestamp::now_seconds();
-        let expiry_time_duration = automation_task_metadata.expiry_time - current_time;
+        let expiry_time_duration = automation_registry_state::task_expiry_time(&automation_task_metadata) - current_time;
 
         let refund_amount = expiry_time_duration * automation_unit_price;
         transfer_fee_to_account_internal(user, refund_amount);
@@ -326,36 +218,28 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Returns next task index in registry
-    public fun get_next_task_index(): u64 acquires AutomationRegistry {
-        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
-        automation_registry.current_index + 1
+    public fun get_next_task_index(): u64 {
+        automation_registry_state::get_next_task_index()
     }
 
     #[view]
     /// List all the automation task ids
-    public fun get_active_task_ids(): vector<u64> acquires AutomationRegistry {
-        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
-
-        let active_task_ids = vector[];
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        vector::for_each(ids, |id| {
-            let task = enumerable_map::get_value(&automation_registry.tasks, id);
-            if (task.is_active) {
-                vector::push_back(&mut active_task_ids, id);
-            };
-        });
-        return active_task_ids
+    public fun get_active_task_ids(): vector<u64> {
+        automation_registry_state::get_active_task_ids()
     }
 
     #[view]
     /// Retrieves the details of a automation task entry by its ID.
     /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
     /// and the second element contains the `AutomationTaskMetaData` details.
-    public fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);
-        enumerable_map::get_value(&automation_task_metadata.tasks, id)
+    public fun get_task_details(id: u64): AutomationTaskMetaData {
+        automation_registry_state::get_task_details(id)
+    }
+
+    #[view]
+    /// Checks whether there is an active task in registry with specified input task id.
+    public fun has_active_task_with_id(id: u64): bool {
+        automation_registry_state::has_active_task_with_id(id)
     }
 
     #[view]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -5,8 +5,7 @@ module supra_framework::automation_registry {
 
     use std::signer;
     use supra_framework::event;
-    use supra_framework::automation_registry_state::AutomationTaskMetaData;
-    use supra_framework::automation_registry_state;
+    use supra_framework::automation_registry_state::{Self, AutomationTaskMetaData};
 
     use supra_framework::account::{Self, SignerCapability};
     use supra_framework::block;
@@ -230,8 +229,7 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Retrieves the details of a automation task entry by its ID.
-    /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
-    /// and the second element contains the `AutomationTaskMetaData` details.
+    /// Error will be returned if entry with specified ID does not exist.
     public fun get_task_details(id: u64): AutomationTaskMetaData {
         automation_registry_state::get_task_details(id)
     }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -97,7 +97,7 @@ module supra_framework::automation_registry {
 
 
     /// Withdraw accumulated automation task fees from the resource account - access by admin
-    entry fun withdraw_automation_task_fees(
+    public fun withdraw_automation_task_fees(
         supra_framework: &signer,
         to: address,
         amount: u64
@@ -116,7 +116,8 @@ module supra_framework::automation_registry {
         supra_account::transfer(&resource_signer, to, amount);
     }
 
-    /// Update Automation gas limit
+    /// Update Automation gas limit.
+    /// If the committed gas amount for the next epoch is greater then the new gas limit, then error is reported.
     public entry fun update_automation_gas_limit(
         supra_framework: &signer,
         automation_gas_limit: u64
@@ -162,7 +163,7 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry {
         let registry_data = borrow_global_mut<AutomationRegistry>(@supra_framework);
 
-        //Well formedness check of payload_tx is done in native layer beforehand.
+        //Well-formedness check of payload_tx is done in native layer beforehand.
 
         let current_time = timestamp::now_seconds();
         assert!(expiry_time > current_time, EINVALID_EXPIRY_TIME);
@@ -192,7 +193,12 @@ module supra_framework::automation_registry {
     }
 
     /// Cancel Automation task with specified id.
-    /// Only existing task can be cancled and only by task onwer.
+    /// Only existing task, which is PENDING or ACTIVE, can be cancled and only by task onwer.
+    /// If the task is
+    ///   - active, its state is updated to be CANCELLED.
+    ///   - pending, it is removed form the list.
+    ///   - cancelled, an error is reported
+    /// Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
     public entry fun cancel_task(owner: &signer, id: u64) acquires AutomationRegistry {
         let automation_task_metadata = automation_registry_state::cancel_task(owner, id);
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
@@ -220,7 +226,9 @@ module supra_framework::automation_registry {
     }
 
     #[view]
-    /// List all the automation task ids
+    /// List all active automation task ids for the current epoch.
+    /// Note that the tasks with CANCELLED state are still considered active for the current epoch,
+    /// as cancellation takes effect in the next epoch only.
     public fun get_active_task_ids(): vector<u64> {
         automation_registry_state::get_active_task_ids()
     }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -248,9 +248,8 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Ge gas committed for next epoch
-    public fun get_gas_committed_for_next_epoch(): u64 acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        automation_task_metadata.gas_committed_for_next_epoch
+    public fun get_gas_committed_for_next_epoch(): u64 {
+        automation_registry_state::get_gas_committed_for_next_epoch()
     }
 
     #[test_only]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -21,10 +21,12 @@ module supra_framework::automation_registry {
 
     friend supra_framework::genesis;
 
+    /// Invalid expiry time: it cannot be earlier than the current time
+    const EINVALID_EXPIRY_TIME: u64 = 1;
     /// Expiry time does not go beyond upper cap duration
-    const EEXPIRY_TIME_UPPER: u64 = 1;
+    const EEXPIRY_TIME_UPPER: u64 = 2;
     /// Expiry time must be after the start of the next epoch
-    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 2;
+    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 3;
 
     /// The default automation task gas limit
     const DEFAULT_AUTOMATION_GAS_LIMIT: u64 = 100000000;
@@ -163,9 +165,11 @@ module supra_framework::automation_registry {
         //Well formedness check of payload_tx is done in native layer beforehand.
 
         let current_time = timestamp::now_seconds();
+        assert!(expiry_time > current_time, EINVALID_EXPIRY_TIME);
         let task_duration = expiry_time - current_time;
         assert!(task_duration < registry_data.duration_upper_limit, EEXPIRY_TIME_UPPER);
 
+        // Check that task is valid at least in the next epoch
         let epoch_interval = block::get_epoch_interval_secs();
         let last_epoch_time = get_last_epoch_time_second();
         assert!(expiry_time > (last_epoch_time + epoch_interval), EEXPIRY_BEFORE_NEXT_EPOCH);
@@ -187,9 +191,10 @@ module supra_framework::automation_registry {
             registry_data.registry_fee_address);
     }
 
-    /// Remove Automatioon task entry.
-    public entry fun remove_task(owner: &signer, id: u64) acquires AutomationRegistry {
-        let automation_task_metadata = automation_registry_state::remove_task(owner, id);
+    /// Cancel Automation task with specified id.
+    /// Only existing task can be cancled and only by task onwer.
+    public entry fun cancel_task(owner: &signer, id: u64) acquires AutomationRegistry {
+        let automation_task_metadata = automation_registry_state::cancel_task(owner, id);
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         refund_automation_task_fee(signer::address_of(owner), automation_task_metadata, automation_registry.automation_unit_price);
     }
@@ -240,7 +245,7 @@ module supra_framework::automation_registry {
     }
 
     #[view]
-    /// Ge gas committed for next epoch
+    /// Get gas committed for next epoch
     public fun get_gas_committed_for_next_epoch(): u64 {
         automation_registry_state::get_gas_committed_for_next_epoch()
     }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -13,9 +13,6 @@ module supra_framework::automation_registry {
     use supra_framework::supra_account;
     use supra_framework::system_addresses;
     use supra_framework::timestamp;
-    use supra_framework::transaction_context;
-    #[test_only]
-    use std::vector;
 
     #[test_only]
     use supra_framework::coin;

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -36,8 +36,8 @@ module supra_framework::automation_registry_state {
     const EINVALID_TXN_HASH: u64 = 8;
     /// Current committed gas amount is greater than the automation gas limit.
     const EUNACCEPTABLE_AUTOMATION_GAS_LIMIT: u64 = 9;
-    /// Trying to cancel a task which is already cancelled.
-    const EINVALID_CANCELLATION: u64 = 10;
+    /// Task is already cancelled.
+    const EALREADY_CANCELLED: u64 = 10;
 
     /// The lenght of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -124,11 +124,12 @@ module supra_framework::automation_registry_state {
             let task = enumerable_map::get_value_mut(&mut state.tasks, id);
 
             // Tasks that are active during next epoch and are not cancled
+            // current_time shows the start time of the current new epoch.
             if (task.state != CANCELLED && task.expiry_time > (current_time + epoch_interval_secs) ) {
                 gas_committed_for_next_epoch = gas_committed_for_next_epoch + task.max_gas_amount;
             };
 
-            // Drop or activate task
+            // Drop or activate task for this current epoch.
             if (task.expiry_time <= current_time || task.state == CANCELLED) {
                 enumerable_map::remove_value(&mut state.tasks, id);
             } else {
@@ -181,16 +182,19 @@ module supra_framework::automation_registry_state {
     }
 
     /// Cancel Automation task with specified id.
-    /// If the task was active its state is updated to be CANCELLED. Otherwise task is removed form the list.
-    /// Committed gas-limit is updated accordingly.
-    /// Only existing task can be cancled and only by task onwer.
+    /// Only existing task, which is PENDING or ACTIVE, can be cancled and only by task onwer.
+    /// If the task is
+    ///   - active, its state is updated to be CANCELLED.
+    ///   - pending, it is removed form the list.
+    ///   - cancelled, an error is reported
+    /// Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
     public (friend) fun cancel_task(owner: &signer, id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
         let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
         assert!(enumerable_map::contains(&state.tasks, id), EAUTOMATION_TASK_NOT_FOUND);
 
         let automation_task_metadata = enumerable_map::get_value(&state.tasks, id);
         assert!(automation_task_metadata.owner == signer::address_of(owner), EUNAUTHORIZED_TASK_OWNER);
-        assert!(automation_task_metadata.state != CANCELLED, EINVALID_CANCELLATION);
+        assert!(automation_task_metadata.state != CANCELLED, EALREADY_CANCELLED);
         if (automation_task_metadata.state == PENDING) {
             enumerable_map::remove_value(&mut state.tasks, id);
         } else if (automation_task_metadata.state == ACTIVE) {
@@ -205,7 +209,8 @@ module supra_framework::automation_registry_state {
         automation_task_metadata
     }
 
-    /// Update Automation gas limit
+    /// Update Automation gas limit.
+    /// If the committed gas amount for the next epoch is greater then the new gas limit, then error is reported.
     public (friend) fun update_automation_gas_limit(
         supra_framework: &signer,
         automation_gas_limit: u64
@@ -220,7 +225,9 @@ module supra_framework::automation_registry_state {
         event::emit(UpdateAutomationGasLimit { automation_gas_limit });
     }
 
-    /// List all the automation task ids
+    /// List all active automation task ids for the current epoch.
+    /// Note that the tasks with CANCELLED state are still considered active for the current epoch,
+    /// as cancellation takes effect in the next epoch only.
     public(friend) fun get_active_task_ids(): vector<u64> acquires AutomationRegistryState {
         let state = borrow_global<AutomationRegistryState>(@supra_framework);
 
@@ -228,7 +235,7 @@ module supra_framework::automation_registry_state {
         let ids = enumerable_map::get_map_list(&state.tasks);
 
         vector::for_each(ids, |id| {
-            let task = enumerable_map::get_value(&state.tasks, id);
+            let task = enumerable_map::get_value_ref(&state.tasks, id);
             if (task.state != PENDING) {
                 vector::push_back(&mut active_task_ids, id);
             };
@@ -601,7 +608,7 @@ module supra_framework::automation_registry_state {
     }
 
     #[test(framework = @supra_framework)]
-    #[expected_failure(abort_code = EINVALID_CANCELLATION, location = Self)]
+    #[expected_failure(abort_code = EALREADY_CANCELLED, location = Self)]
     fun check_cacellation_of_cancelled_task(framework: signer) acquires AutomationRegistryState {
         initialize_registry_state_test(&framework);
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -17,20 +17,36 @@ module supra_framework::automation_registry_state {
     friend supra_framework::automation_registry;
     friend supra_framework::block;
 
-    /// Registry Id not found
-    const EREGITRY_NOT_FOUND: u64 = 1;
+    /// Invalid expiry time: it cannot be earlier than the current time
+    const EINVALID_EXPIRY_TIME: u64 = 1;
+    /// Invalid gas price: it cannot be zero
+    const EINVALID_GAS_PRICE: u64 = 2;
+    /// Invalid max gas amount for automated task: it cannot be zero
+    const EINVALID_MAX_GAS_AMOUNT: u64 = 3;
+    /// Task with provided Id not found
+    const ETASK_NOT_FOUND: u64 = 4;
     /// Gas amount does not go beyond upper cap limit
-    const EGAS_AMOUNT_UPPER: u64 = 2;
+    const EGAS_AMOUNT_UPPER: u64 = 5;
     /// Automation task not found
-    const EAUTOMATION_TASK_NOT_EXIST: u64 = 3;
+    const EAUTOMATION_TASK_NOT_EXIST: u64 = 6;
     /// Unauthorized access: the caller is not the owner of the task
-    const EUNAUTHORIZED_TASK_OWNER: u64 = 4;
+    const EUNAUTHORIZED_TASK_OWNER: u64 = 7;
     /// Upon new epoch entry failed to propertly calculated committed gas for the next epoch.
     /// It is greater than current epoch committed gas.
-    const EINVALID_COMMITTED_GAS_CALCULATION: u64 = 5;
+    const EINVALID_COMMITTED_GAS_CALCULATION: u64 = 8;
+    /// Transactoin hash that registring current task is invalid. Lenght should be 32.
+    /// It is greater than current epoch committed gas.
+    const EINVALID_TXN_HASH: u64 = 9;
+    /// Transactoin hash that registring current task is invalid. Lenght should be 32.
+    /// It is greater than current epoch committed gas.
+    const EINVALID_PAYLOAD: u64 = 10;
+
+    /// The lenght of the transaction hash.
+    const TXN_HASH_LENGTH: u64 = 32;
 
     /// Conversion factor between microseconds and second
     const MICROSECS_CONVERSION_FACTOR: u64 = 1_000_000;
+
     /// It tracks entries both pending and completed, organized by unique indices.
     struct AutomationRegistryState has key, store {
         /// A collection of automation task entries that are active state.
@@ -121,7 +137,6 @@ module supra_framework::automation_registry_state {
         state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
     }
 
-
     /// Registers a new automation task entry.
     public(friend) fun register(
         owner: &signer,
@@ -133,6 +148,13 @@ module supra_framework::automation_registry_state {
         tx_hash: vector<u8>,
     ) acquires AutomationRegistryState {
         let registry_data = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        let registration_time = timestamp::now_seconds();
+
+        assert!(expiry_time > registration_time, EINVALID_EXPIRY_TIME);
+        assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
+        assert!(max_gas_amount > 0, EINVALID_MAX_GAS_AMOUNT);
+        assert!(vector::length(&tx_hash) == TXN_HASH_LENGTH, EINVALID_TXN_HASH);
+        assert!(!vector::is_empty(&payload_tx), EINVALID_PAYLOAD);
 
         let committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
         assert!(committed_gas < registry_data.automation_gas_limit, EGAS_AMOUNT_UPPER);
@@ -148,7 +170,7 @@ module supra_framework::automation_registry_state {
             gas_price_cap,
             is_active: false,
             registration_epoch,
-            registration_time: timestamp::now_seconds(),
+            registration_time,
             tx_hash,
         };
 
@@ -208,7 +230,7 @@ module supra_framework::automation_registry_state {
     /// Error will be returned if entry with specified ID does not exist.
     public (friend) fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
         let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), ETASK_NOT_FOUND);
         enumerable_map::get_value(&automation_task_metadata.tasks, id)
     }
 
@@ -237,6 +259,11 @@ module supra_framework::automation_registry_state {
     }
 
     #[test_only]
+    const PARENT_HASH: vector<u8> = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+    #[test_only]
+    const PAYLOAD: vector<u8> = x"0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20101112131415161718191a1b1c1d1e1f20";
+
+    #[test_only]
     fun initialize_registry_state_test(framework: &signer) {
         timestamp::set_time_has_started_for_testing(framework);
         initialize(framework, 100);
@@ -248,83 +275,163 @@ module supra_framework::automation_registry_state {
 
         let account = account::create_account_for_test(@0x123456);
         register(&account,
-            vector[0, 1, 2, 3, 4],
+            PAYLOAD,
         100,
         10,
         20,
         1,
-        vector[0, 1, 2 ,3],
+        PARENT_HASH,
         );
         assert!(1 == get_next_task_index(), 1);
         assert!(10 == get_gas_committed_for_next_epoch(), 1)
     }
 
     #[test(framework = @supra_framework)]
-    #[expected_failure(abort_code = 2)]
+    #[expected_failure(abort_code = EINVALID_EXPIRY_TIME, location = Self)]
+    fun check_registration_invalid_expiry_time(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        timestamp::update_global_time_for_test_secs(50);
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            25,
+            70,
+            20,
+            1,
+            PARENT_HASH,
+        );
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EINVALID_GAS_PRICE, location = Self)]
+    fun check_registration_invalid_gas_price_cap(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            25,
+            70,
+            0,
+            1,
+            PARENT_HASH,
+        );
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EINVALID_MAX_GAS_AMOUNT, location = Self)]
+    fun check_registration_invalid_max_gas_amount(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            25,
+            0,
+            70,
+            1,
+            PARENT_HASH,
+        );
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EINVALID_PAYLOAD, location = Self)]
+    fun check_registration_invalid_payload(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            vector[],
+            25,
+            10,
+            70,
+            1,
+            PARENT_HASH,
+        );
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EINVALID_TXN_HASH, location = Self)]
+    fun check_registration_invalid_parent_hash(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            25,
+            10,
+            70,
+            1,
+            vector<u8>[0, 1, 2, 3],
+        );
+    }
+
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EGAS_AMOUNT_UPPER, location = Self)]
     fun check_registration_with_overflow_gas_limit(framework: signer) acquires AutomationRegistryState {
         initialize_registry_state_test(&framework);
 
         let account = account::create_account_for_test(@0x123456);
         register(&account,
-            vector[0, 1, 2, 3, 4],
+            PAYLOAD,
             100,
             70,
             20,
             1,
-            vector[0, 1, 2 ,3],
+            PARENT_HASH
         );
         assert!(1 == get_next_task_index(), 1);
         assert!(70 == get_gas_committed_for_next_epoch(), 1);
         register(&account,
-            vector[0, 1, 2, 3, 4],
+            PAYLOAD,
             100,
             70,
             20,
             1,
-            vector[0, 1, 2 ,3],
+            PARENT_HASH
         );
     }
 
     #[test(framework = @supra_framework)]
     fun check_task_activation_on_new_epoch(framework: signer) acquires AutomationRegistryState {
         initialize_registry_state_test(&framework);
-        let payload_tx = vector<u8>[0, 1, 2, 3, 4];
-        let txn_hash = vector<u8>[1, 2, 3, 4, 5];
 
         let account = account::create_account_for_test(@0x123456);
         register(&account,
-            payload_tx,
+            PAYLOAD,
             100,
             10,
             20,
             1,
-            txn_hash,
+            PARENT_HASH
         );
         // When moving to next epoch this task will be considered as expired
         register(&account,
-            payload_tx,
+            PAYLOAD,
             25,
             10,
             20,
             1,
-            txn_hash,
+            PARENT_HASH
         );
         register(&account,
-            payload_tx,
+            PAYLOAD,
             150,
             10,
             20,
             1,
-            txn_hash,
+            PARENT_HASH
         );
         // When moving to next epoch this task will be considered as expired for the updcoming new epoch
         register(&account,
-            payload_tx,
+            PAYLOAD,
             75,
             10,
             20,
             1,
-            txn_hash,
+            PARENT_HASH
         );
         // No active task and committed gas for the next epoch is total of the all registered tasks
         assert!(40 == get_gas_committed_for_next_epoch(), 1);

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -96,7 +96,7 @@ module supra_framework::automation_registry_state {
         id: u64
     }
 
-    public fun task_expiry_time(task: &AutomationTaskMetaData): u64 {
+    public(friend) fun task_expiry_time(task: &AutomationTaskMetaData): u64 {
         task.expiry_time
     }
 
@@ -111,6 +111,7 @@ module supra_framework::automation_registry_state {
             automation_gas_limit
         })
     }
+
     public(friend) fun on_new_epoch(epoch_interval_micro: u64) acquires AutomationRegistryState {
         let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
         let ids = enumerable_map::get_map_list(&state.tasks);
@@ -255,7 +256,7 @@ module supra_framework::automation_registry_state {
     public(friend) fun has_active_task_with_id(id: u64): bool acquires AutomationRegistryState {
         let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
         if (enumerable_map::contains(&automation_task_metadata.tasks, id)) {
-            let value = enumerable_map::get_value(&automation_task_metadata.tasks, id);
+            let value = enumerable_map::get_value_ref(&automation_task_metadata.tasks, id);
             value.state != PENDING
         } else  {
             false

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -11,6 +11,8 @@ module supra_framework::automation_registry_state {
 
     use supra_framework::system_addresses;
     use supra_framework::timestamp;
+    #[test_only]
+    use supra_framework::account;
 
     friend supra_framework::automation_registry;
     friend supra_framework::block;
@@ -23,7 +25,12 @@ module supra_framework::automation_registry_state {
     const EAUTOMATION_TASK_NOT_EXIST: u64 = 3;
     /// Unauthorized access: the caller is not the owner of the task
     const EUNAUTHORIZED_TASK_OWNER: u64 = 4;
+    /// Upon new epoch entry failed to propertly calculated committed gas for the next epoch.
+    /// It is greater than current epoch committed gas.
+    const EINVALID_COMMITTED_GAS_CALCULATION: u64 = 5;
 
+    /// Conversion factor between microseconds and second
+    const MICROSECS_CONVERSION_FACTOR: u64 = 1_000_000;
     /// It tracks entries both pending and completed, organized by unique indices.
     struct AutomationRegistryState has key, store {
         /// A collection of automation task entries that are active state.
@@ -85,10 +92,11 @@ module supra_framework::automation_registry_state {
             automation_gas_limit
         })
     }
-    public(friend) fun on_new_epoch(epoch_interval: u64) acquires AutomationRegistryState {
+    public(friend) fun on_new_epoch(epoch_interval_micro: u64) acquires AutomationRegistryState {
         let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
         let ids = enumerable_map::get_map_list(&state.tasks);
 
+        let epoch_interval_secs = epoch_interval_micro / MICROSECS_CONVERSION_FACTOR;
         let current_time = timestamp::now_seconds();
         let expired_task_gas = 0;
 
@@ -97,7 +105,7 @@ module supra_framework::automation_registry_state {
             let task = enumerable_map::get_value_mut(&mut state.tasks, id);
 
             // Tasks that are active during this new epoch but will be already expired for the next epoch
-            if (task.expiry_time <= (current_time + epoch_interval)) {
+            if (task.expiry_time <= (current_time + epoch_interval_secs)) {
                 expired_task_gas = expired_task_gas + task.max_gas_amount;
             };
 
@@ -107,6 +115,7 @@ module supra_framework::automation_registry_state {
                 task.is_active = true;
             }
         });
+        assert!(expired_task_gas <= state.gas_committed_for_next_epoch, EINVALID_COMMITTED_GAS_CALCULATION);
 
         // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
         state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
@@ -150,16 +159,16 @@ module supra_framework::automation_registry_state {
 
     /// Remove Automatioon task entry.
     public (friend) fun remove_task(owner: &signer, id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
-        let automation_registry = borrow_global_mut<AutomationRegistryState>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_registry.tasks, id), EAUTOMATION_TASK_NOT_EXIST);
+        let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        assert!(enumerable_map::contains(&state.tasks, id), EAUTOMATION_TASK_NOT_EXIST);
 
-        let automation_task_metadata = enumerable_map::get_value(&automation_registry.tasks, id);
+        let automation_task_metadata = enumerable_map::get_value(&state.tasks, id);
         assert!(automation_task_metadata.owner == signer::address_of(owner), EUNAUTHORIZED_TASK_OWNER);
 
-        enumerable_map::remove_value(&mut automation_registry.tasks, id);
+        enumerable_map::remove_value(&mut state.tasks, id);
 
         // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+        state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
 
         event::emit(RemoveAutomationTask { id: automation_task_metadata.id });
         // todo : return refund amount to user
@@ -173,21 +182,21 @@ module supra_framework::automation_registry_state {
     ) acquires AutomationRegistryState {
         system_addresses::assert_supra_framework(supra_framework);
 
-        let automation_registry = borrow_global_mut<AutomationRegistryState>(@supra_framework);
-        automation_registry.automation_gas_limit = automation_gas_limit;
+        let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        state.automation_gas_limit = automation_gas_limit;
 
         event::emit(UpdateAutomationGasLimit { automation_gas_limit });
     }
 
     /// List all the automation task ids
     public(friend) fun get_active_task_ids(): vector<u64> acquires AutomationRegistryState {
-        let automation_registry = borrow_global<AutomationRegistryState>(@supra_framework);
+        let state = borrow_global<AutomationRegistryState>(@supra_framework);
 
         let active_task_ids = vector[];
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+        let ids = enumerable_map::get_map_list(&state.tasks);
 
         vector::for_each(ids, |id| {
-            let task = enumerable_map::get_value(&automation_registry.tasks, id);
+            let task = enumerable_map::get_value(&state.tasks, id);
             if (task.is_active) {
                 vector::push_back(&mut active_task_ids, id);
             };
@@ -221,4 +230,116 @@ module supra_framework::automation_registry_state {
         state.current_index
     }
 
+    /// Ge gas committed for next epoch
+    public(friend) fun get_gas_committed_for_next_epoch(): u64 acquires AutomationRegistryState {
+        let state = borrow_global<AutomationRegistryState>(@supra_framework);
+        state.gas_committed_for_next_epoch
+    }
+
+    #[test_only]
+    fun initialize_registry_state_test(framework: &signer) {
+        timestamp::set_time_has_started_for_testing(framework);
+        initialize(framework, 100);
+    }
+
+    #[test(framework = @supra_framework)]
+    fun check_task_registration(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            vector[0, 1, 2, 3, 4],
+        100,
+        10,
+        20,
+        1,
+        vector[0, 1, 2 ,3],
+        );
+        assert!(1 == get_next_task_index(), 1);
+        assert!(10 == get_gas_committed_for_next_epoch(), 1)
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = 2)]
+    fun check_registration_with_overflow_gas_limit(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            vector[0, 1, 2, 3, 4],
+            100,
+            70,
+            20,
+            1,
+            vector[0, 1, 2 ,3],
+        );
+        assert!(1 == get_next_task_index(), 1);
+        assert!(70 == get_gas_committed_for_next_epoch(), 1);
+        register(&account,
+            vector[0, 1, 2, 3, 4],
+            100,
+            70,
+            20,
+            1,
+            vector[0, 1, 2 ,3],
+        );
+    }
+
+    #[test(framework = @supra_framework)]
+    fun check_task_activation_on_new_epoch(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+        let payload_tx = vector<u8>[0, 1, 2, 3, 4];
+        let txn_hash = vector<u8>[1, 2, 3, 4, 5];
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            payload_tx,
+            100,
+            10,
+            20,
+            1,
+            txn_hash,
+        );
+        // When moving to next epoch this task will be considered as expired
+        register(&account,
+            payload_tx,
+            25,
+            10,
+            20,
+            1,
+            txn_hash,
+        );
+        register(&account,
+            payload_tx,
+            150,
+            10,
+            20,
+            1,
+            txn_hash,
+        );
+        // When moving to next epoch this task will be considered as expired for the updcoming new epoch
+        register(&account,
+            payload_tx,
+            75,
+            10,
+            20,
+            1,
+            txn_hash,
+        );
+        // No active task and committed gas for the next epoch is total of the all registered tasks
+        assert!(40 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        assert!(active_task_ids == vector[], 1);
+
+        timestamp::update_global_time_for_test_secs(50);
+        on_new_epoch(30 * MICROSECS_CONVERSION_FACTOR);
+        // Committed gas for the next epoch only for 2 tasks 0 and 2, the task 3 will not be active during upcoming epoch
+        assert!(20 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        // But here task 3 is in the active list as it is still active in this new epoch.
+        let expected_ids = vector<u64>[0, 2, 3];
+        vector::for_each(active_task_ids, |id| {
+            assert!(vector::contains(&expected_ids, &id), 1);
+        })
+    }
 }

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -12,7 +12,6 @@ module supra_framework::automation_registry_state {
     use supra_framework::system_addresses;
     use supra_framework::timestamp;
 
-    friend supra_framework::genesis;
     friend supra_framework::automation_registry;
     friend supra_framework::block;
 
@@ -197,8 +196,7 @@ module supra_framework::automation_registry_state {
     }
 
     /// Retrieves the details of a automation task entry by its ID.
-    /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
-    /// and the second element contains the `AutomationTaskMetaData` details.
+    /// Error will be returned if entry with specified ID does not exist.
     public (friend) fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
         let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
         assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -91,8 +91,8 @@ module supra_framework::automation_registry_state {
     }
 
     #[event]
-    /// Remove automation task registry event
-    struct CanclledAutomationTask has drop, store {
+    /// Cancelled automation task registry event
+    struct CancelledAutomationTask has drop, store {
         id: u64
     }
 
@@ -205,7 +205,7 @@ module supra_framework::automation_registry_state {
         // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
         state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
 
-        event::emit(CanclledAutomationTask { id: automation_task_metadata.id });
+        event::emit(CancelledAutomationTask { id: automation_task_metadata.id });
         automation_task_metadata
     }
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -1,0 +1,226 @@
+/// Supra Automation Registry State
+///
+/// This contract is part of the Supra Framework and is designed to manage automated task entries
+module supra_framework::automation_registry_state {
+
+    use std::signer;
+    use std::vector;
+    use supra_framework::event;
+
+    use supra_std::enumerable_map::{Self, EnumerableMap};
+
+    use supra_framework::system_addresses;
+    use supra_framework::timestamp;
+
+    friend supra_framework::genesis;
+    friend supra_framework::automation_registry;
+    friend supra_framework::block;
+
+    /// Registry Id not found
+    const EREGITRY_NOT_FOUND: u64 = 1;
+    /// Gas amount does not go beyond upper cap limit
+    const EGAS_AMOUNT_UPPER: u64 = 2;
+    /// Automation task not found
+    const EAUTOMATION_TASK_NOT_EXIST: u64 = 3;
+    /// Unauthorized access: the caller is not the owner of the task
+    const EUNAUTHORIZED_TASK_OWNER: u64 = 4;
+
+    /// It tracks entries both pending and completed, organized by unique indices.
+    struct AutomationRegistryState has key, store {
+        /// A collection of automation task entries that are active state.
+        tasks: EnumerableMap<u64, AutomationTaskMetaData>,
+        current_index: u64,
+        gas_committed_for_next_epoch: u64,
+        automation_gas_limit: u64,
+    }
+
+    #[event]
+    /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
+    struct AutomationTaskMetaData has copy, store, drop {
+        /// Automation task index in registry
+        id: u64,
+        /// The address of the task owner.
+        owner: address,
+        /// The function signature associated with the registry entry.
+        payload_tx: vector<u8>,
+        /// Expiry of the task, represented in a timestamp in second.
+        expiry_time: u64,
+        /// The transaction hash of the request transaction.
+        tx_hash: vector<u8>,
+        /// Max gas amount of automation task
+        max_gas_amount: u64,
+        /// Maximum gas price cap for the task
+        gas_price_cap: u64,
+        /// Registration epoch number
+        registration_epoch: u64,
+        /// Registration epoch time
+        registration_time: u64,
+        /// Flag indicating whether the task is active.
+        is_active: bool
+    }
+
+    #[event]
+    /// Update automation gas limit event
+    struct UpdateAutomationGasLimit has drop, store {
+        automation_gas_limit: u64
+    }
+
+    #[event]
+    /// Remove automation task registry event
+    struct RemoveAutomationTask has drop, store {
+        id: u64
+    }
+
+    public fun task_expiry_time(task: &AutomationTaskMetaData): u64 {
+        task.expiry_time
+    }
+
+    // todo : this function should call during initialzation, but since we already done genesis in that case who can access the function
+    public(friend) fun initialize(supra_framework: &signer, automation_gas_limit: u64) {
+        system_addresses::assert_supra_framework(supra_framework);
+
+        move_to(supra_framework, AutomationRegistryState {
+            tasks: enumerable_map::new_map(),
+            current_index: 0,
+            gas_committed_for_next_epoch: 0,
+            automation_gas_limit
+        })
+    }
+    public(friend) fun on_new_epoch(epoch_interval: u64) acquires AutomationRegistryState {
+        let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        let ids = enumerable_map::get_map_list(&state.tasks);
+
+        let current_time = timestamp::now_seconds();
+        let expired_task_gas = 0;
+
+        // Perform clean up and updation of state
+        vector::for_each(ids, |id| {
+            let task = enumerable_map::get_value_mut(&mut state.tasks, id);
+
+            // Tasks that are active during this new epoch but will be already expired for the next epoch
+            if (task.expiry_time <= (current_time + epoch_interval)) {
+                expired_task_gas = expired_task_gas + task.max_gas_amount;
+            };
+
+            if (task.expiry_time <= current_time) {
+                enumerable_map::remove_value(&mut state.tasks, id);
+            } else {
+                task.is_active = true;
+            }
+        });
+
+        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+        state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
+    }
+
+
+    /// Registers a new automation task entry.
+    public(friend) fun register(
+        owner: &signer,
+        payload_tx: vector<u8>,
+        expiry_time: u64,
+        max_gas_amount: u64,
+        gas_price_cap: u64,
+        registration_epoch: u64,
+        tx_hash: vector<u8>,
+    ) acquires AutomationRegistryState {
+        let registry_data = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+
+        let committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
+        assert!(committed_gas < registry_data.automation_gas_limit, EGAS_AMOUNT_UPPER);
+        registry_data.gas_committed_for_next_epoch = committed_gas;
+        let task_index = registry_data.current_index;
+
+        let automation_task_metadata = AutomationTaskMetaData {
+            id: task_index,
+            owner: signer::address_of(owner),
+            payload_tx,
+            expiry_time,
+            max_gas_amount,
+            gas_price_cap,
+            is_active: false,
+            registration_epoch,
+            registration_time: timestamp::now_seconds(),
+            tx_hash,
+        };
+
+        enumerable_map::add_value(&mut registry_data.tasks, task_index, automation_task_metadata);
+        registry_data.current_index = registry_data.current_index + 1;
+        event::emit(automation_task_metadata);
+    }
+
+    /// Remove Automatioon task entry.
+    public (friend) fun remove_task(owner: &signer, id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
+        let automation_registry = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_registry.tasks, id), EAUTOMATION_TASK_NOT_EXIST);
+
+        let automation_task_metadata = enumerable_map::get_value(&automation_registry.tasks, id);
+        assert!(automation_task_metadata.owner == signer::address_of(owner), EUNAUTHORIZED_TASK_OWNER);
+
+        enumerable_map::remove_value(&mut automation_registry.tasks, id);
+
+        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+        automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+
+        event::emit(RemoveAutomationTask { id: automation_task_metadata.id });
+        // todo : return refund amount to user
+        automation_task_metadata
+    }
+
+    /// Update Automation gas limit
+    public (friend) fun update_automation_gas_limit(
+        supra_framework: &signer,
+        automation_gas_limit: u64
+    ) acquires AutomationRegistryState {
+        system_addresses::assert_supra_framework(supra_framework);
+
+        let automation_registry = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        automation_registry.automation_gas_limit = automation_gas_limit;
+
+        event::emit(UpdateAutomationGasLimit { automation_gas_limit });
+    }
+
+    /// List all the automation task ids
+    public(friend) fun get_active_task_ids(): vector<u64> acquires AutomationRegistryState {
+        let automation_registry = borrow_global<AutomationRegistryState>(@supra_framework);
+
+        let active_task_ids = vector[];
+        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+
+        vector::for_each(ids, |id| {
+            let task = enumerable_map::get_value(&automation_registry.tasks, id);
+            if (task.is_active) {
+                vector::push_back(&mut active_task_ids, id);
+            };
+        });
+        return active_task_ids
+    }
+
+    /// Retrieves the details of a automation task entry by its ID.
+    /// Returns a tuple where the first element indicates if the registry is completed/failed (`true`) or pending (`false`),
+    /// and the second element contains the `AutomationTaskMetaData` details.
+    public (friend) fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
+        let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EREGITRY_NOT_FOUND);
+        enumerable_map::get_value(&automation_task_metadata.tasks, id)
+    }
+
+    /// Checks whether there is an active task in registry with specified input task id.
+    public fun has_active_task_with_id(id: u64): bool acquires AutomationRegistryState {
+        let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
+        if (enumerable_map::contains(&automation_task_metadata.tasks, id)) {
+            // TODO: uncomment when activation of the tasks on new epoch is enabled.
+            let value = enumerable_map::get_value(&automation_task_metadata.tasks, id);
+            value.is_active
+        } else  {
+            false
+        }
+    }
+
+    /// Returns next task index in registry
+    public (friend) fun get_next_task_index(): u64 acquires AutomationRegistryState {
+        let state = borrow_global<AutomationRegistryState>(@supra_framework);
+        state.current_index
+    }
+
+}

--- a/aptos-move/framework/supra-framework/sources/automation_registry_state.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry_state.move
@@ -24,28 +24,31 @@ module supra_framework::automation_registry_state {
     /// Invalid max gas amount for automated task: it cannot be zero
     const EINVALID_MAX_GAS_AMOUNT: u64 = 3;
     /// Task with provided Id not found
-    const ETASK_NOT_FOUND: u64 = 4;
+    const EAUTOMATION_TASK_NOT_FOUND: u64 = 4;
     /// Gas amount does not go beyond upper cap limit
     const EGAS_AMOUNT_UPPER: u64 = 5;
-    /// Automation task not found
-    const EAUTOMATION_TASK_NOT_EXIST: u64 = 6;
     /// Unauthorized access: the caller is not the owner of the task
-    const EUNAUTHORIZED_TASK_OWNER: u64 = 7;
+    const EUNAUTHORIZED_TASK_OWNER: u64 = 6;
     /// Upon new epoch entry failed to propertly calculated committed gas for the next epoch.
     /// It is greater than current epoch committed gas.
-    const EINVALID_COMMITTED_GAS_CALCULATION: u64 = 8;
+    const EINVALID_COMMITTED_GAS_CALCULATION: u64 = 7;
     /// Transactoin hash that registring current task is invalid. Lenght should be 32.
-    /// It is greater than current epoch committed gas.
-    const EINVALID_TXN_HASH: u64 = 9;
-    /// Transactoin hash that registring current task is invalid. Lenght should be 32.
-    /// It is greater than current epoch committed gas.
-    const EINVALID_PAYLOAD: u64 = 10;
+    const EINVALID_TXN_HASH: u64 = 8;
+    /// Current committed gas amount is greater than the automation gas limit.
+    const EUNACCEPTABLE_AUTOMATION_GAS_LIMIT: u64 = 9;
+    /// Trying to cancel a task which is already cancelled.
+    const EINVALID_CANCELLATION: u64 = 10;
 
     /// The lenght of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
 
     /// Conversion factor between microseconds and second
     const MICROSECS_CONVERSION_FACTOR: u64 = 1_000_000;
+
+    /// Constants describing task state.
+    const PENDING: u8 = 0;
+    const ACTIVE: u8 = 1;
+    const CANCELLED: u8 = 2;
 
     /// It tracks entries both pending and completed, organized by unique indices.
     struct AutomationRegistryState has key, store {
@@ -77,8 +80,8 @@ module supra_framework::automation_registry_state {
         registration_epoch: u64,
         /// Registration epoch time
         registration_time: u64,
-        /// Flag indicating whether the task is active.
-        is_active: bool
+        /// Flag indicating whether the task is active, canclled or pending.
+        state: u8
     }
 
     #[event]
@@ -89,7 +92,7 @@ module supra_framework::automation_registry_state {
 
     #[event]
     /// Remove automation task registry event
-    struct RemoveAutomationTask has drop, store {
+    struct CanclledAutomationTask has drop, store {
         id: u64
     }
 
@@ -114,27 +117,26 @@ module supra_framework::automation_registry_state {
 
         let epoch_interval_secs = epoch_interval_micro / MICROSECS_CONVERSION_FACTOR;
         let current_time = timestamp::now_seconds();
-        let expired_task_gas = 0;
+        let gas_committed_for_next_epoch = 0;
 
         // Perform clean up and updation of state
         vector::for_each(ids, |id| {
             let task = enumerable_map::get_value_mut(&mut state.tasks, id);
 
-            // Tasks that are active during this new epoch but will be already expired for the next epoch
-            if (task.expiry_time <= (current_time + epoch_interval_secs)) {
-                expired_task_gas = expired_task_gas + task.max_gas_amount;
+            // Tasks that are active during next epoch and are not cancled
+            if (task.state != CANCELLED && task.expiry_time > (current_time + epoch_interval_secs) ) {
+                gas_committed_for_next_epoch = gas_committed_for_next_epoch + task.max_gas_amount;
             };
 
-            if (task.expiry_time <= current_time) {
+            // Drop or activate task
+            if (task.expiry_time <= current_time || task.state == CANCELLED) {
                 enumerable_map::remove_value(&mut state.tasks, id);
             } else {
-                task.is_active = true;
+                task.state = ACTIVE;
             }
         });
-        assert!(expired_task_gas <= state.gas_committed_for_next_epoch, EINVALID_COMMITTED_GAS_CALCULATION);
 
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
-        state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - expired_task_gas;
+        state.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
     }
 
     /// Registers a new automation task entry.
@@ -154,7 +156,6 @@ module supra_framework::automation_registry_state {
         assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
         assert!(max_gas_amount > 0, EINVALID_MAX_GAS_AMOUNT);
         assert!(vector::length(&tx_hash) == TXN_HASH_LENGTH, EINVALID_TXN_HASH);
-        assert!(!vector::is_empty(&payload_tx), EINVALID_PAYLOAD);
 
         let committed_gas = registry_data.gas_committed_for_next_epoch + max_gas_amount;
         assert!(committed_gas < registry_data.automation_gas_limit, EGAS_AMOUNT_UPPER);
@@ -168,7 +169,7 @@ module supra_framework::automation_registry_state {
             expiry_time,
             max_gas_amount,
             gas_price_cap,
-            is_active: false,
+            state: PENDING,
             registration_epoch,
             registration_time,
             tx_hash,
@@ -179,21 +180,28 @@ module supra_framework::automation_registry_state {
         event::emit(automation_task_metadata);
     }
 
-    /// Remove Automatioon task entry.
-    public (friend) fun remove_task(owner: &signer, id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
+    /// Cancel Automation task with specified id.
+    /// If the task was active its state is updated to be CANCELLED. Otherwise task is removed form the list.
+    /// Committed gas-limit is updated accordingly.
+    /// Only existing task can be cancled and only by task onwer.
+    public (friend) fun cancel_task(owner: &signer, id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
         let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
-        assert!(enumerable_map::contains(&state.tasks, id), EAUTOMATION_TASK_NOT_EXIST);
+        assert!(enumerable_map::contains(&state.tasks, id), EAUTOMATION_TASK_NOT_FOUND);
 
         let automation_task_metadata = enumerable_map::get_value(&state.tasks, id);
         assert!(automation_task_metadata.owner == signer::address_of(owner), EUNAUTHORIZED_TASK_OWNER);
+        assert!(automation_task_metadata.state != CANCELLED, EINVALID_CANCELLATION);
+        if (automation_task_metadata.state == PENDING) {
+            enumerable_map::remove_value(&mut state.tasks, id);
+        } else if (automation_task_metadata.state == ACTIVE) {
+            automation_task_metadata.state = CANCELLED;
+            enumerable_map::update_value(&mut state.tasks, id, automation_task_metadata);
+        };
 
-        enumerable_map::remove_value(&mut state.tasks, id);
-
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the expired task
+        // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
         state.gas_committed_for_next_epoch = state.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
 
-        event::emit(RemoveAutomationTask { id: automation_task_metadata.id });
-        // todo : return refund amount to user
+        event::emit(CanclledAutomationTask { id: automation_task_metadata.id });
         automation_task_metadata
     }
 
@@ -205,6 +213,8 @@ module supra_framework::automation_registry_state {
         system_addresses::assert_supra_framework(supra_framework);
 
         let state = borrow_global_mut<AutomationRegistryState>(@supra_framework);
+        assert!(state.gas_committed_for_next_epoch < automation_gas_limit, EUNACCEPTABLE_AUTOMATION_GAS_LIMIT);
+
         state.automation_gas_limit = automation_gas_limit;
 
         event::emit(UpdateAutomationGasLimit { automation_gas_limit });
@@ -219,7 +229,7 @@ module supra_framework::automation_registry_state {
 
         vector::for_each(ids, |id| {
             let task = enumerable_map::get_value(&state.tasks, id);
-            if (task.is_active) {
+            if (task.state != PENDING) {
                 vector::push_back(&mut active_task_ids, id);
             };
         });
@@ -230,20 +240,24 @@ module supra_framework::automation_registry_state {
     /// Error will be returned if entry with specified ID does not exist.
     public (friend) fun get_task_details(id: u64): AutomationTaskMetaData acquires AutomationRegistryState {
         let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), ETASK_NOT_FOUND);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, id), EAUTOMATION_TASK_NOT_FOUND);
         enumerable_map::get_value(&automation_task_metadata.tasks, id)
     }
 
     /// Checks whether there is an active task in registry with specified input task id.
-    public fun has_active_task_with_id(id: u64): bool acquires AutomationRegistryState {
+    public(friend) fun has_active_task_with_id(id: u64): bool acquires AutomationRegistryState {
         let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
         if (enumerable_map::contains(&automation_task_metadata.tasks, id)) {
-            // TODO: uncomment when activation of the tasks on new epoch is enabled.
             let value = enumerable_map::get_value(&automation_task_metadata.tasks, id);
-            value.is_active
+            value.state != PENDING
         } else  {
             false
         }
+    }
+    #[test_only]
+    fun has_task_with_id(id: u64): bool acquires AutomationRegistryState {
+        let automation_task_metadata = borrow_global<AutomationRegistryState>(@supra_framework);
+        enumerable_map::contains(&automation_task_metadata.tasks, id)
     }
 
     /// Returns next task index in registry
@@ -267,6 +281,43 @@ module supra_framework::automation_registry_state {
     fun initialize_registry_state_test(framework: &signer) {
         timestamp::set_time_has_started_for_testing(framework);
         initialize(framework, 100);
+    }
+
+    #[test(framework = @supra_framework)]
+    fun check_automation_gas_limit_success_update(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            100,
+            50,
+            20,
+            1,
+            PARENT_HASH,
+        );
+
+        // Next epoch gas committed gas is less than the new limit value.
+        update_automation_gas_limit(&framework, 75);
+        let state = borrow_global<AutomationRegistryState>(@supra_framework);
+        assert!(state.automation_gas_limit == 75, 1);
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EUNACCEPTABLE_AUTOMATION_GAS_LIMIT, location = Self)]
+    fun check_automation_gas_limit_failed_update(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            100,
+            50,
+            20,
+            1,
+            PARENT_HASH,
+        );
+
+        // Next epoch gas committed gas is greater than the new limit value.
+        update_automation_gas_limit(&framework, 45);
     }
 
     #[test(framework = @supra_framework)]
@@ -329,22 +380,6 @@ module supra_framework::automation_registry_state {
             PAYLOAD,
             25,
             0,
-            70,
-            1,
-            PARENT_HASH,
-        );
-    }
-
-    #[test(framework = @supra_framework)]
-    #[expected_failure(abort_code = EINVALID_PAYLOAD, location = Self)]
-    fun check_registration_invalid_payload(framework: signer) acquires AutomationRegistryState {
-        initialize_registry_state_test(&framework);
-
-        let account = account::create_account_for_test(@0x123456);
-        register(&account,
-            vector[],
-            25,
-            10,
             70,
             1,
             PARENT_HASH,
@@ -433,6 +468,7 @@ module supra_framework::automation_registry_state {
             1,
             PARENT_HASH
         );
+
         // No active task and committed gas for the next epoch is total of the all registered tasks
         assert!(40 == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
@@ -447,6 +483,141 @@ module supra_framework::automation_registry_state {
         let expected_ids = vector<u64>[0, 2, 3];
         vector::for_each(active_task_ids, |id| {
             assert!(vector::contains(&expected_ids, &id), 1);
-        })
+        });
+    }
+
+    #[test(framework = @supra_framework)]
+    fun check_task_successful_cancellation(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            100,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+        // When moving to next epoch this task will be considered as expired
+        register(&account,
+            PAYLOAD,
+            25,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+        register(&account,
+            PAYLOAD,
+            150,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+        // When moving to next epoch this task will be considered as expired for the updcoming new epoch
+        register(&account,
+            PAYLOAD,
+            75,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+
+        timestamp::update_global_time_for_test_secs(50);
+        on_new_epoch(30 * MICROSECS_CONVERSION_FACTOR);
+        // Committed gas for the next epoch only for 2 tasks 0 and 2, the task 3 will not be active during upcoming epoch
+        assert!(20 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        // But here task 3 is in the active list as it is still active in this new epoch.
+        let expected_ids = vector<u64>[0, 2, 3];
+        vector::for_each(active_task_ids, |id| {
+            assert!(vector::contains(&expected_ids, &id), 1);
+        });
+
+        // Cancle task 2. The committed gas for the next epoch will be updated,
+        // but when requested active task it will be still available in the list
+        cancel_task(&account, 2);
+        // Task will be still available in the registry but with cancled state
+        let task_2_details = get_task_details(2);
+        assert!(task_2_details.state == CANCELLED, 1);
+
+        assert!(10 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        let expected_ids = vector<u64>[0, 2, 3];
+        vector::for_each(active_task_ids, |id| {
+            assert!(vector::contains(&expected_ids, &id), 1);
+        });
+
+        // Add and cancel the task in the same epoch. Task index will be 4
+        assert!(get_next_task_index() == 4, 1);
+        register(&account,
+            PAYLOAD,
+            75,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+        cancel_task(&account, 4);
+        assert!(10 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        let expected_ids = vector<u64>[0, 2, 3];
+        vector::for_each(active_task_ids, |id| {
+            assert!(vector::contains(&expected_ids, &id), 1);
+        });
+        // there is no task with index 4 and the next task index will be 5.
+        assert!(!has_task_with_id(4), 1);
+        assert!(get_next_task_index() == 5, 1)
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EAUTOMATION_TASK_NOT_FOUND, location = Self)]
+    fun check_cancellation_of_non_existing_task(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        cancel_task(&account, 1);
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EUNAUTHORIZED_TASK_OWNER, location = Self)]
+    fun check_unauthorized_cancellation_(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account1 = account::create_account_for_test(@0x123456);
+        let account2 = account::create_account_for_test(@0x654321);
+        register(&account1,
+            PAYLOAD,
+            75,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+        cancel_task(&account2, 0);
+    }
+
+    #[test(framework = @supra_framework)]
+    #[expected_failure(abort_code = EINVALID_CANCELLATION, location = Self)]
+    fun check_cacellation_of_cancelled_task(framework: signer) acquires AutomationRegistryState {
+        initialize_registry_state_test(&framework);
+
+        let account = account::create_account_for_test(@0x123456);
+        register(&account,
+            PAYLOAD,
+            100,
+            10,
+            20,
+            1,
+            PARENT_HASH
+        );
+        timestamp::update_global_time_for_test_secs(50);
+        on_new_epoch(30 * MICROSECS_CONVERSION_FACTOR);
+        // Cancel the same task 2 times
+        cancel_task(&account, 0);
+        cancel_task(&account, 0);
     }
 }

--- a/aptos-move/framework/supra-framework/sources/block.move
+++ b/aptos-move/framework/supra-framework/sources/block.move
@@ -6,6 +6,7 @@ module supra_framework::block {
     use std::option;
     use aptos_std::table_with_length::{Self, TableWithLength};
     use std::option::Option;
+    use supra_framework::automation_registry_state;
     use supra_framework::randomness;
 
     use supra_framework::account;
@@ -235,6 +236,7 @@ module supra_framework::block {
         randomness::on_new_block(&vm, epoch, round, option::none());
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
             reconfiguration::reconfigure();
+            automation_registry_state::on_new_epoch(epoch_interval);
         };
     }
 
@@ -264,6 +266,7 @@ module supra_framework::block {
 
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
             reconfiguration_with_dkg::try_start();
+            automation_registry_state::on_new_epoch(epoch_interval);
         };
     }
 

--- a/aptos-move/framework/supra-framework/sources/transaction_context.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_context.move
@@ -132,14 +132,6 @@ module supra_framework::transaction_context {
     }
     native fun entry_function_payload_internal(): Option<EntryFunctionPayload>;
 
-    /// Returns the original transaction hash calculated on the raw-bytes.
-    /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
-    public fun txn_app_hash(): vector<u8> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
-        txn_app_hash_internal()
-    }
-    native fun txn_app_hash_internal(): vector<u8>;
-
     /// Returns the account address of the entry function payload.
     public fun account_address(payload: &EntryFunctionPayload): address {
         assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
@@ -266,12 +258,5 @@ module supra_framework::transaction_context {
     fun test_call_multisig_payload() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _multisig = multisig_payload();
-    }
-
-    #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
-    fun test_call_txn_app_hash() {
-        // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
-        let _txn_app_hash = txn_app_hash();
     }
 }

--- a/aptos-move/framework/supra-stdlib/doc/enumerable_map.md
+++ b/aptos-move/framework/supra-stdlib/doc/enumerable_map.md
@@ -21,6 +21,7 @@ The module includes error handling and a suite of test functions for validation.
 -  [Function `remove_value_bulk`](#0x1_enumerable_map_remove_value_bulk)
 -  [Function `clear`](#0x1_enumerable_map_clear)
 -  [Function `get_value`](#0x1_enumerable_map_get_value)
+-  [Function `get_value_ref`](#0x1_enumerable_map_get_value_ref)
 -  [Function `get_value_mut`](#0x1_enumerable_map_get_value_mut)
 -  [Function `get_map_list`](#0x1_enumerable_map_get_map_list)
 -  [Function `contains`](#0x1_enumerable_map_contains)
@@ -422,6 +423,31 @@ Returns the value of a key that is present in Enumerable Map
 
 <pre><code><b>public</b> <b>fun</b> <a href="enumerable_map.md#0x1_enumerable_map_get_value">get_value</a>&lt;K : <b>copy</b>+drop, V : store+drop+<b>copy</b>&gt;(map: & <a href="enumerable_map.md#0x1_enumerable_map_EnumerableMap">EnumerableMap</a>&lt;K, V&gt;, key: K): V {
     <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&map.map, key).value
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_enumerable_map_get_value_ref"></a>
+
+## Function `get_value_ref`
+
+Returns reference to the value of a key that is present in Enumerable Map
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="enumerable_map.md#0x1_enumerable_map_get_value_ref">get_value_ref</a>&lt;K: <b>copy</b>, drop, V: <b>copy</b>, drop, store&gt;(map: &<a href="enumerable_map.md#0x1_enumerable_map_EnumerableMap">enumerable_map::EnumerableMap</a>&lt;K, V&gt;, key: K): &V
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="enumerable_map.md#0x1_enumerable_map_get_value_ref">get_value_ref</a>&lt;K : <b>copy</b>+drop, V : store+drop+<b>copy</b>&gt;(map: & <a href="enumerable_map.md#0x1_enumerable_map_EnumerableMap">EnumerableMap</a>&lt;K, V&gt;, key: K): &V {
+    &<a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&map.map, key).value
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-stdlib/sources/enumerable_map.move
+++ b/aptos-move/framework/supra-stdlib/sources/enumerable_map.move
@@ -132,6 +132,12 @@ module supra_std::enumerable_map {
         table::borrow(&map.map, key).value
     }
 
+    /// Returns reference to the value of a key that is present in Enumerable Map
+    public fun get_value_ref<K : copy+drop, V : store+drop+copy>(map: & EnumerableMap<K, V>, key: K): &V {
+        &table::borrow(&map.map, key).value
+    }
+
+
     /// Returns the value of a key that is present in Enumerable Map
     public fun get_value_mut<K : copy+drop, V : store+drop+copy>(map: &mut EnumerableMap<K, V>, key: K): &mut V {
         &mut table::borrow_mut(&mut map.map, key).value

--- a/types/src/transaction/automation.rs
+++ b/types/src/transaction/automation.rs
@@ -36,13 +36,14 @@ pub struct RegistrationParams {
 }
 
 impl RegistrationParams {
-    pub fn serialized_args_with_sender(&self, sender: AccountAddress) -> Vec<Vec<u8>> {
+    pub fn serialized_args_with_sender_and_parent_hash(&self, sender: AccountAddress, parent_hash: Vec<u8>) -> Vec<Vec<u8>> {
         serialize_values(&[
             MoveValue::Address(sender),
             MoveValue::vector_u8(bcs::to_bytes(&self.automated_function).unwrap()),
             MoveValue::U64(self.expiration_timestamp_secs),
             MoveValue::U64(self.max_gas_amount),
-            MoveValue::U64(self.gas_price_cap)
+            MoveValue::U64(self.gas_price_cap),
+            MoveValue::vector_u8(parent_hash),
         ])
     }
 }

--- a/types/src/transaction/user_transaction_context.rs
+++ b/types/src/transaction/user_transaction_context.rs
@@ -56,7 +56,6 @@ pub struct UserTransactionContext {
     gas_unit_price: u64,
     chain_id: u8,
     payload_type_reference: PayloadTypeReferenceContext,
-    txn_app_hash: Vec<u8>,
 }
 
 impl UserTransactionContext {
@@ -68,7 +67,6 @@ impl UserTransactionContext {
         gas_unit_price: u64,
         chain_id: u8,
         payload_type_reference: PayloadTypeReferenceContext,
-        txn_app_hash: Vec<u8>,
     ) -> Self {
         Self {
             sender,
@@ -78,7 +76,6 @@ impl UserTransactionContext {
             gas_unit_price,
             chain_id,
             payload_type_reference,
-            txn_app_hash,
         }
     }
 
@@ -116,9 +113,6 @@ impl UserTransactionContext {
 
     pub fn is_automation_registration(&self) -> bool {
         self.payload_type_reference.is_automation_registration()
-    }
-    pub fn txn_app_hash(&self) -> Vec<u8> {
-        self.txn_app_hash.clone()
     }
 }
 


### PR DESCRIPTION
 - split automation registry external API and internal state to avoid circular dependencies
 - enabled automation-registry-state update on new epoch from block module.
