### PR TITLE
Added function for locking previously delegated stake and removed requirement that delegation pool vesting start times be in the future

### DIFF
--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -550,10 +550,10 @@ pub enum EntryFunctionCall {
         stakes: Vec<u64>,
     },
 
-    /// For each `delegator` in `delegators`, locks the amount of stake specified in the same index of `stakes_to_lock`.
-    /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
-    /// to `pool_address` was created. Terminates with an error if any `stake_to_lock` exceeds the stake allocated to
-    /// the corresponding `delegator` in the `DelegationPool` located at `pool_address`.
+    /// Updates the `principle_stake` of each `delegator` in `delegators` according to the amount specified
+    /// at the corresponding index of `new_principle_stakes`. Also ensures that the `delegator`'s `active` stake
+    /// is as close to the specified amount as possible. The locked amount is subject to the vesting schedule
+    /// specified when the delegation pool corresponding to `pool_address` was created.
     ///
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
@@ -562,7 +562,7 @@ pub enum EntryFunctionCall {
     PboDelegationPoolLockDelegatorsStakes {
         pool_address: AccountAddress,
         delegators: Vec<AccountAddress>,
-        stakes_to_lock: Vec<u64>,
+        new_principle_stakes: Vec<u64>,
     },
 
     /// Move `amount` of coins from pending_inactive to active.
@@ -1533,10 +1533,12 @@ impl EntryFunctionCall {
             PboDelegationPoolLockDelegatorsStakes {
                 pool_address,
                 delegators,
-                stakes_to_lock,
-            } => {
-                pbo_delegation_pool_lock_delegators_stakes(pool_address, delegators, stakes_to_lock)
-            },
+                new_principle_stakes,
+            } => pbo_delegation_pool_lock_delegators_stakes(
+                pool_address,
+                delegators,
+                new_principle_stakes,
+            ),
             PboDelegationPoolReactivateStake {
                 pool_address,
                 amount,
@@ -3334,10 +3336,10 @@ pub fn pbo_delegation_pool_fund_delegators_with_stake(
     ))
 }
 
-/// For each `delegator` in `delegators`, locks the amount of stake specified in the same index of `stakes_to_lock`.
-/// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
-/// to `pool_address` was created. Terminates with an error if any `stake_to_lock` exceeds the stake allocated to
-/// the corresponding `delegator` in the `DelegationPool` located at `pool_address`.
+/// Updates the `principle_stake` of each `delegator` in `delegators` according to the amount specified
+/// at the corresponding index of `new_principle_stakes`. Also ensures that the `delegator`'s `active` stake
+/// is as close to the specified amount as possible. The locked amount is subject to the vesting schedule
+/// specified when the delegation pool corresponding to `pool_address` was created.
 ///
 /// Note that this function is only temporarily intended to work as specified above and exists to enable The
 /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
@@ -3346,7 +3348,7 @@ pub fn pbo_delegation_pool_fund_delegators_with_stake(
 pub fn pbo_delegation_pool_lock_delegators_stakes(
     pool_address: AccountAddress,
     delegators: Vec<AccountAddress>,
-    stakes_to_lock: Vec<u64>,
+    new_principle_stakes: Vec<u64>,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -3361,7 +3363,7 @@ pub fn pbo_delegation_pool_lock_delegators_stakes(
         vec![
             bcs::to_bytes(&pool_address).unwrap(),
             bcs::to_bytes(&delegators).unwrap(),
-            bcs::to_bytes(&stakes_to_lock).unwrap(),
+            bcs::to_bytes(&new_principle_stakes).unwrap(),
         ],
     ))
 }
@@ -6045,7 +6047,7 @@ mod decoder {
             Some(EntryFunctionCall::PboDelegationPoolLockDelegatorsStakes {
                 pool_address: bcs::from_bytes(script.args().get(0)?).ok()?,
                 delegators: bcs::from_bytes(script.args().get(1)?).ok()?,
-                stakes_to_lock: bcs::from_bytes(script.args().get(2)?).ok()?,
+                new_principle_stakes: bcs::from_bytes(script.args().get(2)?).ok()?,
             })
         } else {
             None

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -955,7 +955,7 @@ module supra_framework::pbo_delegation_pool {
         };
 
         fund_delegators_with_stake(funder, pool_address, delegators, stakes);
-        lock_existing_delegators_stakes(funder, pool_address, delegators, stakes);
+        lock_existing_delegators_stakes(pool_address, delegators, stakes);
     }
 
     public entry fun fund_delegators_with_stake(
@@ -1544,6 +1544,56 @@ module supra_framework::pbo_delegation_pool {
         }
     }
 
+    /// Reactivates the `pending_inactive` and `inactive` stakes of `delegator`. 
+    /// 
+    /// This function must remain private because it must only be called by an authorized entity and it is the
+    /// callers responsibility to ensure that this is true. Authorized entities currently include the delegator
+    /// itself and the multisig admin of the delegation pool, which must be controlled by The Supra Foundation.
+    /// 
+    /// Note that this function is only temporarily intended to work as specified above and exists to enable The
+    /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// validator-owners to prevent it from being abused, from which time forward only the delegator will be
+    /// authorized to reactivate their own stake. 
+    fun authorized_reactivate_stake(
+        delegator: address, pool_address: address, amount: u64
+    ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
+        // short-circuit if amount to reactivate is 0 so no event is emitted
+        if (amount == 0) { return };
+        // synchronize delegation and stake pools before any user operation
+        synchronize_delegation_pool(pool_address);
+
+        let pool = borrow_global_mut<DelegationPool>(pool_address);
+
+        amount = coins_to_transfer_to_ensure_min_stake(
+            pending_inactive_shares_pool(pool),
+            &pool.active_shares,
+            delegator,
+            amount
+        );
+        let observed_lockup_cycle = pool.observed_lockup_cycle;
+        amount = redeem_inactive_shares(
+            pool,
+            delegator,
+            amount,
+            observed_lockup_cycle
+        );
+
+        stake::reactivate_stake(&retrieve_stake_pool_owner(pool), amount);
+
+        buy_in_active_shares(pool, delegator, amount);
+        assert_min_active_balance(pool, delegator);
+
+        event::emit_event(
+            &mut pool.reactivate_stake_events,
+            ReactivateStakeEvent {
+                pool_address,
+                delegator_address: delegator,
+                amount_reactivated: amount
+            }
+        );
+    }
+
     /// For each delegator in `delegators`, locks the amount of stake specified in the same index of `stakes`.
     /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
     /// to `pool_address` was created.
@@ -1555,7 +1605,6 @@ module supra_framework::pbo_delegation_pool {
     /// This function also assumes that `multisig_admin` is the admin of the `DelegationPool` at `pool_address`.
     /// The caller must ensure that this is true.
     fun lock_existing_delegators_stakes(
-        multisig_admin: &signer,
         pool_address: address,
         delegators: vector<address>,
         stakes: vector<u64>
@@ -1596,7 +1645,7 @@ module supra_framework::pbo_delegation_pool {
         pool_address: address,
         delegators: vector<address>,
         stakes_to_lock: vector<u64>
-    ) acquires DelegationPool {
+    ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         // Ensure that the caller is the admin of the delegation pool.
         {
             assert!(
@@ -1610,7 +1659,7 @@ module supra_framework::pbo_delegation_pool {
             delegators,
             stakes_to_lock,
             |delegator, stake_to_lock| {
-                (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+                let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
 
                 // Ensure that the amount to lock is greater than the stake owned by `delegator`.
                 assert!(
@@ -1619,15 +1668,15 @@ module supra_framework::pbo_delegation_pool {
                 );
                 
                 // Either the amount to lock can be covered by the `active` stake, in which case
-                // `reactivate_stake` will short-circuit, or the amount to lock can be covered
+                // `authorized_reactivate_stake` will short-circuit, or the amount to lock can be covered
                 // by reactivating some previously unlocked stake. Only reactivate the required
                 // amount to avoid unnecessarily interfering with in-progress withdrawals.
-                amount_to_reactivate = stake_to_lock - active;
-                reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                let amount_to_reactivate = stake_to_lock - active;
+                authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
             }
         );
 
-        lock_existing_delegators_stakes(funder, pool_address, delegators, stakes_to_lock);
+        lock_existing_delegators_stakes(pool_address, delegators, stakes_to_lock);
     }
 
     ///CAUTION: This is to be used only in the rare circumstances where multisig_admin is convinced that a delegator was the
@@ -1921,41 +1970,8 @@ module supra_framework::pbo_delegation_pool {
     public entry fun reactivate_stake(
         delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
-        // short-circuit if amount to reactivate is 0 so no event is emitted
-        if (amount == 0) { return };
-        // synchronize delegation and stake pools before any user operation
-        synchronize_delegation_pool(pool_address);
-
-        let pool = borrow_global_mut<DelegationPool>(pool_address);
         let delegator_address = signer::address_of(delegator);
-
-        amount = coins_to_transfer_to_ensure_min_stake(
-            pending_inactive_shares_pool(pool),
-            &pool.active_shares,
-            delegator_address,
-            amount
-        );
-        let observed_lockup_cycle = pool.observed_lockup_cycle;
-        amount = redeem_inactive_shares(
-            pool,
-            delegator_address,
-            amount,
-            observed_lockup_cycle
-        );
-
-        stake::reactivate_stake(&retrieve_stake_pool_owner(pool), amount);
-
-        buy_in_active_shares(pool, delegator_address, amount);
-        assert_min_active_balance(pool, delegator_address);
-
-        event::emit_event(
-            &mut pool.reactivate_stake_events,
-            ReactivateStakeEvent {
-                pool_address,
-                delegator_address,
-                amount_reactivated: amount
-            }
-        );
+        authorized_reactivate_stake(delegator_address, pool_address, amount)
     }
 
     /// Withdraw `amount` of owned inactive stake from the delegation pool at `pool_address`.

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -248,7 +248,7 @@ module supra_framework::pbo_delegation_pool {
 
     /// Minimum amount of coins to be unlocked.
     const EMINIMUM_UNLOCK_AMOUNT: u64 = 38;
-    
+
     /// Balance is not enough.
     const EBALANCE_NOT_SUFFICIENT: u64 = 39;
 
@@ -621,6 +621,7 @@ module supra_framework::pbo_delegation_pool {
         assert_delegation_pool_exists(pool_address);
         let pool = borrow_global<DelegationPool>(pool_address);
         let (lockup_cycle_ended, active, _, commission_active, commission_pending_inactive) =
+
             calculate_stake_pool_drift(pool);
 
         let total_active_shares = pool_u64::total_shares(&pool.active_shares);
@@ -1014,11 +1015,7 @@ module supra_framework::pbo_delegation_pool {
                     // Record the details of the lockup event. Note that only the newly locked
                     // amount is reported and not the total locked amount.
                     event::emit(
-                        UnlockScheduleApplied {
-                            pool_address,
-                            delegator,
-                            amount: stake
-                        }
+                        UnlockScheduleApplied { pool_address, delegator, amount: stake }
                     );
                 }
             }
@@ -1557,7 +1554,10 @@ module supra_framework::pbo_delegation_pool {
         // short-circuit if amount to add is 0 so no event is emitted
         if (amount == 0) { return };
         // fail unlock of less than `MIN_COINS_ON_SHARES_POOL`
-        assert!(amount >= MIN_COINS_ON_SHARES_POOL, error::invalid_argument(EMINIMUM_UNLOCK_AMOUNT));
+        assert!(
+            amount >= MIN_COINS_ON_SHARES_POOL,
+            error::invalid_argument(EMINIMUM_UNLOCK_AMOUNT)
+        );
         // synchronize delegation and stake pools before any user operation
         synchronize_delegation_pool(pool_address);
 
@@ -1616,23 +1616,26 @@ module supra_framework::pbo_delegation_pool {
     }
 
     /// Reactivates the `pending_inactive` stake of `delegator`.
-    /// 
+    ///
     /// This function must remain private because it must only be called by an authorized entity and it is the
     /// callers responsibility to ensure that this is true. Authorized entities currently include the delegator
     /// itself and the multisig admin of the delegation pool, which must be controlled by The Supra Foundation.
-    /// 
+    ///
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
-    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external
     /// validator-owners to prevent it from being abused, from which time forward only the delegator will be
-    /// authorized to reactivate their own stake. 
+    /// authorized to reactivate their own stake.
     fun authorized_reactivate_stake(
         delegator: address, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         // short-circuit if amount to reactivate is 0 so no event is emitted
         if (amount == 0) { return };
         // fail unlock of less than `MIN_COINS_ON_SHARES_POOL`
-        assert!(amount >= MIN_COINS_ON_SHARES_POOL, error::invalid_argument(EMINIMUM_UNLOCK_AMOUNT));
+        assert!(
+            amount >= MIN_COINS_ON_SHARES_POOL,
+            error::invalid_argument(EMINIMUM_UNLOCK_AMOUNT)
+        );
         // synchronize delegation and stake pools before any user operation
         synchronize_delegation_pool(pool_address);
 
@@ -1645,12 +1648,7 @@ module supra_framework::pbo_delegation_pool {
             amount
         );
         let observed_lockup_cycle = pool.observed_lockup_cycle;
-        amount = redeem_inactive_shares(
-            pool,
-            delegator,
-            amount,
-            observed_lockup_cycle
-        );
+        amount = redeem_inactive_shares(pool, delegator, amount, observed_lockup_cycle);
 
         stake::reactivate_stake(&retrieve_stake_pool_owner(pool), amount);
 
@@ -1669,13 +1667,16 @@ module supra_framework::pbo_delegation_pool {
 
     /// Withdraws the specified `amount` from the `inactive` stake belonging to the given `delegator_address`
     /// to the address of the `DelegationPool`'s `multisig_admin`, if available.
-    /// 
+    ///
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
-    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external
     /// validator-owners to prevent it from being abused.
     fun admin_withdraw(
-        multisig_admin: &signer, pool_address: address, delegator_address: address, amount: u64
+        multisig_admin: &signer,
+        pool_address: address,
+        delegator_address: address,
+        amount: u64
     ) acquires DelegationPool, GovernanceRecords {
         // Ensure that the caller is the admin of the delegation pool.
         {
@@ -1689,7 +1690,7 @@ module supra_framework::pbo_delegation_pool {
             borrow_global_mut<DelegationPool>(pool_address),
             delegator_address,
             amount,
-            signer::address_of(multisig_admin),
+            signer::address_of(multisig_admin)
         );
     }
 
@@ -1697,10 +1698,10 @@ module supra_framework::pbo_delegation_pool {
     /// at the corresponding index of `new_principle_stakes`. Also ensures that the `delegator`'s `active` stake
     /// is as close to the specified amount as possible. The locked amount is subject to the vesting schedule
     /// specified when the delegation pool corresponding to `pool_address` was created.
-    /// 
+    ///
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
-    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external
     /// validator-owners to prevent it from being abused.
     public entry fun lock_delegators_stakes(
         multisig_admin: &signer,
@@ -1719,18 +1720,19 @@ module supra_framework::pbo_delegation_pool {
         // Synchronize the delegation and stake pools before any user operation.
         synchronize_delegation_pool(pool_address);
 
-        // Ensure that each `delegator` has an `active` stake balance that is as close to 
+        // Ensure that each `delegator` has an `active` stake balance that is as close to
         // `principle_stake`  as possible.
         vector::zip_reverse(
             delegators,
             new_principle_stakes,
             |delegator, principle_stake| {
-                let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+                let (active, inactive, pending_inactive) =
+                    get_stake(pool_address, delegator);
 
                 // Ensure that all stake to be locked is made `active`.
                 if (active < principle_stake) {
                     // The amount to lock can be covered by reactivating some previously unlocked stake.
-                    // Only reactivate the required amount to avoid unnecessarily interfering with 
+                    // Only reactivate the required amount to avoid unnecessarily interfering with
                     // in-progress withdrawals.
                     let amount_to_reactivate = principle_stake - active;
 
@@ -1743,14 +1745,17 @@ module supra_framework::pbo_delegation_pool {
 
                     if (amount_to_reactivate > MIN_COINS_ON_SHARES_POOL) {
                         // Reactivate the required amount of `pending_inactive` stake first.
-                        authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                        authorized_reactivate_stake(
+                            delegator, pool_address, amount_to_reactivate
+                        );
                     };
 
                     let active_and_pending_inactive = active + pending_inactive;
-                    
+
                     if (active_and_pending_inactive < principle_stake) {
                         // Need to reactivate some of the `inactive` stake.
-                        let amount_to_withdraw = principle_stake - active_and_pending_inactive;
+                        let amount_to_withdraw =
+                            principle_stake - active_and_pending_inactive;
 
                         // Ensure that we do not try to withdraw more stake than the `inactive` stake.
                         if (amount_to_withdraw > inactive) {
@@ -1766,9 +1771,14 @@ module supra_framework::pbo_delegation_pool {
                                 amount_to_withdraw
                             );
                             // Then allocate it to the delegator again.
-                            fund_delegator_stake(multisig_admin, pool_address, delegator, amount_to_withdraw);
+                            fund_delegator_stake(
+                                multisig_admin,
+                                pool_address,
+                                delegator,
+                                amount_to_withdraw
+                            );
                         }
-                    }                    
+                    }
                 };
                 // else: The amount to lock can be covered by the currently `active` stake.
 
@@ -1791,10 +1801,10 @@ module supra_framework::pbo_delegation_pool {
     /// rightful owner of `old_delegator` but has lost access and the delegator is also the rightful
     /// owner of `new_delegator` , Only for those stakeholders which were added at the time of creation
     /// This does not apply to anyone who added stake later or operator
-    /// 
+    ///
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
-    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external
     /// validator-owners to prevent it from being abused.
     public entry fun replace_delegator(
         multisig_admin: &signer,
@@ -2005,16 +2015,26 @@ module supra_framework::pbo_delegation_pool {
         let last_unlocked_period = unlock_schedule.last_unlock_period;
         let schedule_length = vector::length(&unlock_schedule.schedule);
         let cfraction = unlock_schedule.cumulative_unlocked_fraction;
-        while (last_unlocked_period < unlock_periods_passed && fixed_point64::less(cfraction, one)
-                && last_unlocked_period < schedule_length) {
-            let next_fraction = *vector::borrow(&unlock_schedule.schedule, last_unlocked_period);
+        while (last_unlocked_period < unlock_periods_passed
+            && fixed_point64::less(cfraction, one)
+            && last_unlocked_period < schedule_length) {
+            let next_fraction =
+                *vector::borrow(&unlock_schedule.schedule, last_unlocked_period);
             cfraction = fixed_point64::add(cfraction, next_fraction);
             last_unlocked_period = last_unlocked_period + 1;
         };
-        if (last_unlocked_period < unlock_periods_passed && fixed_point64::less(cfraction, one)) {
-            let final_fraction= *vector::borrow(&unlock_schedule.schedule, schedule_length - 1);
+        if (last_unlocked_period < unlock_periods_passed
+            && fixed_point64::less(cfraction, one)) {
+            let final_fraction =
+                *vector::borrow(&unlock_schedule.schedule, schedule_length - 1);
             // Acclerate calculation to current period and don't update last_unlocked_period since it is not used anymore
-            cfraction = fixed_point64::add(cfraction, fixed_point64::multiply_u128_return_fixpoint64((unlock_periods_passed - last_unlocked_period as u128), final_fraction));
+            cfraction = fixed_point64::add(
+                cfraction,
+                fixed_point64::multiply_u128_return_fixpoint64(
+                    (unlock_periods_passed - last_unlocked_period as u128),
+                    final_fraction
+                )
+            );
             cfraction = fixed_point64::min(cfraction, one);
         };
         unlock_schedule.cumulative_unlocked_fraction = cfraction;
@@ -2031,7 +2051,10 @@ module supra_framework::pbo_delegation_pool {
         // short-circuit if amount to unlock is 0 so no event is emitted
         if (amount == 0) { return };
         // fail unlock of less than `MIN_COINS_ON_SHARES_POOL`
-        assert!(amount >= MIN_COINS_ON_SHARES_POOL, error::invalid_argument(EMINIMUM_UNLOCK_AMOUNT));
+        assert!(
+            amount >= MIN_COINS_ON_SHARES_POOL,
+            error::invalid_argument(EMINIMUM_UNLOCK_AMOUNT)
+        );
         // fail unlock of more stake than `active` on the stake pool
         let (active, _, _, _) = stake::get_stake(pool_address);
         assert!(
@@ -2094,14 +2117,17 @@ module supra_framework::pbo_delegation_pool {
             borrow_global_mut<DelegationPool>(pool_address),
             delegator_address,
             amount,
-            delegator_address,
+            delegator_address
         );
     }
 
     // TODO: `recipient_address` must be removed and replaced with `delegator_address` before the
     // validator set is opened to non-Foundation validator-owners.
     fun withdraw_internal(
-        pool: &mut DelegationPool, delegator_address: address, amount: u64, recipient_address: address
+        pool: &mut DelegationPool,
+        delegator_address: address,
+        amount: u64,
+        recipient_address: address
     ) acquires GovernanceRecords {
         // TODO: recycle storage when a delegator fully exits the delegation pool.
         // short-circuit if amount to withdraw is 0 so no event is emitted
@@ -2201,7 +2227,12 @@ module supra_framework::pbo_delegation_pool {
             pending_withdrawal_exists(pool, delegator_address);
         if (withdrawal_exists
             && withdrawal_olc.index < pool.observed_lockup_cycle.index) {
-            withdraw_internal(pool, delegator_address, MAX_U64, delegator_address);
+            withdraw_internal(
+                pool,
+                delegator_address,
+                MAX_U64,
+                delegator_address
+            );
         }
     }
 
@@ -9718,7 +9749,7 @@ module supra_framework::pbo_delegation_pool {
             can_principle_unlock(
                 delegator_address,
                 pool_address,
-                (500 * ONE_SUPRA)-1
+                (500 * ONE_SUPRA) - 1
             );
         assert!(unlock_coin, 11);
     }
@@ -9903,8 +9934,10 @@ module supra_framework::pbo_delegation_pool {
         let delegator_allocation = 10 * ONE_SUPRA;
         let half_delegator_allocation = delegator_allocation / 2;
         // A rounding error of 1 Quant is introduced by `unlock`.
-        let half_delegator_allocation_with_rounding_error = half_delegator_allocation - 1;
-        let delegator_allocation_after_rounding_error = half_delegator_allocation + half_delegator_allocation_with_rounding_error;
+        let half_delegator_allocation_with_rounding_error = half_delegator_allocation
+            - 1;
+        let delegator_allocation_after_rounding_error =
+            half_delegator_allocation + half_delegator_allocation_with_rounding_error;
 
         // Fund another delegator.
         fund_delegators_with_stake(
@@ -9931,7 +9964,10 @@ module supra_framework::pbo_delegation_pool {
         let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
         assert!(active == half_delegator_allocation, active);
         assert!(inactive == 0, inactive);
-        assert!(pending_inactive == half_delegator_allocation_with_rounding_error, pending_inactive);
+        assert!(
+            pending_inactive == half_delegator_allocation_with_rounding_error,
+            pending_inactive
+        );
 
         // Attempt to lock the full allocation, which should cause the `pending_inactive` allocation
         // to become `active` again.
@@ -9963,7 +9999,10 @@ module supra_framework::pbo_delegation_pool {
         let delegator_stake = delegator_allocation_after_rounding_error + epoch_reward;
         // The amount of stake withheld due to the withdrawal and restaking process used to
         // recover `inactive` stake.
-        let add_stake_fee = get_add_stake_fee(pool_address, half_delegator_allocation + half_epoch_reward);
+        let add_stake_fee =
+            get_add_stake_fee(
+                pool_address, half_delegator_allocation + half_epoch_reward
+            );
 
         // Fund another delegator.
         fund_delegators_with_stake(
@@ -9992,9 +10031,17 @@ module supra_framework::pbo_delegation_pool {
 
         // Ensure that half of the allocation is marked as `active` and the other half as `inactive`.
         let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
-        assert!(active == half_delegator_allocation + half_epoch_reward, active);
+        assert!(
+            active == half_delegator_allocation + half_epoch_reward,
+            active
+        );
         // Another rounding error is introduced by the second `unlock`.
-        assert!(inactive == half_delegator_allocation_with_rounding_error + half_epoch_reward - 1, inactive);
+        assert!(
+            inactive
+                == half_delegator_allocation_with_rounding_error + half_epoch_reward
+                    - 1,
+            inactive
+        );
         assert!(pending_inactive == 0, pending_inactive);
 
         // Attempt to lock the full allocation, which should cause the `inactive` allocation
@@ -10019,7 +10066,6 @@ module supra_framework::pbo_delegation_pool {
         let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
         assert!(delegator_principle_stake == delegator_stake, delegator_principle_stake);
 
-
         //
         // Ensure that `lock_delegators_stakes` locks the maximum available stake when the amount
         // requested to be locked exceeds the available stake. Also ensure that the same delegator
@@ -10037,7 +10083,8 @@ module supra_framework::pbo_delegation_pool {
 
         // Calculate the fee for the newly added amount.
         let add_stake_fee = get_add_stake_fee(pool_address, delegator_allocation);
-        let expected_total_stake = expected_active_stake + delegator_allocation - add_stake_fee;
+        let expected_total_stake =
+            expected_active_stake + delegator_allocation - add_stake_fee;
 
         // Ensure that the entire allocation is marked as active.
         let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
@@ -10057,6 +10104,9 @@ module supra_framework::pbo_delegation_pool {
         // Ensure that the delegator's `principle_stake` has been updated.
         let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
         let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
-        assert!(delegator_principle_stake == more_than_allocated_stake, delegator_principle_stake);
+        assert!(
+            delegator_principle_stake == more_than_allocated_stake,
+            delegator_principle_stake
+        );
     }
 }

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -1741,8 +1741,11 @@ module supra_framework::pbo_delegation_pool {
                         amount_to_reactivate = pending_inactive;
                     };
 
-                    // Reactivate the required amount of `pending_inactive` stake first, if there is any.
-                    authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                    if (amount_to_reactivate > MIN_COINS_ON_SHARES_POOL) {
+                        // Reactivate the required amount of `pending_inactive` stake first.
+                        authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                    };
+
                     let active_and_pending_inactive = active + pending_inactive;
                     
                     if (active_and_pending_inactive < principle_stake) {
@@ -1754,7 +1757,7 @@ module supra_framework::pbo_delegation_pool {
                             amount_to_withdraw = inactive;
                         };
 
-                        if (amount_to_withdraw > 0) {
+                        if (amount_to_withdraw > MIN_COINS_ON_SHARES_POOL) {
                             // Withdraw the minimum required amount to the admin's address.
                             admin_withdraw(
                                 multisig_admin,
@@ -9597,7 +9600,7 @@ module supra_framework::pbo_delegation_pool {
 
         let delegator = @0x0216;
         let delegator_signer = account::create_signer_for_test(delegator);
-        let delegator_allocation = 2 * ONE_SUPRA;
+        let delegator_allocation = 10 * ONE_SUPRA;
         let half_delegator_allocation = delegator_allocation / 2;
         // A rounding error of 1 Quant is introduced by `unlock`.
         let half_delegator_allocation_with_rounding_error = half_delegator_allocation - 1;
@@ -9626,9 +9629,9 @@ module supra_framework::pbo_delegation_pool {
 
         // Ensure that half of the allocation is marked as `active` and the other half as `pending_inactive`.
         let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
-        assert!(active == half_delegator_allocation_with_rounding_error, active);
+        assert!(active == half_delegator_allocation, active);
         assert!(inactive == 0, inactive);
-        assert!(pending_inactive == half_delegator_allocation, pending_inactive);
+        assert!(pending_inactive == half_delegator_allocation_with_rounding_error, pending_inactive);
 
         // Attempt to lock the full allocation, which should cause the `pending_inactive` allocation
         // to become `active` again.
@@ -9689,8 +9692,9 @@ module supra_framework::pbo_delegation_pool {
 
         // Ensure that half of the allocation is marked as `active` and the other half as `inactive`.
         let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
-        assert!(active == half_delegator_allocation_with_rounding_error + half_epoch_reward, active);
-        assert!(inactive == half_delegator_allocation + half_epoch_reward, inactive);
+        assert!(active == half_delegator_allocation + half_epoch_reward, active);
+        // Another rounding error is introduced by the second `unlock`.
+        assert!(inactive == half_delegator_allocation_with_rounding_error + half_epoch_reward - 1, inactive);
         assert!(pending_inactive == 0, pending_inactive);
 
         // Attempt to lock the full allocation, which should cause the `inactive` allocation
@@ -9742,7 +9746,7 @@ module supra_framework::pbo_delegation_pool {
         assert!(pending_inactive == 0, pending_inactive);
 
         // Attempt to lock more than the full allocation.
-        let more_than_allocated_stake = delegator_allocation * 10;
+        let more_than_allocated_stake = delegator_allocation * 2;
         lock_delegators_stakes(
             &funder_signer,
             pool_address,

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -9577,7 +9577,7 @@ module supra_framework::pbo_delegation_pool {
         assert!(inactive == 0, inactive);
         assert!(pending_inactive == 0, pending_inactive);
 
-        // Ensure that the delegators stake is now subject to the pool vesting schedule.
+        // Ensure that the delegator's stake is now subject to the pool vesting schedule.
         assert!(is_principle_stakeholder(delegator, pool_address), 0);
 
         //
@@ -9641,7 +9641,9 @@ module supra_framework::pbo_delegation_pool {
         assert!(inactive == 0, inactive);
         assert!(pending_inactive == 0, pending_inactive);
 
-        // Ensure that the delegators stake is now subject to the pool vesting schedule.
-        assert!(is_principle_stakeholder(delegator, pool_address), 0);
+        // Ensure that the delegator's stake is now subject to the pool vesting schedule.
+        let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
+        assert!(delegator_principle_stake == delegator_stake, delegator_principle_stake);
     }
 }

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -9818,4 +9818,245 @@ module supra_framework::pbo_delegation_pool {
             );
         assert!(unlock_coin, 11);
     }
+
+    #[test(supra_framework = @supra_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_lock_delegator_stake_after_allocation(
+        supra_framework: &signer, validator: &signer, delegator: &signer
+    ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
+        initialize_for_test(supra_framework);
+        account::create_account_for_test(signer::address_of(validator));
+        let delegator_address = signer::address_of(delegator);
+        let delegator_address_vec = vector[delegator_address, @0x020];
+        let principle_stake = vector[300 * ONE_SUPRA, 200 * ONE_SUPRA];
+        let coin = stake::mint_coins(500 * ONE_SUPRA);
+        let principle_lockup_time = 7776000;
+        let multisig = generate_multisig_account(validator, vector[@0x12134], 2);
+
+        initialize_test_validator(
+            validator,
+            0,
+            true,
+            true,
+            0,
+            delegator_address_vec,
+            principle_stake,
+            coin,
+            option::some(multisig),
+            vector[2, 2, 3],
+            10,
+            principle_lockup_time,
+            LOCKUP_CYCLE_SECONDS
+        );
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let new_delegator_address = @0x0215;
+        let new_delegator_address_signer =
+            account::create_account_for_test(new_delegator_address);
+        let funder_signer = account::create_signer_for_test(multisig);
+        let funder = signer::address_of(&funder_signer);
+        stake::mint(&funder_signer, 100 * ONE_SUPRA);
+        stake::mint(&new_delegator_address_signer, 100 * ONE_SUPRA);
+        assert!(
+            coin::balance<SupraCoin>(funder) == (100 * ONE_SUPRA),
+            0
+        );
+
+        assert!(
+            coin::balance<SupraCoin>(new_delegator_address) == (100 * ONE_SUPRA),
+            0
+        );
+
+        add_stake(&new_delegator_address_signer, pool_address, 100 * ONE_SUPRA);
+
+        //
+        // Ensure that `lock_delegators_stakes` can lock newly-allocated stakes.
+        //
+
+        // Fund a new delegator.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[new_delegator_address],
+            vector[1 * ONE_SUPRA]
+        );
+        // Ensure that its stake is not subject to the pool vesting schedule.
+        assert!(!is_principle_stakeholder(new_delegator_address, pool_address), 1);
+
+        // Lock its stake.
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[new_delegator_address],
+            vector[1 * ONE_SUPRA]
+        );
+        // Ensure that its stake is now subject to the pool vesting schedule.
+        assert!(is_principle_stakeholder(new_delegator_address, pool_address), 0);
+
+        //
+        // Ensure that `lock_delegators_stakes` reactivates `pending_inactive` stake.
+        //
+
+        let delegator = @0x0216;
+        let delegator_signer = account::create_signer_for_test(delegator);
+        let delegator_allocation = 10 * ONE_SUPRA;
+        let half_delegator_allocation = delegator_allocation / 2;
+        // A rounding error of 1 Quant is introduced by `unlock`.
+        let half_delegator_allocation_with_rounding_error = half_delegator_allocation - 1;
+        let delegator_allocation_after_rounding_error = half_delegator_allocation + half_delegator_allocation_with_rounding_error;
+
+        // Fund another delegator.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation]
+        );
+
+        // End the current lockup cycle to ensure that the stake fee that is deducted when the stake
+        // is first added has been returned.
+        fast_forward_to_unlock(pool_address);
+
+        // Ensure that the entire allocation is marked as active.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_allocation, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Unlock half of the initial allocation (i.e. move it to `pending_inactive`).
+        unlock(&delegator_signer, pool_address, half_delegator_allocation);
+
+        // Ensure that half of the allocation is marked as `active` and the other half as `pending_inactive`.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == half_delegator_allocation, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == half_delegator_allocation_with_rounding_error, pending_inactive);
+
+        // Attempt to lock the full allocation, which should cause the `pending_inactive` allocation
+        // to become `active` again.
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation_after_rounding_error]
+        );
+
+        // Ensure that the entire allocation is marked as active again.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_allocation_after_rounding_error, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Ensure that the delegator's stake is now subject to the pool vesting schedule.
+        assert!(is_principle_stakeholder(delegator, pool_address), 0);
+
+        //
+        // Ensure that `lock_delegators_stakes` reactivates `inactive` stake.
+        //
+
+        delegator = @0x0217;
+        delegator_signer = account::create_signer_for_test(delegator);
+        // The amount of staking rewards earned each epoch. See `initialize_for_test_custom`.
+        let epoch_reward = delegator_allocation / 100;
+        let half_epoch_reward = epoch_reward / 2;
+        let delegator_stake = delegator_allocation_after_rounding_error + epoch_reward;
+        // The amount of stake withheld due to the withdrawal and restaking process used to
+        // recover `inactive` stake.
+        let add_stake_fee = get_add_stake_fee(pool_address, half_delegator_allocation + half_epoch_reward);
+
+        // Fund another delegator.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation]
+        );
+
+        // End the current lockup cycle to ensure that the stake fee that is deducted when the stake
+        // is first added has been returned.
+        fast_forward_to_unlock(pool_address);
+
+        // Ensure that the entire allocation is marked as active.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_allocation, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Unlock half of the initial allocation (i.e. move it to `pending_inactive`).
+        unlock(&delegator_signer, pool_address, half_delegator_allocation);
+
+        // End the current lockup cycle to move the `pending_inactive` stake to `inactive`.
+        // This will also distribute staking rewards for the epoch.
+        fast_forward_to_unlock(pool_address);
+
+        // Ensure that half of the allocation is marked as `active` and the other half as `inactive`.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == half_delegator_allocation + half_epoch_reward, active);
+        // Another rounding error is introduced by the second `unlock`.
+        assert!(inactive == half_delegator_allocation_with_rounding_error + half_epoch_reward - 1, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Attempt to lock the full allocation, which should cause the `inactive` allocation
+        // to become `active` again.
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_stake]
+        );
+
+        // Ensure that the entire allocation is marked as active again. The fee for adding stake
+        // needs to be subtracted from the `active` amount because we've not entered the next epoch yet.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        let expected_active_stake = delegator_stake - add_stake_fee;
+        assert!(active == expected_active_stake, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Ensure that the delegator's stake is now subject to the pool vesting schedule.
+        let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
+        assert!(delegator_principle_stake == delegator_stake, delegator_principle_stake);
+
+
+        //
+        // Ensure that `lock_delegators_stakes` locks the maximum available stake when the amount
+        // requested to be locked exceeds the available stake. Also ensure that the same delegator
+        // can be funded and its new allocation locked, multiple times, and that the principle stake
+        // specified in the most recent call to `lock_delegators_stakes` is applied correctly.
+        //
+
+        // Fund the same delegator to ensure that we can lock additional amounts.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation]
+        );
+
+        // Calculate the fee for the newly added amount.
+        let add_stake_fee = get_add_stake_fee(pool_address, delegator_allocation);
+        let expected_total_stake = expected_active_stake + delegator_allocation - add_stake_fee;
+
+        // Ensure that the entire allocation is marked as active.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == expected_total_stake, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Attempt to lock more than the full allocation.
+        let more_than_allocated_stake = delegator_allocation * 2;
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[more_than_allocated_stake]
+        );
+
+        // Ensure that the delegator's `principle_stake` has been updated.
+        let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
+        assert!(delegator_principle_stake == more_than_allocated_stake, delegator_principle_stake);
+    }
 }

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -133,8 +133,6 @@ module supra_framework::pbo_delegation_pool {
     use supra_framework::staking_config;
     use supra_framework::timestamp;
     use supra_framework::multisig_account;
-    #[test_only]
-    use aptos_std::debug;
 
     const MODULE_SALT: vector<u8> = b"supra_framework::pbo_delegation_pool";
 
@@ -1539,7 +1537,7 @@ module supra_framework::pbo_delegation_pool {
         }
     }
 
-    /// Reactivates the `pending_inactive` and `inactive` stakes of `delegator`. 
+    /// Reactivates the `pending_inactive` stake of `delegator`.
     /// 
     /// This function must remain private because it must only be called by an authorized entity and it is the
     /// callers responsibility to ensure that this is true. Authorized entities currently include the delegator
@@ -1626,6 +1624,32 @@ module supra_framework::pbo_delegation_pool {
         );
     }
 
+    /// Withdraws the specified `amount` from the `inactive` stake belonging to the given `delegator_address`
+    /// to the address of the `DelegationPool`'s `multisig_admin`, if available.
+    /// 
+    /// Note that this function is only temporarily intended to work as specified above and exists to enable The
+    /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// validator-owners to prevent it from being abused.
+    fun admin_withdraw(
+        multisig_admin: &signer, pool_address: address, delegator_address: address, amount: u64
+    ) acquires DelegationPool, GovernanceRecords {
+        // Ensure that the caller is the admin of the delegation pool.
+        {
+            assert!(
+                is_admin(signer::address_of(multisig_admin), pool_address),
+                error::permission_denied(ENOT_AUTHORIZED)
+            );
+        };
+        assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO_STAKE));
+        withdraw_internal(
+            borrow_global_mut<DelegationPool>(pool_address),
+            delegator_address,
+            amount,
+            signer::address_of(multisig_admin),
+        );
+    }
+
     /// For each `delegator` in `delegators`, locks the amount of stake specified in the same index of `stakes_to_lock`.
     /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
     /// to `pool_address` was created. Terminates with an error if any `stake_to_lock` exceeds the stake allocated to
@@ -1649,6 +1673,9 @@ module supra_framework::pbo_delegation_pool {
             );
         };
 
+        // Synchronize the delegation and stake pools before any user operation.
+        synchronize_delegation_pool(pool_address);
+
         // Ensure that each `delegator` has enough active stake to cover the corresponding `stake_to_lock`.
         vector::zip_reverse(
             delegators,
@@ -1656,18 +1683,36 @@ module supra_framework::pbo_delegation_pool {
             |delegator, stake_to_lock| {
                 let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
 
-                // Ensure that the amount to lock is greater than the stake owned by `delegator`.
-                assert!(
-                    active + inactive + pending_inactive >= stake_to_lock,
-                    error::invalid_state(EINSUFFICIENT_STAKE_TO_LOCK)
-                );
-                
-                // Either the amount to lock can be covered by the `active` stake, in which case
-                // `authorized_reactivate_stake` will short-circuit, or the amount to lock can be covered
-                // by reactivating some previously unlocked stake. Only reactivate the required
-                // amount to avoid unnecessarily interfering with in-progress withdrawals.
-                let amount_to_reactivate = stake_to_lock - active;
-                authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                if (active < stake_to_lock) {
+                    // Ensure that the amount to lock is greater than the stake owned by `delegator`.
+                    assert!(
+                        active + inactive + pending_inactive >= stake_to_lock,
+                        error::invalid_state(EINSUFFICIENT_STAKE_TO_LOCK)
+                    );
+
+                    // The amount to lock can be covered by reactivating some previously unlocked stake.
+                    // Only reactivate the required amount to avoid unnecessarily interfering with 
+                    // in-progress withdrawals.
+                    let amount_to_reactivate = stake_to_lock - active;
+                    // Reactivate the required amount of `pending_inactive` stake first, if there is any.
+                    authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                    let active_and_pending_inactive = active + pending_inactive;
+                    
+                    if (active_and_pending_inactive < stake_to_lock) {
+                        // Also need to reactivate some of the `inactive` stake.
+                        let amount_to_withdraw = stake_to_lock - active_and_pending_inactive;
+                        // Withdraw the minimum required amount to the admin's address.
+                        admin_withdraw(
+                            multisig_admin,
+                            pool_address,
+                            delegator,
+                            amount_to_withdraw
+                        );
+                        // Then allocate it to the delegator again.
+                        fund_delegator_stake(multisig_admin, pool_address, delegator, amount_to_withdraw);
+                    }                    
+                }
+                // else: The amount to lock can be covered by the currently `active` stake.
             }
         );
 
@@ -1974,17 +2019,21 @@ module supra_framework::pbo_delegation_pool {
         delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO_STAKE));
-        // synchronize delegation and stake pools before any user operation
+        // Synchronize the delegation and stake pools before any user operation.
         synchronize_delegation_pool(pool_address);
+        let delegator_address = signer::address_of(delegator);
         withdraw_internal(
             borrow_global_mut<DelegationPool>(pool_address),
-            signer::address_of(delegator),
-            amount
+            delegator_address,
+            amount,
+            delegator_address,
         );
     }
 
+    // TODO: `recipient_address` must be removed and replaced with `delegator_address` before the
+    // validator set is opened to non-Foundation validator-owners.
     fun withdraw_internal(
-        pool: &mut DelegationPool, delegator_address: address, amount: u64
+        pool: &mut DelegationPool, delegator_address: address, amount: u64, recipient_address: address
     ) acquires GovernanceRecords {
         // TODO: recycle storage when a delegator fully exits the delegation pool.
         // short-circuit if amount to withdraw is 0 so no event is emitted
@@ -2036,7 +2085,7 @@ module supra_framework::pbo_delegation_pool {
             // no excess stake if `stake::withdraw` does not inactivate at all
             stake::withdraw(stake_pool_owner, amount);
         };
-        supra_account::transfer(stake_pool_owner, delegator_address, amount);
+        supra_account::transfer(stake_pool_owner, recipient_address, amount);
 
         // commit withdrawal of possibly inactive stake to the `total_coins_inactive`
         // known by the delegation pool in order to not mistake it for slashing at next synchronization
@@ -2084,7 +2133,7 @@ module supra_framework::pbo_delegation_pool {
             pending_withdrawal_exists(pool, delegator_address);
         if (withdrawal_exists
             && withdrawal_olc.index < pool.observed_lockup_cycle.index) {
-            withdraw_internal(pool, delegator_address, MAX_U64);
+            withdraw_internal(pool, delegator_address, MAX_U64, delegator_address);
         }
     }
 
@@ -9397,5 +9446,202 @@ module supra_framework::pbo_delegation_pool {
                 (100 * ONE_SUPRA) + 1
             );
         assert!(unlock_coin, 20);
+    }
+
+    #[test(supra_framework = @supra_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_lock_delegator_stake_after_allocation(
+        supra_framework: &signer, validator: &signer, delegator: &signer
+    ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
+        initialize_for_test(supra_framework);
+        account::create_account_for_test(signer::address_of(validator));
+        let delegator_address = signer::address_of(delegator);
+        let delegator_address_vec = vector[delegator_address, @0x020];
+        let principle_stake = vector[300 * ONE_SUPRA, 200 * ONE_SUPRA];
+        let coin = stake::mint_coins(500 * ONE_SUPRA);
+        let principle_lockup_time = 7776000;
+        let multisig = generate_multisig_account(validator, vector[@0x12134], 2);
+
+        initialize_test_validator(
+            validator,
+            0,
+            true,
+            true,
+            0,
+            delegator_address_vec,
+            principle_stake,
+            coin,
+            option::some(multisig),
+            vector[2, 2, 3],
+            10,
+            principle_lockup_time,
+            LOCKUP_CYCLE_SECONDS
+        );
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let new_delegator_address = @0x0215;
+        let new_delegator_address_signer =
+            account::create_account_for_test(new_delegator_address);
+        let funder_signer = account::create_signer_for_test(multisig);
+        let funder = signer::address_of(&funder_signer);
+        stake::mint(&funder_signer, 100 * ONE_SUPRA);
+        stake::mint(&new_delegator_address_signer, 100 * ONE_SUPRA);
+        assert!(
+            coin::balance<SupraCoin>(funder) == (100 * ONE_SUPRA),
+            0
+        );
+
+        assert!(
+            coin::balance<SupraCoin>(new_delegator_address) == (100 * ONE_SUPRA),
+            0
+        );
+
+        add_stake(&new_delegator_address_signer, pool_address, 100 * ONE_SUPRA);
+
+        //
+        // Ensure that `lock_delegators_stakes` can lock newly-allocated stakes.
+        //
+
+        // Fund a new delegator.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[new_delegator_address],
+            vector[1 * ONE_SUPRA]
+        );
+        // Ensure that its stake is not subject to the pool vesting schedule.
+        assert!(!is_principle_stakeholder(new_delegator_address, pool_address), 1);
+
+        // Lock its stake.
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[new_delegator_address],
+            vector[1 * ONE_SUPRA]
+        );
+        // Ensure that its stake is now subject to the pool vesting schedule.
+        assert!(is_principle_stakeholder(new_delegator_address, pool_address), 0);
+
+        //
+        // Ensure that `lock_delegators_stakes` reactivates `pending_inactive` stake.
+        //
+
+        let delegator = @0x0216;
+        let delegator_signer = account::create_signer_for_test(delegator);
+        let delegator_allocation = 2 * ONE_SUPRA;
+        let half_delegator_allocation = delegator_allocation / 2;
+        // A rounding error of 1 Quant is introduced by `unlock`.
+        let half_delegator_allocation_with_rounding_error = half_delegator_allocation - 1;
+        let delegator_allocation_after_rounding_error = half_delegator_allocation + half_delegator_allocation_with_rounding_error;
+
+        // Fund another delegator.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation]
+        );
+
+        // End the current lockup cycle to ensure that the stake fee that is deducted when the stake
+        // is first added has been returned.
+        fast_forward_to_unlock(pool_address);
+
+        // Ensure that the entire allocation is marked as active.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_allocation, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Unlock half of the initial allocation (i.e. move it to `pending_inactive`).
+        unlock(&delegator_signer, pool_address, half_delegator_allocation);
+
+        // Ensure that half of the allocation is marked as `active` and the other half as `pending_inactive`.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == half_delegator_allocation_with_rounding_error, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == half_delegator_allocation, pending_inactive);
+
+        // Attempt to lock the full allocation, which should cause the `pending_inactive` allocation
+        // to become `active` again.
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation_after_rounding_error]
+        );
+
+        // Ensure that the entire allocation is marked as active again.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_allocation_after_rounding_error, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Ensure that the delegators stake is now subject to the pool vesting schedule.
+        assert!(is_principle_stakeholder(delegator, pool_address), 0);
+
+        //
+        // Ensure that `lock_delegators_stakes` reactivates `inactive` stake.
+        //
+
+        delegator = @0x0217;
+        delegator_signer = account::create_signer_for_test(delegator);
+        // The amount of staking rewards earned each epoch. See `initialize_for_test_custom`.
+        let epoch_reward = delegator_allocation / 100;
+        let half_epoch_reward = epoch_reward / 2;
+        let delegator_stake = delegator_allocation_after_rounding_error + epoch_reward;
+        // The amount of stake withheld due to the withdrawal and restaking process used to
+        // recover `inactive` stake.
+        let add_stake_fee = get_add_stake_fee(pool_address, half_delegator_allocation + half_epoch_reward);
+
+        // Fund another delegator.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation]
+        );
+
+        // End the current lockup cycle to ensure that the stake fee that is deducted when the stake
+        // is first added has been returned.
+        fast_forward_to_unlock(pool_address);
+
+        // Ensure that the entire allocation is marked as active.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_allocation, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Unlock half of the initial allocation (i.e. move it to `pending_inactive`).
+        unlock(&delegator_signer, pool_address, half_delegator_allocation);
+
+        // End the current lockup cycle to move the `pending_inactive` stake to `inactive`.
+        // This will also distribute staking rewards for the epoch.
+        fast_forward_to_unlock(pool_address);
+
+        // Ensure that half of the allocation is marked as `active` and the other half as `inactive`.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == half_delegator_allocation_with_rounding_error + half_epoch_reward, active);
+        assert!(inactive == half_delegator_allocation + half_epoch_reward, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Attempt to lock the full allocation, which should cause the `inactive` allocation
+        // to become `active` again.
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_stake]
+        );
+
+        // Ensure that the entire allocation is marked as active again. The fee for adding stake
+        // needs to be subtracted from the `active` amount because we've not entered the next epoch yet.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == delegator_stake - add_stake_fee, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Ensure that the delegators stake is now subject to the pool vesting schedule.
+        assert!(is_principle_stakeholder(delegator, pool_address), 0);
     }
 }

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -986,16 +986,45 @@ module supra_framework::pbo_delegation_pool {
         delegators: vector<address>,
         stakes: vector<u64>
     ) acquires DelegationPool, BeneficiaryForOperator, GovernanceRecords, NextCommissionPercentage {
-        // Ensure that the caller is the admin of the delegation pool.
         {
             assert!(
                 is_admin(signer::address_of(funder), pool_address),
                 error::permission_denied(ENOT_AUTHORIZED)
             );
         };
+        let principle_stake_table =
+            &mut (borrow_global_mut<DelegationPool>(pool_address).principle_stake);
+
+        vector::zip_reverse(
+            delegators,
+            stakes,
+            |delegator, stake| {
+                // Ignore if stake to be added is `0`
+                if (stake > 0) {
+                    // Compute the actual stake that would be added, `principle_stake` has to be
+                    // populated in the table accordingly
+                    if (table::contains(principle_stake_table, delegator)) {
+                        let stake_amount =
+                            table::borrow_mut(principle_stake_table, delegator);
+                        *stake_amount = *stake_amount + stake;
+                    } else {
+                        table::add(principle_stake_table, delegator, stake);
+                    };
+
+                    // Record the details of the lockup event. Note that only the newly locked
+                    // amount is reported and not the total locked amount.
+                    event::emit(
+                        UnlockScheduleApplied {
+                            pool_address,
+                            delegator,
+                            amount: stake
+                        }
+                    );
+                }
+            }
+        );
 
         fund_delegators_with_stake(funder, pool_address, delegators, stakes);
-        lock_existing_delegators_stakes(pool_address, delegators, stakes);
     }
 
     public entry fun fund_delegators_with_stake(
@@ -1638,53 +1667,6 @@ module supra_framework::pbo_delegation_pool {
         );
     }
 
-    /// For each delegator in `delegators`, locks the amount of stake specified in the same index of `stakes`.
-    /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
-    /// to `pool_address` was created.
-    /// 
-    /// This function does not actually add the `stakes` to the stake pool, so must remain private and must
-    /// only be called either after ensuring that all `stakes` already exist in the `active` stake pool, or
-    /// will do so before the end of the transaction.
-    /// 
-    /// This function also assumes that `multisig_admin` is the admin of the `DelegationPool` at `pool_address`.
-    /// The caller must ensure that this is true.
-    fun lock_existing_delegators_stakes(
-        pool_address: address,
-        delegators: vector<address>,
-        stakes: vector<u64>
-    ) acquires DelegationPool {
-        let principle_stake_table =
-            &mut (borrow_global_mut<DelegationPool>(pool_address).principle_stake);
-
-        vector::zip_reverse(
-            delegators,
-            stakes,
-            |delegator, stake| {
-                if (stake > 0) {
-                    // Compute the stake to be added. `principle_stake` must be added to the table accordingly.
-                    if (table::contains(principle_stake_table, delegator)) {
-                        let stake_amount =
-                            table::borrow_mut(principle_stake_table, delegator);
-                        *stake_amount = *stake_amount + stake;
-                    } else {
-                        table::add(principle_stake_table, delegator, stake);
-                    };
-
-                    // Record the details of the lockup event. Note that only the newly locked
-                    // amount is reported and not the total locked amount.
-                    event::emit(
-                        UnlockScheduleApplied {
-                            pool_address,
-                            delegator,
-                            amount: stake
-                        }
-                    );
-                }
-                // else: The stake to be added is `0`. Do nothing.
-            }
-        );
-    }
-
     /// Withdraws the specified `amount` from the `inactive` stake belonging to the given `delegator_address`
     /// to the address of the `DelegationPool`'s `multisig_admin`, if available.
     /// 
@@ -1711,10 +1693,10 @@ module supra_framework::pbo_delegation_pool {
         );
     }
 
-    /// For each `delegator` in `delegators`, locks up to the amount of stake specified in the same index of
-    /// `max_stakes_to_lock`, which represents the upper bound on the total amount of locked stake that the
-    /// delegator should have when the function terminates. The locked amount is subject to the vesting
-    /// schedule specified when the delegation pool corresponding to `pool_address` was created.
+    /// Updates the `principle_stake` of each `delegator` in `delegators` according to the amount specified
+    /// at the corresponding index of `new_principle_stakes`. Also ensures that the `delegator`'s `active` stake
+    /// is as close to the specified amount as possible. The locked amount is subject to the vesting schedule
+    /// specified when the delegation pool corresponding to `pool_address` was created.
     /// 
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
@@ -1724,7 +1706,7 @@ module supra_framework::pbo_delegation_pool {
         multisig_admin: &signer,
         pool_address: address,
         delegators: vector<address>,
-        max_stakes_to_lock: vector<u64>
+        new_principle_stakes: vector<u64>
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         // Ensure that the caller is the admin of the delegation pool.
         {
@@ -1737,46 +1719,42 @@ module supra_framework::pbo_delegation_pool {
         // Synchronize the delegation and stake pools before any user operation.
         synchronize_delegation_pool(pool_address);
 
-        // Ensure that each `delegator` has enough active stake to cover the corresponding `stake_to_lock`.
-        let new_amounts_to_lock = vector::zip_map(
+        // Ensure that each `delegator` has an `active` stake balance that is as close to 
+        // `principle_stake`  as possible.
+        vector::zip_reverse(
             delegators,
-            max_stakes_to_lock,
-            |delegator, max_stake_to_lock| {
+            new_principle_stakes,
+            |delegator, principle_stake| {
                 let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
-                let already_locked = 0;
-                let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
 
-                // See if the delegator already has a locked allocation.
-                if (table::contains(&pool.principle_stake, delegator)) {
-                    already_locked = *table::borrow(&pool.principle_stake, delegator);
-                };
+                // Ensure that all stake to be locked is made `active`.
+                if (active < principle_stake) {
+                    // The amount to lock can be covered by reactivating some previously unlocked stake.
+                    // Only reactivate the required amount to avoid unnecessarily interfering with 
+                    // in-progress withdrawals.
+                    let amount_to_reactivate = principle_stake - active;
 
-                if (max_stake_to_lock > already_locked) {
-                    let max_new_stake_to_lock = max_stake_to_lock - already_locked;
-                    // All `already_locked` stake must be `active`.
-                    let lockable_active_stake = active - already_locked;
+                    // Ensure that we do not try to reactivate more than the available `pending_inactive` stake.
+                    // This should be enforced by functions within `authorized_reactivate_stake`, but checking
+                    // again here makes the correctness of this function easier to reason about.
+                    if (amount_to_reactivate > pending_inactive) {
+                        amount_to_reactivate = pending_inactive;
+                    };
 
-                    // Ensure that all stake to be locked is made `active`.
-                    if (lockable_active_stake < max_new_stake_to_lock) {
-                        // The amount to lock can be covered by reactivating some previously unlocked stake.
-                        // Only reactivate the required amount to avoid unnecessarily interfering with 
-                        // in-progress withdrawals.
-                        let amount_to_reactivate = max_new_stake_to_lock - lockable_active_stake;
+                    // Reactivate the required amount of `pending_inactive` stake first, if there is any.
+                    authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                    let active_and_pending_inactive = active + pending_inactive;
+                    
+                    if (active_and_pending_inactive < principle_stake) {
+                        // Need to reactivate some of the `inactive` stake.
+                        let amount_to_withdraw = principle_stake - active_and_pending_inactive;
 
-                        // Ensure that we do not try to reactivate more than the available `pending_inactive` stake.
-                        // This should be enforced by functions within `authorized_reactivate_stake`, but checking
-                        // again here makes the correctness of this function easier to reason about.
-                        if (amount_to_reactivate > pending_inactive) {
-                            amount_to_reactivate = pending_inactive;
+                        // Ensure that we do not try to withdraw more stake than the `inactive` stake.
+                        if (amount_to_withdraw > inactive) {
+                            amount_to_withdraw = inactive;
                         };
 
-                        // Reactivate the required amount of `pending_inactive` stake first, if there is any.
-                        authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
-                        let active_and_pending_inactive = lockable_active_stake + pending_inactive;
-                        
-                        if (active_and_pending_inactive < max_new_stake_to_lock) {
-                            // Need to reactivate some of the `inactive` stake.
-                            let amount_to_withdraw = max_new_stake_to_lock - active_and_pending_inactive;
+                        if (amount_to_withdraw > 0) {
                             // Withdraw the minimum required amount to the admin's address.
                             admin_withdraw(
                                 multisig_admin,
@@ -1786,26 +1764,24 @@ module supra_framework::pbo_delegation_pool {
                             );
                             // Then allocate it to the delegator again.
                             fund_delegator_stake(multisig_admin, pool_address, delegator, amount_to_withdraw);
-                        }                    
-                    };
-                    // else: The amount to lock can be covered by the currently `active` stake.
+                        }
+                    }                    
+                };
+                // else: The amount to lock can be covered by the currently `active` stake.
 
-                    let lockable_total_stake = lockable_active_stake + inactive + pending_inactive;
-
-                    if (lockable_total_stake < max_new_stake_to_lock) {
-                        // Not enough stake to meet the requested amount. Lock all available stake.
-                        lockable_total_stake
-                    } else {
-                        max_new_stake_to_lock
+                // Update the delegator's principle stake and record the details of the lockup event.
+                let principle_stake_table =
+                    &mut (borrow_global_mut<DelegationPool>(pool_address).principle_stake);
+                table::upsert(principle_stake_table, delegator, principle_stake);
+                event::emit(
+                    UnlockScheduleApplied {
+                        pool_address,
+                        delegator,
+                        amount: principle_stake
                     }
-                } else {
-                    // `max_stake_to_lock` has already been locked.
-                    0
-                }
+                );
             }
         );
-
-        lock_existing_delegators_stakes(pool_address, delegators, new_amounts_to_lock);
     }
 
     ///CAUTION: This is to be used only in the rare circumstances where multisig_admin is convinced that a delegator was the
@@ -9743,7 +9719,8 @@ module supra_framework::pbo_delegation_pool {
         //
         // Ensure that `lock_delegators_stakes` locks the maximum available stake when the amount
         // requested to be locked exceeds the available stake. Also ensure that the same delegator
-        // can be funded and its new allocation locked, multiple times.
+        // can be funded and its new allocation locked, multiple times, and that the principle stake
+        // specified in the most recent call to `lock_delegators_stakes` is applied correctly.
         //
 
         // Fund the same delegator to ensure that we can lock additional amounts.
@@ -9773,9 +9750,9 @@ module supra_framework::pbo_delegation_pool {
             vector[more_than_allocated_stake]
         );
 
-        // Ensure that the delegator's stake is now subject to the pool vesting schedule.
+        // Ensure that the delegator's `principle_stake` has been updated.
         let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
         let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
-        assert!(delegator_principle_stake == expected_total_stake, delegator_principle_stake);
+        assert!(delegator_principle_stake == more_than_allocated_stake, delegator_principle_stake);
     }
 }

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -786,11 +786,6 @@ module supra_framework::pbo_delegation_pool {
             features::delegation_pools_enabled(),
             error::invalid_state(EDELEGATION_POOLS_DISABLED)
         );
-        //Unlock start time can not be in the past
-        assert!(
-            unlock_start_time >= timestamp::now_seconds(),
-            error::invalid_argument(ESTARTUP_TIME_IN_PAST)
-        );
         //Unlock duration can not be zero
         assert!(unlock_duration > 0, error::invalid_argument(EPERIOD_DURATION_IS_ZERO));
         //Fraction denominator can not be zero

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -484,6 +484,13 @@ module supra_framework::pbo_delegation_pool {
         commission_percentage_next_lockup_cycle: u64
     }
 
+    #[event]
+    struct UnlockScheduleApplied has drop, store {
+        pool_address: address,
+        delegator: address,
+        amount: u64
+    }
+
     #[view]
     /// Return whether supplied address `addr` is owner of a delegation pool.
     public fun owner_cap_exists(addr: address): bool {
@@ -1661,7 +1668,17 @@ module supra_framework::pbo_delegation_pool {
                         *stake_amount = *stake_amount + stake;
                     } else {
                         table::add(principle_stake_table, delegator, stake);
-                    }
+                    };
+
+                    // Record the details of the lockup event. Note that only the newly locked
+                    // amount is reported and not the total locked amount.
+                    event::emit(
+                        UnlockScheduleApplied {
+                            pool_address,
+                            delegator,
+                            amount: stake
+                        }
+                    );
                 }
                 // else: The stake to be added is `0`. Do nothing.
             }
@@ -1694,10 +1711,10 @@ module supra_framework::pbo_delegation_pool {
         );
     }
 
-    /// For each `delegator` in `delegators`, locks the amount of stake specified in the same index of `stakes_to_lock`.
-    /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
-    /// to `pool_address` was created. Terminates with an error if any `stake_to_lock` exceeds the stake allocated to
-    /// the corresponding `delegator` in the `DelegationPool` located at `pool_address`.
+    /// For each `delegator` in `delegators`, locks up to the amount of stake specified in the same index of
+    /// `max_stakes_to_lock`, which represents the upper bound on the total amount of locked stake that the
+    /// delegator should have when the function terminates. The locked amount is subject to the vesting
+    /// schedule specified when the delegation pool corresponding to `pool_address` was created.
     /// 
     /// Note that this function is only temporarily intended to work as specified above and exists to enable The
     /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
@@ -1707,7 +1724,7 @@ module supra_framework::pbo_delegation_pool {
         multisig_admin: &signer,
         pool_address: address,
         delegators: vector<address>,
-        stakes_to_lock: vector<u64>
+        max_stakes_to_lock: vector<u64>
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         // Ensure that the caller is the admin of the delegation pool.
         {
@@ -1721,46 +1738,74 @@ module supra_framework::pbo_delegation_pool {
         synchronize_delegation_pool(pool_address);
 
         // Ensure that each `delegator` has enough active stake to cover the corresponding `stake_to_lock`.
-        vector::zip_reverse(
+        let new_amounts_to_lock = vector::zip_map(
             delegators,
-            stakes_to_lock,
-            |delegator, stake_to_lock| {
+            max_stakes_to_lock,
+            |delegator, max_stake_to_lock| {
                 let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+                let already_locked = 0;
+                let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
 
-                if (active < stake_to_lock) {
-                    // Ensure that the amount to lock is greater than the stake owned by `delegator`.
-                    assert!(
-                        active + inactive + pending_inactive >= stake_to_lock,
-                        error::invalid_state(EINSUFFICIENT_STAKE_TO_LOCK)
-                    );
+                // See if the delegator already has a locked allocation.
+                if (table::contains(&pool.principle_stake, delegator)) {
+                    already_locked = *table::borrow(&pool.principle_stake, delegator);
+                };
 
-                    // The amount to lock can be covered by reactivating some previously unlocked stake.
-                    // Only reactivate the required amount to avoid unnecessarily interfering with 
-                    // in-progress withdrawals.
-                    let amount_to_reactivate = stake_to_lock - active;
-                    // Reactivate the required amount of `pending_inactive` stake first, if there is any.
-                    authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
-                    let active_and_pending_inactive = active + pending_inactive;
-                    
-                    if (active_and_pending_inactive < stake_to_lock) {
-                        // Also need to reactivate some of the `inactive` stake.
-                        let amount_to_withdraw = stake_to_lock - active_and_pending_inactive;
-                        // Withdraw the minimum required amount to the admin's address.
-                        admin_withdraw(
-                            multisig_admin,
-                            pool_address,
-                            delegator,
-                            amount_to_withdraw
-                        );
-                        // Then allocate it to the delegator again.
-                        fund_delegator_stake(multisig_admin, pool_address, delegator, amount_to_withdraw);
-                    }                    
+                if (max_stake_to_lock > already_locked) {
+                    let max_new_stake_to_lock = max_stake_to_lock - already_locked;
+                    // All `already_locked` stake must be `active`.
+                    let lockable_active_stake = active - already_locked;
+
+                    // Ensure that all stake to be locked is made `active`.
+                    if (lockable_active_stake < max_new_stake_to_lock) {
+                        // The amount to lock can be covered by reactivating some previously unlocked stake.
+                        // Only reactivate the required amount to avoid unnecessarily interfering with 
+                        // in-progress withdrawals.
+                        let amount_to_reactivate = max_new_stake_to_lock - lockable_active_stake;
+
+                        // Ensure that we do not try to reactivate more than the available `pending_inactive` stake.
+                        // This should be enforced by functions within `authorized_reactivate_stake`, but checking
+                        // again here makes the correctness of this function easier to reason about.
+                        if (amount_to_reactivate > pending_inactive) {
+                            amount_to_reactivate = pending_inactive;
+                        };
+
+                        // Reactivate the required amount of `pending_inactive` stake first, if there is any.
+                        authorized_reactivate_stake(delegator, pool_address, amount_to_reactivate);
+                        let active_and_pending_inactive = lockable_active_stake + pending_inactive;
+                        
+                        if (active_and_pending_inactive < max_new_stake_to_lock) {
+                            // Need to reactivate some of the `inactive` stake.
+                            let amount_to_withdraw = max_new_stake_to_lock - active_and_pending_inactive;
+                            // Withdraw the minimum required amount to the admin's address.
+                            admin_withdraw(
+                                multisig_admin,
+                                pool_address,
+                                delegator,
+                                amount_to_withdraw
+                            );
+                            // Then allocate it to the delegator again.
+                            fund_delegator_stake(multisig_admin, pool_address, delegator, amount_to_withdraw);
+                        }                    
+                    };
+                    // else: The amount to lock can be covered by the currently `active` stake.
+
+                    let lockable_total_stake = lockable_active_stake + inactive + pending_inactive;
+
+                    if (lockable_total_stake < max_new_stake_to_lock) {
+                        // Not enough stake to meet the requested amount. Lock all available stake.
+                        lockable_total_stake
+                    } else {
+                        max_new_stake_to_lock
+                    }
+                } else {
+                    // `max_stake_to_lock` has already been locked.
+                    0
                 }
-                // else: The amount to lock can be covered by the currently `active` stake.
             }
         );
 
-        lock_existing_delegators_stakes(pool_address, delegators, stakes_to_lock);
+        lock_existing_delegators_stakes(pool_address, delegators, new_amounts_to_lock);
     }
 
     ///CAUTION: This is to be used only in the rare circumstances where multisig_admin is convinced that a delegator was the
@@ -9684,7 +9729,8 @@ module supra_framework::pbo_delegation_pool {
         // Ensure that the entire allocation is marked as active again. The fee for adding stake
         // needs to be subtracted from the `active` amount because we've not entered the next epoch yet.
         let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
-        assert!(active == delegator_stake - add_stake_fee, active);
+        let expected_active_stake = delegator_stake - add_stake_fee;
+        assert!(active == expected_active_stake, active);
         assert!(inactive == 0, inactive);
         assert!(pending_inactive == 0, pending_inactive);
 
@@ -9692,5 +9738,44 @@ module supra_framework::pbo_delegation_pool {
         let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
         let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
         assert!(delegator_principle_stake == delegator_stake, delegator_principle_stake);
+
+
+        //
+        // Ensure that `lock_delegators_stakes` locks the maximum available stake when the amount
+        // requested to be locked exceeds the available stake. Also ensure that the same delegator
+        // can be funded and its new allocation locked, multiple times.
+        //
+
+        // Fund the same delegator to ensure that we can lock additional amounts.
+        fund_delegators_with_stake(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[delegator_allocation]
+        );
+
+        // Calculate the fee for the newly added amount.
+        let add_stake_fee = get_add_stake_fee(pool_address, delegator_allocation);
+        let expected_total_stake = expected_active_stake + delegator_allocation - add_stake_fee;
+
+        // Ensure that the entire allocation is marked as active.
+        let (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+        assert!(active == expected_total_stake, active);
+        assert!(inactive == 0, inactive);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // Attempt to lock more than the full allocation.
+        let more_than_allocated_stake = delegator_allocation * 10;
+        lock_delegators_stakes(
+            &funder_signer,
+            pool_address,
+            vector[delegator],
+            vector[more_than_allocated_stake]
+        );
+
+        // Ensure that the delegator's stake is now subject to the pool vesting schedule.
+        let pool: &mut DelegationPool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_principle_stake = *table::borrow(&pool.principle_stake, delegator);
+        assert!(delegator_principle_stake == expected_total_stake, delegator_principle_stake);
     }
 }

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -249,6 +249,10 @@ module supra_framework::pbo_delegation_pool {
 
     const ENEW_IS_SAME_AS_OLD_DELEGATOR: u64 = 37;
 
+    /// Thrown by `lock_delegators_stakes` when a given delegator has less than the specified
+    /// amount of stake available in the specified stake pool.
+    const EINSUFFICIENT_STAKE_TO_LOCK: u64 = 38;
+
     const MAX_U64: u64 = 18446744073709551615;
 
     /// Maximum operator percentage fee(of double digit precision): 22.85% is represented as 2285
@@ -607,7 +611,6 @@ module supra_framework::pbo_delegation_pool {
         assert_delegation_pool_exists(pool_address);
         let pool = borrow_global<DelegationPool>(pool_address);
         let (lockup_cycle_ended, active, _, commission_active, commission_pending_inactive) =
-
             calculate_stake_pool_drift(pool);
 
         let total_active_shares = pool_u64::total_shares(&pool.active_shares);
@@ -943,35 +946,16 @@ module supra_framework::pbo_delegation_pool {
         delegators: vector<address>,
         stakes: vector<u64>
     ) acquires DelegationPool, BeneficiaryForOperator, GovernanceRecords, NextCommissionPercentage {
+        // Ensure that the caller is the admin of the delegation pool.
         {
             assert!(
                 is_admin(signer::address_of(funder), pool_address),
                 error::permission_denied(ENOT_AUTHORIZED)
             );
         };
-        let principle_stake_table =
-            &mut (borrow_global_mut<DelegationPool>(pool_address).principle_stake);
-
-        vector::zip_reverse(
-            delegators,
-            stakes,
-            |delegator, stake| {
-                //Ignore if stake to be added is `0`
-                if (stake > 0) {
-                    //Compute the actual stake that would be added, `principle_stake` has to be
-                    //populated in the table accordingly
-                    if (table::contains(principle_stake_table, delegator)) {
-                        let stake_amount =
-                            table::borrow_mut(principle_stake_table, delegator);
-                        *stake_amount = *stake_amount + stake;
-                    } else {
-                        table::add(principle_stake_table, delegator, stake);
-                    }
-                }
-            }
-        );
 
         fund_delegators_with_stake(funder, pool_address, delegators, stakes);
+        lock_existing_delegators_stakes(funder, pool_address, delegators, stakes);
     }
 
     public entry fun fund_delegators_with_stake(
@@ -988,7 +972,6 @@ module supra_framework::pbo_delegation_pool {
                 fund_delegator_stake(funder, pool_address, delegator, stake);
             }
         );
-
     }
 
     #[view]
@@ -1561,10 +1544,101 @@ module supra_framework::pbo_delegation_pool {
         }
     }
 
+    /// For each delegator in `delegators`, locks the amount of stake specified in the same index of `stakes`.
+    /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
+    /// to `pool_address` was created.
+    /// 
+    /// This function does not actually add the `stakes` to the stake pool, so must remain private and must
+    /// only be called either after ensuring that all `stakes` already exist in the `active` stake pool, or
+    /// will do so before the end of the transaction.
+    /// 
+    /// This function also assumes that `multisig_admin` is the admin of the `DelegationPool` at `pool_address`.
+    /// The caller must ensure that this is true.
+    fun lock_existing_delegators_stakes(
+        multisig_admin: &signer,
+        pool_address: address,
+        delegators: vector<address>,
+        stakes: vector<u64>
+    ) acquires DelegationPool {
+        let principle_stake_table =
+            &mut (borrow_global_mut<DelegationPool>(pool_address).principle_stake);
+
+        vector::zip_reverse(
+            delegators,
+            stakes,
+            |delegator, stake| {
+                if (stake > 0) {
+                    // Compute the stake to be added. `principle_stake` must be added to the table accordingly.
+                    if (table::contains(principle_stake_table, delegator)) {
+                        let stake_amount =
+                            table::borrow_mut(principle_stake_table, delegator);
+                        *stake_amount = *stake_amount + stake;
+                    } else {
+                        table::add(principle_stake_table, delegator, stake);
+                    }
+                }
+                // else: The stake to be added is `0`. Do nothing.
+            }
+        );
+    }
+
+    /// For each `delegator` in `delegators`, locks the amount of stake specified in the same index of `stakes_to_lock`.
+    /// The locked amount is subject to the vesting schedule specified when the delegation pool corresponding
+    /// to `pool_address` was created. Terminates with an error if any `stake_to_lock` exceeds the stake allocated to
+    /// the corresponding `delegator` in the `DelegationPool` located at `pool_address`.
+    /// 
+    /// Note that this function is only temporarily intended to work as specified above and exists to enable The
+    /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// validator-owners to prevent it from being abused.
+    public entry fun lock_delegators_stakes(
+        multisig_admin: &signer,
+        pool_address: address,
+        delegators: vector<address>,
+        stakes_to_lock: vector<u64>
+    ) acquires DelegationPool {
+        // Ensure that the caller is the admin of the delegation pool.
+        {
+            assert!(
+                is_admin(signer::address_of(multisig_admin), pool_address),
+                error::permission_denied(ENOT_AUTHORIZED)
+            );
+        };
+
+        // Ensure that each `delegator` has enough active stake to cover the corresponding `stake_to_lock`.
+        vector::zip_reverse(
+            delegators,
+            stakes_to_lock,
+            |delegator, stake_to_lock| {
+                (active, inactive, pending_inactive) = get_stake(pool_address, delegator);
+
+                // Ensure that the amount to lock is greater than the stake owned by `delegator`.
+                assert!(
+                    active + inactive + pending_inactive >= stake_to_lock,
+                    error::invalid_state(EINSUFFICIENT_STAKE_TO_LOCK)
+                );
+                
+                // Either the amount to lock can be covered by the `active` stake, in which case
+                // `reactivate_stake` will short-circuit, or the amount to lock can be covered
+                // by reactivating some previously unlocked stake. Only reactivate the required
+                // amount to avoid unnecessarily interfering with in-progress withdrawals.
+                amount_to_reactivate = stake_to_lock - active;
+                reactivate_stake(delegator, pool_address, amount_to_reactivate);
+            }
+        );
+
+        lock_existing_delegators_stakes(funder, pool_address, delegators, stakes_to_lock);
+    }
+
     ///CAUTION: This is to be used only in the rare circumstances where multisig_admin is convinced that a delegator was the
     /// rightful owner of `old_delegator` but has lost access and the delegator is also the rightful
     /// owner of `new_delegator` , Only for those stakeholders which were added at the time of creation
     /// This does not apply to anyone who added stake later or operator
+    /// 
+    /// Note that this function is only temporarily intended to work as specified above and exists to enable The
+    /// Supra Foundation to ensure that the allocations of all investors are subject to the terms specified in the
+    /// corresponding legal contracts. It will be deactivated before the validator set it opened up to external 
+    /// validator-owners to prevent it from being abused.
     public entry fun replace_delegator(
         multisig_admin: &signer,
         pool_address: address,


### PR DESCRIPTION
See #150 and #151.

### QA Notes:

Please perform the following steps to help us verify that this new functionality is safe to deploy to and use in mainnet:
1. Start a local network running the current mainnet release ([`release/v7.1`](https://github.com/Entropy-Foundation/smr-moonshot/releases/tag/supra_node_v7.1.8)). Set `epoch_duration_secs` to something short---maybe 30 seconds. Also set `recurring_lockup_duration_secs` and `voting_duration_secs` to small values so that it is possible to unlock and withdraw stake during this test. Finally, set the `genesis_timestamp_microseconds` to 31 days ago (in microseconds). This will ensure that the first lockup period of the Delegation Pool vesting schedules has passed.
2. Delegate some stake to one of the genesis Delegation Pools on behalf of a few accounts using `0x1::pbo_delegation_pool::fund_delegators_with_stake`. You can find the keys for the pool owners after starting the local network in `smr-moonshot/remote-env/Logs/owners`.
3. Move the stake of different accounts into different states:
    a. Leave one account untouched.
    b. Unlock half of the stake of one account, but do not withdraw any.
    c. Unlock the full stake of one account, but do not withdraw any.
    d. Unlock the full stake of one account and withdraw half.
4. Build the new version of the Supra Framework from `dev` of our fork of `aptos-core` and deploy it to the local network via a framework upgrade governance transaction.
5. Unlock the stake of one account just before performing Step 6. The goal of this step is to ensure that one of the accounts has a `pending_inactive` allocation when Step 6 is performed.
6. Lock the previously delegated stakes by calling `0x1::pbo_delegation_pool::lock_delegators_stakes`. Use the original allocations when calling this function: Do not adjust for the fact that some of the stake has been withdrawn from some accounts.
7. Ensure that the remaining allocations of the accounts are now `active` and are subject to the vesting schedule. This can be confirmed by ensuring that the accounts that did not withdraw anything in the steps above can now unlock and withdraw their first-period allocations, and that the other accounts cannot unlock anything (yet).