### PR TITLE
Add functionality to change unlock schedule if feasible

### DIFF
--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -762,7 +762,7 @@ module supra_framework::pbo_delegation_pool {
     }
     /// Pre-condition: `cumulative_unlocked_fraction` should be zero, which would indicate that even
     /// though there are principle stake holders, none of those have yet called `unlock` on the pool
-    /// thus it may be ``safe'' to change the schedule
+    /// thus it is ``safe'' to change the schedule
     /// This is a temporary measure to allow Supra Foundation to change the schedule for those pools
     /// there were initialized with ``dummy/default'' schedule. This method should be disabled
     /// before external validator might be allowed to join  the validator set

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -765,7 +765,7 @@ module supra_framework::pbo_delegation_pool {
     /// thus it is ``safe'' to change the schedule
     /// This is a temporary measure to allow Supra Foundation to change the schedule for those pools
     /// there were initialized with ``dummy/default'' schedule. This method must be disabled
-    /// before external validator might be allowed to join  the validator set
+    /// before external validators are allowed to join the validator set.
     public entry fun update_unlocking_schedule (multisig_admin: &signer, 
             pool_address: address, unlock_numerators : vector<u64>, unlock_denominator : u64, unlock_start_time: u64,
             unlock_duration: u64) acquires DelegationPool {

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -764,7 +764,7 @@ module supra_framework::pbo_delegation_pool {
     /// though there are principle stake holders, none of those have yet called `unlock` on the pool
     /// thus it is ``safe'' to change the schedule
     /// This is a temporary measure to allow Supra Foundation to change the schedule for those pools
-    /// there were initialized with ``dummy/default'' schedule. This method should be disabled
+    /// there were initialized with ``dummy/default'' schedule. This method must be disabled
     /// before external validator might be allowed to join  the validator set
     public entry fun update_unlocking_schedule (multisig_admin: &signer, 
             pool_address: address, unlock_numerators : vector<u64>, unlock_denominator : u64, unlock_start_time: u64,

--- a/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
+++ b/aptos-move/framework/supra-framework/sources/pbo_delegation_pool.move
@@ -9260,7 +9260,7 @@ module supra_framework::pbo_delegation_pool {
             );
         assert!(unlock_coin, 20);
     }
-    // Test that after unlock schedule change can not happen after a princile stakeholder calls
+    // Test that after unlock schedule change can not happen after a principle stakeholder calls
     // `can_principle_unlock` and the unlock fraction becomes non zero
     #[test(supra_framework = @supra_framework, validator = @0x123, delegator = @0x010)]
     #[expected_failure(abort_code = 196646, location = Self)]


### PR DESCRIPTION
Add a functionality to change unlock schedule if possible to change unlock schedule.

After `can_principle_unlock` is called successfully which may result in `cumulative_unlocked_fraction` to become non-zero, this may not be called successfully.