### PR TITLE
Fixed transaction parent hash calculation to match txn hash in smr-moonshot

### DIFF
--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -85,7 +85,7 @@ impl TransactionMetadata {
                 .map(|res| !res.is_empty())
                 .unwrap_or(false),
             payload_type_reference,
-            txn_app_hash: HashValue::sha3_256_of(
+            txn_app_hash: HashValue::keccak_256_of(
                 &bcs::to_bytes(&txn).expect("Unable to serialize SignedTransaction"),
             )
             .to_vec(),

--- a/crates/aptos-crypto/src/hash.rs
+++ b/crates/aptos-crypto/src/hash.rs
@@ -113,7 +113,7 @@ use std::{
     fmt,
     str::FromStr,
 };
-use tiny_keccak::{Hasher, Sha3};
+use tiny_keccak::{Hasher, Sha3, Keccak};
 
 /// A prefix used to begin the salt of every hashable structure. The salt
 /// consists in this global prefix, concatenated with the specified
@@ -182,6 +182,15 @@ impl HashValue {
         HashValue::from_keccak(sha3)
     }
 
+    /// Convenience function that computes a `HashValue` internally equal to
+    /// the keccak_256 of a byte buffer. It will handle hasher creation, data
+    /// feeding and finalization.
+    pub fn keccak_256_of(buffer: &[u8]) -> Self {
+        let mut keccak = Keccak::v256();
+        keccak.update(buffer);
+        HashValue::from_keccak(keccak)
+    }
+
     #[cfg(test)]
     pub fn from_iter_sha3<'a, I>(buffers: I) -> Self
     where
@@ -198,7 +207,7 @@ impl HashValue {
         &mut self.hash[..]
     }
 
-    fn from_keccak(state: Sha3) -> Self {
+    fn from_keccak(state: impl Hasher) -> Self {
         let mut hash = Self::zero();
         state.finalize(hash.as_ref_mut());
         hash

--- a/types/src/transaction/automated_transaction.rs
+++ b/types/src/transaction/automated_transaction.rs
@@ -133,7 +133,7 @@ impl AutomatedTransaction {
     /// Returns the hash of the transaction.
     pub fn hash(&self) -> HashValue {
         *self.hash.get_or_init(|| {
-            HashValue::sha3_256_of(
+            HashValue::keccak_256_of(
                 &bcs::to_bytes(&self).expect("Unable to serialize AutomatedTransaction"),
             )
         })

--- a/types/src/transaction/automated_transaction.rs
+++ b/types/src/transaction/automated_transaction.rs
@@ -164,7 +164,7 @@ macro_rules! value_or_missing {
 #[derive(Clone, Debug)]
 pub enum BuilderResult {
     Success(AutomatedTransaction),
-    GasPriceThresholdExceeded { threshold: u64, value: u64 },
+    GasPriceThresholdExceeded { task_index: u64, threshold: u64, value: u64 },
     MissingValue(&'static str),
 }
 
@@ -173,8 +173,8 @@ impl BuilderResult {
         Self::Success(txn)
     }
 
-    pub fn gas_price_threshold_exceeded(threshold: u64, value: u64) -> BuilderResult {
-        Self::GasPriceThresholdExceeded { threshold, value }
+    pub fn gas_price_threshold_exceeded(task_index: u64, threshold: u64, value: u64) -> BuilderResult {
+        Self::GasPriceThresholdExceeded { task_index, threshold, value }
     }
     pub fn missing_value(missing: &'static str) -> BuilderResult {
         Self::MissingValue(missing)
@@ -271,6 +271,10 @@ impl AutomatedTransactionBuilder {
         self
     }
 
+    pub fn expiration_timestamp_secs(&self) -> u64 {
+        self.expiration_timestamp_secs.unwrap_or(0)
+    }
+
     /// Build an [AutomatedTransaction] instance.
     /// Fails if
     ///    - any of the mandatory fields is missing
@@ -299,7 +303,7 @@ impl AutomatedTransactionBuilder {
         let expiration_timestamp_secs =
             value_or_missing!(expiration_timestamp_secs, "expiration_timestamp_secs");
         if gas_price_cap < gas_unit_price {
-            return BuilderResult::gas_price_threshold_exceeded(gas_price_cap, gas_unit_price);
+            return BuilderResult::gas_price_threshold_exceeded(sequence_number, gas_price_cap, gas_unit_price);
         }
         let raw_transaction = RawTransaction::new(
             sender,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2043,6 +2043,14 @@ impl Transaction {
         }
     }
 
+    pub fn try_as_automated_txn(&self) -> Option<&AutomatedTransaction> {
+        match self {
+            Transaction::AutomatedTransaction(txn) => Some(txn),
+            _ => None,
+        }
+    }
+
+
     pub fn type_name(&self) -> &'static str {
         match self {
             Transaction::UserTransaction(_) => "user_transaction",


### PR DESCRIPTION
- smr moonshot uses Keccak::256 to calcualte the hash of the data. Introduced `HashValue::keccak_256_of` API and utilized it to calcuate `TransactionMetadata::txn_app_hash`