### PR TITLE
Multiple improvements to Governance CLI

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
+++ b/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
@@ -50,6 +50,7 @@ module 0x{}::test {{
                 .to_path_buf()
                 .join(CompiledPackageLayout::Sources.path())
                 .join("proposal.move"),
+            "main".to_string(),
         )
         .unwrap();
     let _ = build_package(proposal_dir.path().to_path_buf(), BuildOptions::default()).unwrap();

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -164,16 +164,18 @@ impl ReleasePackage {
         &self,
         for_address: AccountAddress,
         out: PathBuf,
+        function_name: String,
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, false, false, Vec::new())
+        self.generate_script_proposal_impl(for_address, out, false, false, Vec::new(), function_name)
     }
 
     pub fn generate_script_proposal_testnet(
         &self,
         for_address: AccountAddress,
         out: PathBuf,
+        function_name: String,
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, true, false, Vec::new())
+        self.generate_script_proposal_impl(for_address, out, true, false, Vec::new(), function_name)
     }
 
     pub fn generate_script_proposal_multi_step(
@@ -181,8 +183,9 @@ impl ReleasePackage {
         for_address: AccountAddress,
         out: PathBuf,
         next_execution_hash: Vec<u8>,
+        function_name: String
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, true, true, next_execution_hash)
+        self.generate_script_proposal_impl(for_address, out, true, true, next_execution_hash, function_name)
     }
 
     fn generate_script_proposal_impl(
@@ -192,6 +195,7 @@ impl ReleasePackage {
         is_testnet: bool,
         is_multi_step: bool,
         next_execution_hash: Vec<u8>,
+        function_name: String,
     ) -> anyhow::Result<()> {
         let writer = CodeWriter::new(Loc::default());
         emitln!(
@@ -207,7 +211,7 @@ impl ReleasePackage {
         emitln!(writer, "use supra_framework::code;\n");
 
         if is_testnet && !is_multi_step {
-            emitln!(writer, "fun main(core_resources: &signer){");
+            emitln!(writer, "fun {}(core_resources: &signer){{", function_name);
             writer.indent();
             emitln!(
                 writer,
@@ -215,7 +219,7 @@ impl ReleasePackage {
                 for_address
             );
         } else if !is_multi_step {
-            emitln!(writer, "fun main(proposal_id: u64){");
+            emitln!(writer, "fun {}(proposal_id: u64){{", function_name);
             writer.indent();
             emitln!(
                 writer,
@@ -223,7 +227,7 @@ impl ReleasePackage {
                 for_address
             );
         } else {
-            emitln!(writer, "fun main(proposal_id: u64){");
+            emitln!(writer, "fun {}(proposal_id: u64){{", function_name);
             writer.indent();
             Self::generate_next_execution_hash_blob(&writer, for_address, next_execution_hash);
         }
@@ -289,14 +293,14 @@ impl ReleasePackage {
         if next_execution_hash == "vector::empty<u8>()".as_bytes() {
             emitln!(
                 writer,
-                "let framework_signer = supra_governance::resolve_multi_step_proposal(proposal_id, @{}, {});\n",
+                "let framework_signer = supra_governance::resolve_supra_multi_step_proposal(proposal_id, @{}, {});\n",
                 for_address,
                 "vector::empty<u8>()",
             );
         } else {
             emitln!(
                 writer,
-                "let framework_signer = supra_governance::resolve_multi_step_proposal("
+                "let framework_signer = supra_governance::resolve_supra_multi_step_proposal("
             );
             writer.indent();
             emitln!(writer, "proposal_id,");

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -205,7 +205,11 @@ impl ReleasePackage {
             "// Upgrade proposal for package `{}`\n",
             self.metadata.name
         );
-        emitln!(writer, "// source digest: {}", self.metadata.source_digest);
+
+        // The Sha2-256 digest here is the combined hash of all the hashes of the `.move` files and
+        // the manifest file(Move.toml) in the source package.
+        // Check [move_package::resolution::digest::compile_digest]
+        emitln!(writer, "// source package's SHA2-256 digest: {}", self.metadata.source_digest);
         emitln!(writer, "script {");
         writer.indent();
         emitln!(writer, "use std::vector;");
@@ -213,7 +217,7 @@ impl ReleasePackage {
         emitln!(writer, "use supra_framework::code;\n");
 
         if is_testnet && !is_multi_step {
-            emitln!(writer, "fun {function_name}(core_resources: &signer){{");
+            emitln!(writer, "fun {function_name} (core_resources: &signer) {{");
             writer.indent();
             emitln!(
                 writer,
@@ -221,7 +225,7 @@ impl ReleasePackage {
                 for_address
             );
         } else if !is_multi_step {
-            emitln!(writer, "fun {}(proposal_id: u64){{", function_name);
+            emitln!(writer, "fun {} (proposal_id: u64) {{", function_name);
             writer.indent();
             emitln!(
                 writer,
@@ -229,7 +233,7 @@ impl ReleasePackage {
                 for_address
             );
         } else {
-            emitln!(writer, "fun {}(proposal_id: u64){{", function_name);
+            emitln!(writer, "fun {} (proposal_id: u64) {{", function_name);
             writer.indent();
             Self::generate_next_execution_hash_blob(&writer, for_address, next_execution_hash);
         }

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -166,7 +166,7 @@ impl ReleasePackage {
         out: PathBuf,
         function_name: String,
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, false, false, Vec::new(), function_name)
+        self.generate_script_proposal_impl(for_address, out, false, false, String::new(), function_name)
     }
 
     pub fn generate_script_proposal_testnet(
@@ -175,14 +175,14 @@ impl ReleasePackage {
         out: PathBuf,
         function_name: String,
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, true, false, Vec::new(), function_name)
+        self.generate_script_proposal_impl(for_address, out, true, false, String::new(), function_name)
     }
 
     pub fn generate_script_proposal_multi_step(
         &self,
         for_address: AccountAddress,
         out: PathBuf,
-        next_execution_hash: Vec<u8>,
+        next_execution_hash: String,
         function_name: String
     ) -> anyhow::Result<()> {
         self.generate_script_proposal_impl(for_address, out, true, true, next_execution_hash, function_name)
@@ -194,7 +194,7 @@ impl ReleasePackage {
         out: PathBuf,
         is_testnet: bool,
         is_multi_step: bool,
-        next_execution_hash: Vec<u8>,
+        next_execution_hash: String,
         function_name: String,
     ) -> anyhow::Result<()> {
         let writer = CodeWriter::new(Loc::default());
@@ -288,9 +288,9 @@ impl ReleasePackage {
     fn generate_next_execution_hash_blob(
         writer: &CodeWriter,
         for_address: AccountAddress,
-        next_execution_hash: Vec<u8>,
+        next_execution_hash: String,
     ) {
-        if next_execution_hash == "vector::empty<u8>()".as_bytes() {
+        if next_execution_hash.is_empty() {
             emitln!(
                 writer,
                 "let framework_signer = supra_governance::resolve_supra_multi_step_proposal(proposal_id, @{}, {});\n",
@@ -305,11 +305,12 @@ impl ReleasePackage {
             writer.indent();
             emitln!(writer, "proposal_id,");
             emitln!(writer, "@{},", for_address);
-            emit!(writer, "vector[");
-            for b in next_execution_hash.iter() {
-                emit!(writer, "{}u8,", b);
-            }
-            emitln!(writer, "],");
+            emitln!(writer, "x{}", next_execution_hash);
+            // emit!(writer, "vector[");
+            // for b in next_execution_hash.iter() {
+            //     emit!(writer, "{}u8,", b);
+            // }
+            // emitln!(writer, "],");
             writer.unindent();
             emitln!(writer, ");");
         }

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -10,6 +10,8 @@ use move_core_types::language_storage::ModuleId;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf};
+use std::fmt::Display;
+use aptos_crypto::HashValue;
 
 /// A release bundle consists of a list of release packages.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -166,7 +168,7 @@ impl ReleasePackage {
         out: PathBuf,
         function_name: String,
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, false, false, String::new(), function_name)
+        self.generate_script_proposal_impl(for_address, out, false, false, None, function_name)
     }
 
     pub fn generate_script_proposal_testnet(
@@ -175,14 +177,14 @@ impl ReleasePackage {
         out: PathBuf,
         function_name: String,
     ) -> anyhow::Result<()> {
-        self.generate_script_proposal_impl(for_address, out, true, false, String::new(), function_name)
+        self.generate_script_proposal_impl(for_address, out, true, false, None, function_name)
     }
 
     pub fn generate_script_proposal_multi_step(
         &self,
         for_address: AccountAddress,
         out: PathBuf,
-        next_execution_hash: String,
+        next_execution_hash: Option<HashValue>,
         function_name: String
     ) -> anyhow::Result<()> {
         self.generate_script_proposal_impl(for_address, out, true, true, next_execution_hash, function_name)
@@ -194,7 +196,7 @@ impl ReleasePackage {
         out: PathBuf,
         is_testnet: bool,
         is_multi_step: bool,
-        next_execution_hash: String,
+        next_execution_hash: Option<HashValue>,
         function_name: String,
     ) -> anyhow::Result<()> {
         let writer = CodeWriter::new(Loc::default());
@@ -211,7 +213,7 @@ impl ReleasePackage {
         emitln!(writer, "use supra_framework::code;\n");
 
         if is_testnet && !is_multi_step {
-            emitln!(writer, "fun {}(core_resources: &signer){{", function_name);
+            emitln!(writer, "fun {function_name}(core_resources: &signer){{");
             writer.indent();
             emitln!(
                 writer,
@@ -288,16 +290,9 @@ impl ReleasePackage {
     fn generate_next_execution_hash_blob(
         writer: &CodeWriter,
         for_address: AccountAddress,
-        next_execution_hash: String,
+        next_execution_hash: Option<HashValue>,
     ) {
-        if next_execution_hash.is_empty() {
-            emitln!(
-                writer,
-                "let framework_signer = supra_governance::resolve_supra_multi_step_proposal(proposal_id, @{}, {});\n",
-                for_address,
-                "vector::empty<u8>()",
-            );
-        } else {
+        if let Some(hash) = next_execution_hash {
             emitln!(
                 writer,
                 "let framework_signer = supra_governance::resolve_supra_multi_step_proposal("
@@ -305,14 +300,16 @@ impl ReleasePackage {
             writer.indent();
             emitln!(writer, "proposal_id,");
             emitln!(writer, "@{},", for_address);
-            emitln!(writer, "x{}", next_execution_hash);
-            // emit!(writer, "vector[");
-            // for b in next_execution_hash.iter() {
-            //     emit!(writer, "{}u8,", b);
-            // }
-            // emitln!(writer, "],");
+            emitln!(writer, "x\"{:x}\"", hash);
             writer.unindent();
             emitln!(writer, ");");
+        } else {
+            emitln!(
+                writer,
+                "let framework_signer = supra_governance::resolve_supra_multi_step_proposal(proposal_id, @{}, {});\n",
+                for_address,
+                "vector::empty<u8>()",
+            );
         }
     }
 }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -67,6 +67,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
+use aptos_crypto::hash::HashValueParseError;
 
 pub const USER_AGENT: &str = concat!("aptos-cli/", env!("CARGO_PKG_VERSION"));
 const US_IN_SECS: u64 = 1_000_000;
@@ -116,6 +117,8 @@ pub enum CliError {
     SimulationError(String),
     #[error("Coverage failed with status: {0}")]
     CoverageError(String),
+    #[error("Failed to parse hash {1} with error: {0}")]
+    HashError(#[source] HashValueParseError, String),
 }
 
 impl CliError {
@@ -136,6 +139,7 @@ impl CliError {
             CliError::UnexpectedError(_) => "UnexpectedError",
             CliError::SimulationError(_) => "SimulationError",
             CliError::CoverageError(_) => "CoverageError",
+            CliError::HashError(..) => "HashError",
         }
     }
 }

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -50,6 +50,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use std::fmt::Display;
+use std::str::FromStr;
 use supra_aptos::{SupraCommand, SupraCommandArguments};
 use tempfile::TempDir;
 use crate::move_tool::IncludedArtifacts::{All, Sparse};
@@ -1048,8 +1049,8 @@ pub struct GenerateUpgradeProposal {
     #[clap(long, default_value = "")]
     pub(crate) next_execution_hash: String,
 
-    ///  To denote if the upgrade is done via a Single-step or a Multi-step proposal
-    #[clap(long, default_value_t = ProposalType::SingleStep)]
+    /// To denote if the upgrade is done via a Single-step or a Multi-step proposal
+    #[clap(long)]
     pub(crate) proposal_type: ProposalType,
 
     /// Name of the smart contract proposal function. Defaults to 'main' if not supplied
@@ -1118,7 +1119,13 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             }
             // If we're generating a multi-step proposal
         } else {
-            // let next_execution_hash_bytes = hex::decode(next_execution_hash)?;
+            let next_execution_hash = if !next_execution_hash.is_empty() {
+                Some(HashValue::from_str(&next_execution_hash)
+                    .map_err(|e| CliError::HashError(e, next_execution_hash))?)
+            } else {
+                None
+            };
+
             release.generate_script_proposal_multi_step(
                 account,
                 output,

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -1118,11 +1118,11 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             }
             // If we're generating a multi-step proposal
         } else {
-            let next_execution_hash_bytes = hex::decode(next_execution_hash)?;
+            // let next_execution_hash_bytes = hex::decode(next_execution_hash)?;
             release.generate_script_proposal_multi_step(
                 account,
                 output,
-                next_execution_hash_bytes,
+                next_execution_hash,
                 function_name
             )?;
         }

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -36,7 +36,7 @@ use aptos_types::{
     transaction::{Script, TransactionPayload},
 };
 use async_trait::async_trait;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use move_core_types::{
     ident_str, language_storage::ModuleId, parser::parse_type_tag,
     transaction_argument::TransactionArgument,
@@ -49,8 +49,10 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use std::fmt::Display;
 use supra_aptos::{SupraCommand, SupraCommandArguments};
 use tempfile::TempDir;
+use crate::move_tool::IncludedArtifacts::{All, Sparse};
 
 /// Tool for on-chain governance
 ///
@@ -1046,8 +1048,32 @@ pub struct GenerateUpgradeProposal {
     #[clap(long, default_value = "")]
     pub(crate) next_execution_hash: String,
 
+    ///  To denote if the upgrade is done via a Single-step or a Multi-step proposal
+    #[clap(long, default_value_t = ProposalType::SingleStep)]
+    pub(crate) proposal_type: ProposalType,
+
+    /// Name of the smart contract proposal function. Defaults to 'main' if not supplied
+    #[clap(long, default_value = "main")]
+    pub(crate) function_name: String,
+
     #[clap(flatten)]
     pub(crate) move_options: MovePackageDir,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+pub enum ProposalType {
+    SingleStep,
+    MultiStep,
+}
+
+impl Display for ProposalType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use ProposalType::*;
+        match self {
+            SingleStep => f.write_str("single-step"),
+            MultiStep => f.write_str("multi-step"),
+        }
+    }
 }
 
 #[async_trait]
@@ -1064,6 +1090,8 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             output,
             testnet,
             next_execution_hash,
+            proposal_type,
+            function_name
         } = self;
         let package_path = move_options.get_package_path()?;
         let options = included_artifacts.build_options(
@@ -1080,12 +1108,14 @@ impl CliCommand<()> for GenerateUpgradeProposal {
         let package = BuiltPackage::build(package_path, options)?;
         let release = ReleasePackage::new(package)?;
 
-        // If we're generating a single-step proposal on testnet
-        if testnet && next_execution_hash.is_empty() {
-            release.generate_script_proposal_testnet(account, output)?;
+        if let ProposalType::SingleStep = proposal_type {
+            // If we're generating a single-step proposal on testnet
+            if testnet {
+                release.generate_script_proposal_testnet(account, output, function_name)?;
             // If we're generating a single-step proposal on mainnet
-        } else if next_execution_hash.is_empty() {
-            release.generate_script_proposal(account, output)?;
+            } else {
+                release.generate_script_proposal(account, output, function_name)?;
+            }
             // If we're generating a multi-step proposal
         } else {
             let next_execution_hash_bytes = hex::decode(next_execution_hash)?;
@@ -1093,8 +1123,9 @@ impl CliCommand<()> for GenerateUpgradeProposal {
                 account,
                 output,
                 next_execution_hash_bytes,
+                function_name
             )?;
-        };
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Addresses all requirements listed in https://github.com/Entropy-Foundation/smr-moonshot/issues/1468.

Changes:
- Improved the following parameters in Governance proposal generator CLI command
```
Generates a package upgrade proposal script

Usage: supra governance generate-upgrade-proposal [OPTIONS] --account <ACCOUNT>
        . . . . . . . . .
      --next-execution-hash <NEXT_EXECUTION_HASH> 
          [default: ] // Can now take empty string for Multi-Step proposals
      --proposal-type <PROPOSAL_TYPE>
          To denote if the upgrade is done via a Single-step or a Multi-step proposal [default: single-step] [possible values: single-step, multi-step]
      --function-name <FUNCTION_NAME>
          Name of the smart contract proposal function. Defaults to 'main' if not supplied [default: main]
        . . . . . . . . .
```

- The input `next-execution-hash` in the `generate-upgrade-proposal` governance CLI command is emitted as a hex string in the upgrade script that is generated(which was _bytearray_ previously) to improve readability.

- Updated the generator to use the correct supra_governance smart contract function `resolve_supra_multi_step_proposal`.

### Testing

Requested QA to test the new and improved parameters and try generating and executing a governance upgrade successfully.