### PR TITLE
[move-2] self function parameters for move-stdlib and aptos-stdlib

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/any.md
+++ b/aptos-move/framework/aptos-stdlib/doc/any.md
@@ -120,7 +120,7 @@ also required from <code>T</code>.
 Unpack a value from the <code><a href="any.md#0x1_any_Any">Any</a></code> representation. This aborts if the value has not the expected type <code>T</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_unpack">unpack</a>&lt;T&gt;(x: <a href="any.md#0x1_any_Any">any::Any</a>): T
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_unpack">unpack</a>&lt;T&gt;(self: <a href="any.md#0x1_any_Any">any::Any</a>): T
 </code></pre>
 
 
@@ -129,9 +129,9 @@ Unpack a value from the <code><a href="any.md#0x1_any_Any">Any</a></code> repres
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_unpack">unpack</a>&lt;T&gt;(x: <a href="any.md#0x1_any_Any">Any</a>): T {
-    <b>assert</b>!(<a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() == x.type_name, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="any.md#0x1_any_ETYPE_MISMATCH">ETYPE_MISMATCH</a>));
-    from_bytes&lt;T&gt;(x.data)
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_unpack">unpack</a>&lt;T&gt;(self: <a href="any.md#0x1_any_Any">Any</a>): T {
+    <b>assert</b>!(<a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() == self.type_name, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="any.md#0x1_any_ETYPE_MISMATCH">ETYPE_MISMATCH</a>));
+    from_bytes&lt;T&gt;(self.data)
 }
 </code></pre>
 
@@ -146,7 +146,7 @@ Unpack a value from the <code><a href="any.md#0x1_any_Any">Any</a></code> repres
 Returns the type name of this Any
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_type_name">type_name</a>(x: &<a href="any.md#0x1_any_Any">any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_type_name">type_name</a>(self: &<a href="any.md#0x1_any_Any">any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
@@ -155,8 +155,8 @@ Returns the type name of this Any
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_type_name">type_name</a>(x: &<a href="any.md#0x1_any_Any">Any</a>): &String {
-    &x.type_name
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_type_name">type_name</a>(self: &<a href="any.md#0x1_any_Any">Any</a>): &String {
+    &self.type_name
 }
 </code></pre>
 
@@ -195,14 +195,14 @@ Returns the type name of this Any
 ### Function `unpack`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_unpack">unpack</a>&lt;T&gt;(x: <a href="any.md#0x1_any_Any">any::Any</a>): T
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_unpack">unpack</a>&lt;T&gt;(self: <a href="any.md#0x1_any_Any">any::Any</a>): T
 </code></pre>
 
 
 
 
 <pre><code><b>include</b> <a href="any.md#0x1_any_UnpackAbortsIf">UnpackAbortsIf</a>&lt;T&gt;;
-<b>ensures</b> result == <a href="from_bcs.md#0x1_from_bcs_deserialize">from_bcs::deserialize</a>&lt;T&gt;(x.data);
+<b>ensures</b> result == <a href="from_bcs.md#0x1_from_bcs_deserialize">from_bcs::deserialize</a>&lt;T&gt;(self.data);
 </code></pre>
 
 
@@ -212,9 +212,9 @@ Returns the type name of this Any
 
 
 <pre><code><b>schema</b> <a href="any.md#0x1_any_UnpackAbortsIf">UnpackAbortsIf</a>&lt;T&gt; {
-    x: <a href="any.md#0x1_any_Any">Any</a>;
-    <b>aborts_if</b> <a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() != x.type_name;
-    <b>aborts_if</b> !<a href="from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;T&gt;(x.data);
+    self: <a href="any.md#0x1_any_Any">Any</a>;
+    <b>aborts_if</b> <a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() != self.type_name;
+    <b>aborts_if</b> !<a href="from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;T&gt;(self.data);
 }
 </code></pre>
 
@@ -225,9 +225,9 @@ Returns the type name of this Any
 
 
 <pre><code><b>schema</b> <a href="any.md#0x1_any_UnpackRequirement">UnpackRequirement</a>&lt;T&gt; {
-    x: <a href="any.md#0x1_any_Any">Any</a>;
-    <b>requires</b> <a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() == x.type_name;
-    <b>requires</b> <a href="from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;T&gt;(x.data);
+    self: <a href="any.md#0x1_any_Any">Any</a>;
+    <b>requires</b> <a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() == self.type_name;
+    <b>requires</b> <a href="from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;T&gt;(self.data);
 }
 </code></pre>
 
@@ -238,14 +238,14 @@ Returns the type name of this Any
 ### Function `type_name`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_type_name">type_name</a>(x: &<a href="any.md#0x1_any_Any">any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any_type_name">type_name</a>(self: &<a href="any.md#0x1_any_Any">any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == x.type_name;
+<b>ensures</b> result == self.type_name;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/big_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/big_vector.md
@@ -197,11 +197,11 @@ Create a vector of length 1 containing the passed in element.
 
 ## Function `destroy_empty`
 
-Destroy the vector <code>v</code>.
-Aborts if <code>v</code> is not empty.
+Destroy the vector <code>self</code>.
+Aborts if <code>self</code> is not empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(self: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -210,9 +210,9 @@ Aborts if <code>v</code> is not empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
-    <b>assert</b>!(<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(&v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EVECTOR_NOT_EMPTY">EVECTOR_NOT_EMPTY</a>));
-    <b>let</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a> { buckets, end_index: _, bucket_size: _ } = v;
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(self: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
+    <b>assert</b>!(<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(&self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EVECTOR_NOT_EMPTY">EVECTOR_NOT_EMPTY</a>));
+    <b>let</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a> { buckets, end_index: _, bucket_size: _ } = self;
     <a href="table_with_length.md#0x1_table_with_length_destroy_empty">table_with_length::destroy_empty</a>(buckets);
 }
 </code></pre>
@@ -225,10 +225,10 @@ Aborts if <code>v</code> is not empty.
 
 ## Function `destroy`
 
-Destroy the vector <code>v</code> if T has <code>drop</code>
+Destroy the vector <code>self</code> if T has <code>drop</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy">destroy</a>&lt;T: drop&gt;(v: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy">destroy</a>&lt;T: drop&gt;(self: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -237,8 +237,8 @@ Destroy the vector <code>v</code> if T has <code>drop</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy">destroy</a>&lt;T: drop&gt;(v: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
-    <b>let</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a> { buckets, end_index, bucket_size: _ } = v;
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy">destroy</a>&lt;T: drop&gt;(self: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
+    <b>let</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a> { buckets, end_index, bucket_size: _ } = self;
     <b>let</b> i = 0;
     <b>while</b> (end_index &gt; 0) {
         <b>let</b> num_elements = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> buckets, i));
@@ -257,11 +257,11 @@ Destroy the vector <code>v</code> if T has <code>drop</code>
 
 ## Function `borrow`
 
-Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
+Acquire an immutable reference to the <code>i</code>th element of the vector <code>self</code>.
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow">borrow</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &T
 </code></pre>
 
 
@@ -270,9 +270,9 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): &T {
-    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&v.buckets, i / v.bucket_size), i % v.bucket_size)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow">borrow</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): &T {
+    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&self.buckets, i / self.bucket_size), i % self.bucket_size)
 }
 </code></pre>
 
@@ -284,11 +284,11 @@ Aborts if <code>i</code> is out of bounds.
 
 ## Function `borrow_mut`
 
-Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
+Return a mutable reference to the <code>i</code>th element in the vector <code>self</code>.
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T
 </code></pre>
 
 
@@ -297,9 +297,9 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T {
-    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, i / v.bucket_size), i % v.bucket_size)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T {
+    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, i / self.bucket_size), i % self.bucket_size)
 }
 </code></pre>
 
@@ -311,12 +311,12 @@ Aborts if <code>i</code> is out of bounds.
 
 ## Function `append`
 
-Empty and destroy the other vector, and push each of the elements in the other vector onto the lhs vector in the
+Empty and destroy the other vector, and push each of the elements in the other vector onto the self vector in the
 same order as they occurred in other.
 Disclaimer: This function is costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_append">append</a>&lt;T: store&gt;(lhs: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, other: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_append">append</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, other: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -325,16 +325,16 @@ Disclaimer: This function is costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_append">append</a>&lt;T: store&gt;(lhs: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, other: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_append">append</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, other: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
     <b>let</b> other_len = <a href="big_vector.md#0x1_big_vector_length">length</a>(&other);
     <b>let</b> half_other_len = other_len / 2;
     <b>let</b> i = 0;
     <b>while</b> (i &lt; half_other_len) {
-        <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>(lhs, <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>(&<b>mut</b> other, i));
+        <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>(self, <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>(&<b>mut</b> other, i));
         i = i + 1;
     };
     <b>while</b> (i &lt; other_len) {
-        <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>(lhs, <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>(&<b>mut</b> other));
+        <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>(self, <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>(&<b>mut</b> other));
         i = i + 1;
     };
     <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>(other);
@@ -349,11 +349,11 @@ Disclaimer: This function is costly. Use it at your own discretion.
 
 ## Function `push_back`
 
-Add element <code>val</code> to the end of the vector <code>v</code>. It grows the buckets when the current buckets are full.
+Add element <code>val</code> to the end of the vector <code>self</code>. It grows the buckets when the current buckets are full.
 This operation will cost more gas when it adds new bucket.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: T)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: T)
 </code></pre>
 
 
@@ -362,15 +362,15 @@ This operation will cost more gas when it adds new bucket.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, val: T) {
-    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets);
-    <b>if</b> (v.end_index == num_buckets * v.bucket_size) {
-        <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> v.buckets, num_buckets, <a href="../../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>());
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, num_buckets), val);
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, val: T) {
+    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets);
+    <b>if</b> (self.end_index == num_buckets * self.bucket_size) {
+        <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> self.buckets, num_buckets, <a href="../../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>());
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, num_buckets), val);
     } <b>else</b> {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, num_buckets - 1), val);
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, num_buckets - 1), val);
     };
-    v.end_index = v.end_index + 1;
+    self.end_index = self.end_index + 1;
 }
 </code></pre>
 
@@ -382,12 +382,12 @@ This operation will cost more gas when it adds new bucket.
 
 ## Function `pop_back`
 
-Pop an element from the end of vector <code>v</code>. It doesn't shrink the buckets even if they're empty.
+Pop an element from the end of vector <code>self</code>. It doesn't shrink the buckets even if they're empty.
 Call <code>shrink_to_fit</code> explicity to deallocate empty buckets.
-Aborts if <code>v</code> is empty.
+Aborts if <code>self</code> is empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): T
 </code></pre>
 
 
@@ -396,17 +396,17 @@ Aborts if <code>v</code> is empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): T {
-    <b>assert</b>!(!<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="big_vector.md#0x1_big_vector_EVECTOR_EMPTY">EVECTOR_EMPTY</a>));
-    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets);
-    <b>let</b> last_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, num_buckets - 1);
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): T {
+    <b>assert</b>!(!<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="big_vector.md#0x1_big_vector_EVECTOR_EMPTY">EVECTOR_EMPTY</a>));
+    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets);
+    <b>let</b> last_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, num_buckets - 1);
     <b>let</b> val = <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(last_bucket);
     // Shrink the <a href="table.md#0x1_table">table</a> <b>if</b> the last <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a> is empty.
     <b>if</b> (<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(last_bucket)) {
         <b>move</b> last_bucket;
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> v.buckets, num_buckets - 1));
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, num_buckets - 1));
     };
-    v.end_index = v.end_index - 1;
+    self.end_index = self.end_index - 1;
     val
 }
 </code></pre>
@@ -419,12 +419,12 @@ Aborts if <code>v</code> is empty.
 
 ## Function `remove`
 
-Remove the element at index i in the vector v and return the owned value that was previously stored at i in v.
+Remove the element at index i in the vector v and return the owned value that was previously stored at i in self.
 All elements occurring at indices greater than i will be shifted down by 1. Will abort if i is out of bounds.
 Disclaimer: This function is costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_remove">remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_remove">remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
@@ -433,28 +433,28 @@ Disclaimer: This function is costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_remove">remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): T {
-    <b>let</b> len = <a href="big_vector.md#0x1_big_vector_length">length</a>(v);
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_remove">remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): T {
+    <b>let</b> len = <a href="big_vector.md#0x1_big_vector_length">length</a>(self);
     <b>assert</b>!(i &lt; len, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets);
-    <b>let</b> cur_bucket_index = i / v.bucket_size + 1;
-    <b>let</b> cur_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, cur_bucket_index - 1);
-    <b>let</b> res = <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(cur_bucket, i % v.bucket_size);
-    v.end_index = v.end_index - 1;
+    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets);
+    <b>let</b> cur_bucket_index = i / self.bucket_size + 1;
+    <b>let</b> cur_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, cur_bucket_index - 1);
+    <b>let</b> res = <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(cur_bucket, i % self.bucket_size);
+    self.end_index = self.end_index - 1;
     <b>move</b> cur_bucket;
     <b>while</b> ({
         <b>spec</b> {
             <b>invariant</b> cur_bucket_index &lt;= num_buckets;
-            <b>invariant</b> <a href="table_with_length.md#0x1_table_with_length_spec_len">table_with_length::spec_len</a>(v.buckets) == num_buckets;
+            <b>invariant</b> <a href="table_with_length.md#0x1_table_with_length_spec_len">table_with_length::spec_len</a>(self.buckets) == num_buckets;
         };
         (cur_bucket_index &lt; num_buckets)
     }) {
         // remove one element from the start of current <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>
-        <b>let</b> cur_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, cur_bucket_index);
+        <b>let</b> cur_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, cur_bucket_index);
         <b>let</b> t = <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(cur_bucket, 0);
         <b>move</b> cur_bucket;
         // and put it at the end of the last one
-        <b>let</b> prev_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, cur_bucket_index - 1);
+        <b>let</b> prev_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, cur_bucket_index - 1);
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(prev_bucket, t);
         cur_bucket_index = cur_bucket_index + 1;
     };
@@ -463,10 +463,10 @@ Disclaimer: This function is costly. Use it at your own discretion.
     };
 
     // Shrink the <a href="table.md#0x1_table">table</a> <b>if</b> the last <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a> is empty.
-    <b>let</b> last_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, num_buckets - 1);
+    <b>let</b> last_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, num_buckets - 1);
     <b>if</b> (<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(last_bucket)) {
         <b>move</b> last_bucket;
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> v.buckets, num_buckets - 1));
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, num_buckets - 1));
     };
 
     res
@@ -481,12 +481,12 @@ Disclaimer: This function is costly. Use it at your own discretion.
 
 ## Function `swap_remove`
 
-Swap the <code>i</code>th element of the vector <code>v</code> with the last element and then pop the vector.
+Swap the <code>i</code>th element of the vector <code>self</code> with the last element and then pop the vector.
 This is O(1), but does not preserve ordering of elements in the vector.
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
@@ -495,20 +495,20 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): T {
-    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> last_val = <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>(v);
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64): T {
+    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
+    <b>let</b> last_val = <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>(self);
     // <b>if</b> the requested value is the last one, <b>return</b> it
-    <b>if</b> (v.end_index == i) {
+    <b>if</b> (self.end_index == i) {
         <b>return</b> last_val
     };
     // because the lack of mem::swap, here we swap remove the requested value from the bucket
     // and append the last_val <b>to</b> the bucket then swap the last bucket val back
-    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, i / v.bucket_size);
+    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, i / self.bucket_size);
     <b>let</b> bucket_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket);
-    <b>let</b> val = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(bucket, i % v.bucket_size);
+    <b>let</b> val = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(bucket, i % self.bucket_size);
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(bucket, last_val);
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(bucket, i % v.bucket_size, bucket_len - 1);
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(bucket, i % self.bucket_size, bucket_len - 1);
     val
 }
 </code></pre>
@@ -521,11 +521,11 @@ Aborts if <code>i</code> is out of bounds.
 
 ## Function `swap`
 
-Swap the elements at the i'th and j'th indices in the vector v. Will abort if either of i or j are out of bounds
-for v.
+Swap the elements at the i'th and j'th indices in the vector self. Will abort if either of i or j are out of bounds
+for self.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap">swap</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64, j: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap">swap</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64, j: u64)
 </code></pre>
 
 
@@ -534,19 +534,19 @@ for v.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap">swap</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64, j: u64) {
-    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(v) && j &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> i_bucket_index = i / v.bucket_size;
-    <b>let</b> j_bucket_index = j / v.bucket_size;
-    <b>let</b> i_vector_index = i % v.bucket_size;
-    <b>let</b> j_vector_index = j % v.bucket_size;
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap">swap</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, i: u64, j: u64) {
+    <b>assert</b>!(i &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(self) && j &lt; <a href="big_vector.md#0x1_big_vector_length">length</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="big_vector.md#0x1_big_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
+    <b>let</b> i_bucket_index = i / self.bucket_size;
+    <b>let</b> j_bucket_index = j / self.bucket_size;
+    <b>let</b> i_vector_index = i % self.bucket_size;
+    <b>let</b> j_vector_index = j % self.bucket_size;
     <b>if</b> (i_bucket_index == j_bucket_index) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> v.buckets, i_bucket_index), i_vector_index, j_vector_index);
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, i_bucket_index), i_vector_index, j_vector_index);
         <b>return</b>
     };
     // If i and j are in different buckets, take the buckets out first for easy mutation.
-    <b>let</b> bucket_i = <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> v.buckets, i_bucket_index);
-    <b>let</b> bucket_j = <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> v.buckets, j_bucket_index);
+    <b>let</b> bucket_i = <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, i_bucket_index);
+    <b>let</b> bucket_j = <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, j_bucket_index);
     // Get the elements from buckets by calling `swap_remove`.
     <b>let</b> element_i = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(&<b>mut</b> bucket_i, i_vector_index);
     <b>let</b> element_j = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(&<b>mut</b> bucket_j, j_vector_index);
@@ -559,8 +559,8 @@ for v.
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(&<b>mut</b> bucket_i, i_vector_index, last_index_in_bucket_i);
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(&<b>mut</b> bucket_j, j_vector_index, last_index_in_bucket_j);
     // Add back the buckets.
-    <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> v.buckets, i_bucket_index, bucket_i);
-    <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> v.buckets, j_bucket_index, bucket_j);
+    <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> self.buckets, i_bucket_index, bucket_i);
+    <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> self.buckets, j_bucket_index, bucket_j);
 }
 </code></pre>
 
@@ -572,11 +572,11 @@ for v.
 
 ## Function `reverse`
 
-Reverse the order of the elements in the vector v in-place.
+Reverse the order of the elements in the vector self in-place.
 Disclaimer: This function is costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_reverse">reverse</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_reverse">reverse</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -585,17 +585,17 @@ Disclaimer: This function is costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_reverse">reverse</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_reverse">reverse</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;) {
     <b>let</b> new_buckets = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>let</b> push_bucket = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets);
+    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets);
     <b>let</b> num_buckets_left = num_buckets;
 
     <b>while</b> (num_buckets_left &gt; 0) {
-        <b>let</b> pop_bucket = <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> v.buckets, num_buckets_left - 1);
+        <b>let</b> pop_bucket = <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, num_buckets_left - 1);
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_for_each_reverse">vector::for_each_reverse</a>(pop_bucket, |val| {
             <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> push_bucket, val);
-            <b>if</b> (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&push_bucket) == v.bucket_size) {
+            <b>if</b> (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&push_bucket) == self.bucket_size) {
                 <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> new_buckets, push_bucket);
                 push_bucket = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
             };
@@ -611,9 +611,9 @@ Disclaimer: This function is costly. Use it at your own discretion.
 
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_reverse">vector::reverse</a>(&<b>mut</b> new_buckets);
     <b>let</b> i = 0;
-    <b>assert</b>!(<a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets) == 0, 0);
+    <b>assert</b>!(<a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets) == 0, 0);
     <b>while</b> (i &lt; num_buckets) {
-        <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> v.buckets, i, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> new_buckets));
+        <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> self.buckets, i, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> new_buckets));
         i = i + 1;
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(new_buckets);
@@ -628,12 +628,12 @@ Disclaimer: This function is costly. Use it at your own discretion.
 
 ## Function `index_of`
 
-Return the index of the first occurrence of an element in v that is equal to e. Returns (true, index) if such an
+Return the index of the first occurrence of an element in self that is equal to e. Returns (true, index) if such an
 element was found, and (false, 0) otherwise.
 Disclaimer: This function is costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: &T): (bool, u64)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: &T): (bool, u64)
 </code></pre>
 
 
@@ -642,14 +642,14 @@ Disclaimer: This function is costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, val: &T): (bool, u64) {
-    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets);
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, val: &T): (bool, u64) {
+    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets);
     <b>let</b> bucket_index = 0;
     <b>while</b> (bucket_index &lt; num_buckets) {
-        <b>let</b> cur = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&v.buckets, bucket_index);
+        <b>let</b> cur = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&self.buckets, bucket_index);
         <b>let</b> (found, i) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(cur, val);
         <b>if</b> (found) {
-            <b>return</b> (<b>true</b>, bucket_index * v.bucket_size + i)
+            <b>return</b> (<b>true</b>, bucket_index * self.bucket_size + i)
         };
         bucket_index = bucket_index + 1;
     };
@@ -665,11 +665,11 @@ Disclaimer: This function is costly. Use it at your own discretion.
 
 ## Function `contains`
 
-Return if an element equal to e exists in the vector v.
+Return if an element equal to e exists in the vector self.
 Disclaimer: This function is costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_contains">contains</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: &T): bool
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_contains">contains</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: &T): bool
 </code></pre>
 
 
@@ -678,9 +678,9 @@ Disclaimer: This function is costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_contains">contains</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, val: &T): bool {
-    <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(v)) <b>return</b> <b>false</b>;
-    <b>let</b> (exist, _) = <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>(v, val);
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_contains">contains</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;, val: &T): bool {
+    <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(self)) <b>return</b> <b>false</b>;
+    <b>let</b> (exist, _) = <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>(self, val);
     exist
 }
 </code></pre>
@@ -698,7 +698,7 @@ atomic view of the whole vector.
 Disclaimer: This function may be costly as the big vector may be huge in size. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_to_vector">to_vector</a>&lt;T: <b>copy</b>&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_to_vector">to_vector</a>&lt;T: <b>copy</b>&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;
 </code></pre>
 
 
@@ -707,12 +707,12 @@ Disclaimer: This function may be costly as the big vector may be huge in size. U
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_to_vector">to_vector</a>&lt;T: <b>copy</b>&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_to_vector">to_vector</a>&lt;T: <b>copy</b>&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt; {
     <b>let</b> res = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&v.buckets);
+    <b>let</b> num_buckets = <a href="table_with_length.md#0x1_table_with_length_length">table_with_length::length</a>(&self.buckets);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; num_buckets) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> res, *<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&v.buckets, i));
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> res, *<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&self.buckets, i));
         i = i + 1;
     };
     res
@@ -730,7 +730,7 @@ Disclaimer: This function may be costly as the big vector may be huge in size. U
 Return the length of the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_length">length</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_length">length</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): u64
 </code></pre>
 
 
@@ -739,8 +739,8 @@ Return the length of the vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_length">length</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): u64 {
-    v.end_index
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_length">length</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): u64 {
+    self.end_index
 }
 </code></pre>
 
@@ -755,7 +755,7 @@ Return the length of the vector.
 Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): bool
 </code></pre>
 
 
@@ -764,8 +764,8 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): bool {
-    <a href="big_vector.md#0x1_big_vector_length">length</a>(v) == 0
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;): bool {
+    <a href="big_vector.md#0x1_big_vector_length">length</a>(self) == 0
 }
 </code></pre>
 
@@ -876,13 +876,13 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `destroy_empty`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(self: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> !<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(v);
+<pre><code><b>aborts_if</b> !<a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(self);
 </code></pre>
 
 
@@ -892,14 +892,14 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `borrow`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow">borrow</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &T
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(v);
-<b>ensures</b> result == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, i);
+<pre><code><b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(self);
+<b>ensures</b> result == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, i);
 </code></pre>
 
 
@@ -909,14 +909,14 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `borrow_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(v);
-<b>ensures</b> result == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, i);
+<pre><code><b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(self);
+<b>ensures</b> result == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, i);
 </code></pre>
 
 
@@ -926,7 +926,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `append`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_append">append</a>&lt;T: store&gt;(lhs: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, other: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_append">append</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, other: <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -942,19 +942,19 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `push_back`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: T)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_push_back">push_back</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: T)
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> num_buckets = <a href="big_vector.md#0x1_big_vector_spec_table_len">spec_table_len</a>(v.buckets);
+<pre><code><b>let</b> num_buckets = <a href="big_vector.md#0x1_big_vector_spec_table_len">spec_table_len</a>(self.buckets);
 <b>include</b> <a href="big_vector.md#0x1_big_vector_PushbackAbortsIf">PushbackAbortsIf</a>&lt;T&gt;;
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(v) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(v)) + 1;
-<b>ensures</b> v.end_index == <b>old</b>(v.end_index) + 1;
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, v.end_index-1) == val;
-<b>ensures</b> <b>forall</b> i in 0..v.end_index-1: <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(v), i);
-<b>ensures</b> v.bucket_size == <b>old</b>(v).bucket_size;
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(self) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(self)) + 1;
+<b>ensures</b> self.end_index == <b>old</b>(self.end_index) + 1;
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, self.end_index-1) == val;
+<b>ensures</b> <b>forall</b> i in 0..self.end_index-1: <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(self), i);
+<b>ensures</b> self.bucket_size == <b>old</b>(self).bucket_size;
 </code></pre>
 
 
@@ -964,10 +964,10 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 
 <pre><code><b>schema</b> <a href="big_vector.md#0x1_big_vector_PushbackAbortsIf">PushbackAbortsIf</a>&lt;T&gt; {
-    v: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;;
-    <b>let</b> num_buckets = <a href="big_vector.md#0x1_big_vector_spec_table_len">spec_table_len</a>(v.buckets);
-    <b>aborts_if</b> num_buckets * v.bucket_size &gt; MAX_U64;
-    <b>aborts_if</b> v.end_index + 1 &gt; MAX_U64;
+    self: <a href="big_vector.md#0x1_big_vector_BigVector">BigVector</a>&lt;T&gt;;
+    <b>let</b> num_buckets = <a href="big_vector.md#0x1_big_vector_spec_table_len">spec_table_len</a>(self.buckets);
+    <b>aborts_if</b> num_buckets * self.bucket_size &gt; MAX_U64;
+    <b>aborts_if</b> self.end_index + 1 &gt; MAX_U64;
 }
 </code></pre>
 
@@ -978,16 +978,16 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `pop_back`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_pop_back">pop_back</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;): T
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> <a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(v);
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(v) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(v)) - 1;
-<b>ensures</b> result == <b>old</b>(<a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, v.end_index-1));
-<b>ensures</b> <b>forall</b> i in 0..v.end_index: <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(v), i);
+<pre><code><b>aborts_if</b> <a href="big_vector.md#0x1_big_vector_is_empty">is_empty</a>(self);
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(self) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(self)) - 1;
+<b>ensures</b> result == <b>old</b>(<a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, self.end_index-1));
+<b>ensures</b> <b>forall</b> i in 0..self.end_index: <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(self), i);
 </code></pre>
 
 
@@ -997,7 +997,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_remove">remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_remove">remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
@@ -1013,16 +1013,16 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `swap_remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap_remove">swap_remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> verify_duration_estimate = 120;
-<b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(v);
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(v) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(v)) - 1;
-<b>ensures</b> result == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(v), i);
+<b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(self);
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(self) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(self)) - 1;
+<b>ensures</b> result == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(self), i);
 </code></pre>
 
 
@@ -1032,20 +1032,20 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `swap`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap">swap</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64, j: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_swap">swap</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, i: u64, j: u64)
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> verify_duration_estimate = 1000;
-<b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(v) || j &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(v);
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(v) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(v));
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(v), j);
-<b>ensures</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, j) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(v), i);
-<b>ensures</b> <b>forall</b> idx in 0..<a href="big_vector.md#0x1_big_vector_length">length</a>(v)
+<b>aborts_if</b> i &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(self) || j &gt;= <a href="big_vector.md#0x1_big_vector_length">length</a>(self);
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_length">length</a>(self) == <a href="big_vector.md#0x1_big_vector_length">length</a>(<b>old</b>(self));
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(self), j);
+<b>ensures</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, j) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(self), i);
+<b>ensures</b> <b>forall</b> idx in 0..<a href="big_vector.md#0x1_big_vector_length">length</a>(self)
     <b>where</b> idx != i && idx != j:
-    <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, idx) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(v), idx);
+    <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(self, idx) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(<b>old</b>(self), idx);
 </code></pre>
 
 
@@ -1055,7 +1055,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `reverse`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_reverse">reverse</a>&lt;T&gt;(v: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_reverse">reverse</a>&lt;T&gt;(self: &<b>mut</b> <a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -1071,7 +1071,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ### Function `index_of`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>&lt;T&gt;(v: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: &T): (bool, u64)
+<pre><code><b>public</b> <b>fun</b> <a href="big_vector.md#0x1_big_vector_index_of">index_of</a>&lt;T&gt;(self: &<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;, val: &T): (bool, u64)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/capability.md
+++ b/aptos-move/framework/aptos-stdlib/doc/capability.md
@@ -400,7 +400,7 @@ Returns the root address associated with the given capability token. Only the ow
 of the feature can do this.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_root_addr">root_addr</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_root_addr">root_addr</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b>
 </code></pre>
 
 
@@ -409,8 +409,8 @@ of the feature can do this.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_root_addr">root_addr</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">Cap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b> {
-    cap.root
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_root_addr">root_addr</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">Cap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b> {
+    self.root
 }
 </code></pre>
 
@@ -425,7 +425,7 @@ of the feature can do this.
 Returns the root address associated with the given linear capability token.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_linear_root_addr">linear_root_addr</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_LinearCap">capability::LinearCap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_linear_root_addr">linear_root_addr</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_LinearCap">capability::LinearCap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b>
 </code></pre>
 
 
@@ -434,8 +434,8 @@ Returns the root address associated with the given linear capability token.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_linear_root_addr">linear_root_addr</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_LinearCap">LinearCap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b> {
-    cap.root
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_linear_root_addr">linear_root_addr</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_LinearCap">LinearCap</a>&lt;Feature&gt;, _feature_witness: &Feature): <b>address</b> {
+    self.root
 }
 </code></pre>
 
@@ -451,7 +451,7 @@ Registers a delegation relation. If the relation already exists, this function d
 nothing.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_delegate">delegate</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, <b>to</b>: &<a href="../../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_delegate">delegate</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, <b>to</b>: &<a href="../../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -460,12 +460,12 @@ nothing.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_delegate">delegate</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, <b>to</b>: &<a href="../../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_delegate">delegate</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, <b>to</b>: &<a href="../../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 <b>acquires</b> <a href="capability.md#0x1_capability_CapState">CapState</a> {
     <b>let</b> addr = <a href="../../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<b>to</b>);
     <b>if</b> (<b>exists</b>&lt;<a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt;&gt;(addr)) <b>return</b>;
-    <b>move_to</b>(<b>to</b>, <a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt; { root: cap.root });
-    <a href="capability.md#0x1_capability_add_element">add_element</a>(&<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="capability.md#0x1_capability_CapState">CapState</a>&lt;Feature&gt;&gt;(cap.root).delegates, addr);
+    <b>move_to</b>(<b>to</b>, <a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt; { root: self.root });
+    <a href="capability.md#0x1_capability_add_element">add_element</a>(&<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="capability.md#0x1_capability_CapState">CapState</a>&lt;Feature&gt;&gt;(self.root).delegates, addr);
 }
 </code></pre>
 
@@ -480,7 +480,7 @@ nothing.
 Revokes a delegation relation. If no relation exists, this function does nothing.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_revoke">revoke</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, from: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_revoke">revoke</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, from: <b>address</b>)
 </code></pre>
 
 
@@ -489,12 +489,12 @@ Revokes a delegation relation. If no relation exists, this function does nothing
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_revoke">revoke</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, from: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_revoke">revoke</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, from: <b>address</b>)
 <b>acquires</b> <a href="capability.md#0x1_capability_CapState">CapState</a>, <a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>
 {
     <b>if</b> (!<b>exists</b>&lt;<a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt;&gt;(from)) <b>return</b>;
     <b>let</b> <a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a> { root: _root } = <b>move_from</b>&lt;<a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt;&gt;(from);
-    <a href="capability.md#0x1_capability_remove_element">remove_element</a>(&<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="capability.md#0x1_capability_CapState">CapState</a>&lt;Feature&gt;&gt;(cap.root).delegates, &from);
+    <a href="capability.md#0x1_capability_remove_element">remove_element</a>(&<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="capability.md#0x1_capability_CapState">CapState</a>&lt;Feature&gt;&gt;(self.root).delegates, &from);
 }
 </code></pre>
 
@@ -676,7 +676,7 @@ Helper specification function to check whether a delegated capability exists at 
 ### Function `delegate`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_delegate">delegate</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, <b>to</b>: &<a href="../../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_delegate">delegate</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, <b>to</b>: &<a href="../../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -684,8 +684,8 @@ Helper specification function to check whether a delegated capability exists at 
 
 <pre><code><b>let</b> addr = <a href="../../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<b>to</b>);
 <b>ensures</b> <a href="capability.md#0x1_capability_spec_has_delegate_cap">spec_has_delegate_cap</a>&lt;Feature&gt;(addr);
-<b>ensures</b> !<b>old</b>(<a href="capability.md#0x1_capability_spec_has_delegate_cap">spec_has_delegate_cap</a>&lt;Feature&gt;(addr)) ==&gt; <b>global</b>&lt;<a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt;&gt;(addr).root == cap.root;
-<b>ensures</b> !<b>old</b>(<a href="capability.md#0x1_capability_spec_has_delegate_cap">spec_has_delegate_cap</a>&lt;Feature&gt;(addr)) ==&gt; <a href="../../move-stdlib/doc/vector.md#0x1_vector_spec_contains">vector::spec_contains</a>(<a href="capability.md#0x1_capability_spec_delegates">spec_delegates</a>&lt;Feature&gt;(cap.root), addr);
+<b>ensures</b> !<b>old</b>(<a href="capability.md#0x1_capability_spec_has_delegate_cap">spec_has_delegate_cap</a>&lt;Feature&gt;(addr)) ==&gt; <b>global</b>&lt;<a href="capability.md#0x1_capability_CapDelegateState">CapDelegateState</a>&lt;Feature&gt;&gt;(addr).root == self.root;
+<b>ensures</b> !<b>old</b>(<a href="capability.md#0x1_capability_spec_has_delegate_cap">spec_has_delegate_cap</a>&lt;Feature&gt;(addr)) ==&gt; <a href="../../move-stdlib/doc/vector.md#0x1_vector_spec_contains">vector::spec_contains</a>(<a href="capability.md#0x1_capability_spec_delegates">spec_delegates</a>&lt;Feature&gt;(self.root), addr);
 </code></pre>
 
 
@@ -695,7 +695,7 @@ Helper specification function to check whether a delegated capability exists at 
 ### Function `revoke`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_revoke">revoke</a>&lt;Feature&gt;(cap: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, from: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="capability.md#0x1_capability_revoke">revoke</a>&lt;Feature&gt;(self: <a href="capability.md#0x1_capability_Cap">capability::Cap</a>&lt;Feature&gt;, _feature_witness: &Feature, from: <b>address</b>)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/comparator.md
+++ b/aptos-move/framework/aptos-stdlib/doc/comparator.md
@@ -92,7 +92,7 @@ Provides a framework for comparing two elements
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_equal">is_equal</a>(result: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_equal">is_equal</a>(self: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
 </code></pre>
 
 
@@ -101,8 +101,8 @@ Provides a framework for comparing two elements
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_equal">is_equal</a>(result: &<a href="comparator.md#0x1_comparator_Result">Result</a>): bool {
-    result.inner == <a href="comparator.md#0x1_comparator_EQUAL">EQUAL</a>
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_equal">is_equal</a>(self: &<a href="comparator.md#0x1_comparator_Result">Result</a>): bool {
+    self.inner == <a href="comparator.md#0x1_comparator_EQUAL">EQUAL</a>
 }
 </code></pre>
 
@@ -116,7 +116,7 @@ Provides a framework for comparing two elements
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_smaller_than">is_smaller_than</a>(result: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_smaller_than">is_smaller_than</a>(self: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
 </code></pre>
 
 
@@ -125,8 +125,8 @@ Provides a framework for comparing two elements
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_smaller_than">is_smaller_than</a>(result: &<a href="comparator.md#0x1_comparator_Result">Result</a>): bool {
-    result.inner == <a href="comparator.md#0x1_comparator_SMALLER">SMALLER</a>
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_smaller_than">is_smaller_than</a>(self: &<a href="comparator.md#0x1_comparator_Result">Result</a>): bool {
+    self.inner == <a href="comparator.md#0x1_comparator_SMALLER">SMALLER</a>
 }
 </code></pre>
 
@@ -140,7 +140,7 @@ Provides a framework for comparing two elements
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_greater_than">is_greater_than</a>(result: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_greater_than">is_greater_than</a>(self: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
 </code></pre>
 
 
@@ -149,8 +149,8 @@ Provides a framework for comparing two elements
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_greater_than">is_greater_than</a>(result: &<a href="comparator.md#0x1_comparator_Result">Result</a>): bool {
-    result.inner == <a href="comparator.md#0x1_comparator_GREATER">GREATER</a>
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_greater_than">is_greater_than</a>(self: &<a href="comparator.md#0x1_comparator_Result">Result</a>): bool {
+    self.inner == <a href="comparator.md#0x1_comparator_GREATER">GREATER</a>
 }
 </code></pre>
 
@@ -268,14 +268,14 @@ Provides a framework for comparing two elements
 ### Function `is_equal`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_equal">is_equal</a>(result: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_equal">is_equal</a>(self: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>let</b> res = result;
+<b>let</b> res = self;
 <b>ensures</b> result == (res.inner == <a href="comparator.md#0x1_comparator_EQUAL">EQUAL</a>);
 </code></pre>
 
@@ -286,14 +286,14 @@ Provides a framework for comparing two elements
 ### Function `is_smaller_than`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_smaller_than">is_smaller_than</a>(result: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_smaller_than">is_smaller_than</a>(self: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>let</b> res = result;
+<b>let</b> res = self;
 <b>ensures</b> result == (res.inner == <a href="comparator.md#0x1_comparator_SMALLER">SMALLER</a>);
 </code></pre>
 
@@ -304,14 +304,14 @@ Provides a framework for comparing two elements
 ### Function `is_greater_than`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_greater_than">is_greater_than</a>(result: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="comparator.md#0x1_comparator_is_greater_than">is_greater_than</a>(self: &<a href="comparator.md#0x1_comparator_Result">comparator::Result</a>): bool
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>let</b> res = result;
+<b>let</b> res = self;
 <b>ensures</b> result == (res.inner == <a href="comparator.md#0x1_comparator_GREATER">GREATER</a>);
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/doc/copyable_any.md
+++ b/aptos-move/framework/aptos-stdlib/doc/copyable_any.md
@@ -110,7 +110,7 @@ also required from <code>T</code>.
 Unpack a value from the <code><a href="copyable_any.md#0x1_copyable_any_Any">Any</a></code> representation. This aborts if the value has not the expected type <code>T</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_unpack">unpack</a>&lt;T&gt;(x: <a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): T
+<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_unpack">unpack</a>&lt;T&gt;(self: <a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): T
 </code></pre>
 
 
@@ -119,9 +119,9 @@ Unpack a value from the <code><a href="copyable_any.md#0x1_copyable_any_Any">Any
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_unpack">unpack</a>&lt;T&gt;(x: <a href="copyable_any.md#0x1_copyable_any_Any">Any</a>): T {
-    <b>assert</b>!(<a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() == x.type_name, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="copyable_any.md#0x1_copyable_any_ETYPE_MISMATCH">ETYPE_MISMATCH</a>));
-    from_bytes&lt;T&gt;(x.data)
+<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_unpack">unpack</a>&lt;T&gt;(self: <a href="copyable_any.md#0x1_copyable_any_Any">Any</a>): T {
+    <b>assert</b>!(<a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() == self.type_name, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="copyable_any.md#0x1_copyable_any_ETYPE_MISMATCH">ETYPE_MISMATCH</a>));
+    from_bytes&lt;T&gt;(self.data)
 }
 </code></pre>
 
@@ -136,7 +136,7 @@ Unpack a value from the <code><a href="copyable_any.md#0x1_copyable_any_Any">Any
 Returns the type name of this Any
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_type_name">type_name</a>(x: &<a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_type_name">type_name</a>(self: &<a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
@@ -145,8 +145,8 @@ Returns the type name of this Any
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_type_name">type_name</a>(x: &<a href="copyable_any.md#0x1_copyable_any_Any">Any</a>): &String {
-    &x.type_name
+<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_type_name">type_name</a>(self: &<a href="copyable_any.md#0x1_copyable_any_Any">Any</a>): &String {
+    &self.type_name
 }
 </code></pre>
 
@@ -186,14 +186,14 @@ Returns the type name of this Any
 ### Function `unpack`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_unpack">unpack</a>&lt;T&gt;(x: <a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): T
+<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_unpack">unpack</a>&lt;T&gt;(self: <a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): T
 </code></pre>
 
 
 
 
 <pre><code><b>include</b> <a href="copyable_any.md#0x1_copyable_any_UnpackAbortsIf">UnpackAbortsIf</a>&lt;T&gt;;
-<b>ensures</b> result == <a href="from_bcs.md#0x1_from_bcs_deserialize">from_bcs::deserialize</a>&lt;T&gt;(x.data);
+<b>ensures</b> result == <a href="from_bcs.md#0x1_from_bcs_deserialize">from_bcs::deserialize</a>&lt;T&gt;(self.data);
 </code></pre>
 
 
@@ -203,9 +203,9 @@ Returns the type name of this Any
 
 
 <pre><code><b>schema</b> <a href="copyable_any.md#0x1_copyable_any_UnpackAbortsIf">UnpackAbortsIf</a>&lt;T&gt; {
-    x: <a href="copyable_any.md#0x1_copyable_any_Any">Any</a>;
-    <b>aborts_if</b> <a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() != x.type_name;
-    <b>aborts_if</b> !<a href="from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;T&gt;(x.data);
+    self: <a href="copyable_any.md#0x1_copyable_any_Any">Any</a>;
+    <b>aborts_if</b> <a href="type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;() != self.type_name;
+    <b>aborts_if</b> !<a href="from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;T&gt;(self.data);
 }
 </code></pre>
 
@@ -216,14 +216,14 @@ Returns the type name of this Any
 ### Function `type_name`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_type_name">type_name</a>(x: &<a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="copyable_any.md#0x1_copyable_any_type_name">type_name</a>(self: &<a href="copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a>): &<a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == x.type_name;
+<b>ensures</b> result == self.type_name;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
@@ -169,10 +169,10 @@ The computed ratio when converting to a <code><a href="fixed_point64.md#0x1_fixe
 
 ## Function `sub`
 
-Returns x - y. x must be not less than y.
+Returns self - y. self must be not less than y.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
 </code></pre>
 
 
@@ -181,8 +181,8 @@ Returns x - y. x must be not less than y.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
-    <b>let</b> x_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(x);
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>let</b> x_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(self);
     <b>let</b> y_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(y);
     <b>assert</b>!(x_raw &gt;= y_raw, <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>);
     <a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">create_from_raw_value</a>(x_raw - y_raw)
@@ -197,10 +197,10 @@ Returns x - y. x must be not less than y.
 
 ## Function `add`
 
-Returns x + y. The result cannot be greater than MAX_U128.
+Returns self + y. The result cannot be greater than MAX_U128.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
 </code></pre>
 
 
@@ -209,8 +209,8 @@ Returns x + y. The result cannot be greater than MAX_U128.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
-    <b>let</b> x_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(x);
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>let</b> x_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(self);
     <b>let</b> y_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(y);
     <b>let</b> result = (x_raw <b>as</b> u256) + (y_raw <b>as</b> u256);
     <b>assert</b>!(result &lt;= <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>, <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>);
@@ -403,7 +403,7 @@ adding or subtracting FixedPoint64 values, can be done using the raw
 values directly.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -412,8 +412,8 @@ values directly.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-    num.value
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    self.value
 }
 </code></pre>
 
@@ -428,7 +428,7 @@ values directly.
 Returns true if the ratio is zero.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_is_zero">is_zero</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_is_zero">is_zero</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -437,8 +437,8 @@ Returns true if the ratio is zero.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_is_zero">is_zero</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    num.value == 0
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_is_zero">is_zero</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    self.value == 0
 }
 </code></pre>
 
@@ -508,10 +508,10 @@ Returns the larger of the two FixedPoint64 numbers.
 
 ## Function `less_or_equal`
 
-Returns true if num1 <= num2
+Returns true if self <= num2
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -520,8 +520,8 @@ Returns true if num1 <= num2
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    num1.value &lt;= num2.value
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    self.value &lt;= num2.value
 }
 </code></pre>
 
@@ -533,10 +533,10 @@ Returns true if num1 <= num2
 
 ## Function `less`
 
-Returns true if num1 < num2
+Returns true if self < num2
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -545,8 +545,8 @@ Returns true if num1 < num2
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    num1.value &lt; num2.value
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    self.value &lt; num2.value
 }
 </code></pre>
 
@@ -558,10 +558,10 @@ Returns true if num1 < num2
 
 ## Function `greater_or_equal`
 
-Returns true if num1 >= num2
+Returns true if self >= num2
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -570,8 +570,8 @@ Returns true if num1 >= num2
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    num1.value &gt;= num2.value
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    self.value &gt;= num2.value
 }
 </code></pre>
 
@@ -583,10 +583,10 @@ Returns true if num1 >= num2
 
 ## Function `greater`
 
-Returns true if num1 > num2
+Returns true if self > num2
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -595,8 +595,8 @@ Returns true if num1 > num2
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    num1.value &gt; num2.value
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    self.value &gt; num2.value
 }
 </code></pre>
 
@@ -608,10 +608,10 @@ Returns true if num1 > num2
 
 ## Function `equal`
 
-Returns true if num1 = num2
+Returns true if self = num2
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -620,8 +620,8 @@ Returns true if num1 = num2
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    num1.value == num2.value
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    self.value == num2.value
 }
 </code></pre>
 
@@ -633,10 +633,10 @@ Returns true if num1 = num2
 
 ## Function `almost_equal`
 
-Returns true if num1 almost equals to num2, which means abs(num1-num2) <= precision
+Returns true if self almost equals to num2, which means abs(num1-num2) <= precision
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -645,11 +645,11 @@ Returns true if num1 almost equals to num2, which means abs(num1-num2) <= precis
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-    <b>if</b> (num1.value &gt; num2.value) {
-        (num1.value - num2.value &lt;= precision.value)
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    <b>if</b> (self.value &gt; num2.value) {
+        (self.value - num2.value &lt;= precision.value)
     } <b>else</b> {
-        (num2.value - num1.value &lt;= precision.value)
+        (num2.value - self.value &lt;= precision.value)
     }
 }
 </code></pre>
@@ -692,7 +692,7 @@ Create a fixedpoint value from a u128 value.
 Returns the largest integer less than or equal to a given number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -701,8 +701,8 @@ Returns the largest integer less than or equal to a given number.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-    num.value &gt;&gt; 64
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    self.value &gt;&gt; 64
 }
 </code></pre>
 
@@ -717,7 +717,7 @@ Returns the largest integer less than or equal to a given number.
 Rounds up the given FixedPoint64 to the next largest integer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -726,9 +726,9 @@ Rounds up the given FixedPoint64 to the next largest integer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-    <b>let</b> floored_num = <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num) &lt;&lt; 64;
-    <b>if</b> (num.value == floored_num) {
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    <b>let</b> floored_num = <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(self) &lt;&lt; 64;
+    <b>if</b> (self.value == floored_num) {
         <b>return</b> floored_num &gt;&gt; 64
     };
     <b>let</b> val = ((floored_num <b>as</b> u256) + (1 &lt;&lt; 64));
@@ -747,7 +747,7 @@ Rounds up the given FixedPoint64 to the next largest integer.
 Returns the value of a FixedPoint64 to the nearest integer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -756,13 +756,13 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-    <b>let</b> floored_num = <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num) &lt;&lt; 64;
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    <b>let</b> floored_num = <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(self) &lt;&lt; 64;
     <b>let</b> boundary = floored_num + ((1 &lt;&lt; 64) / 2);
-    <b>if</b> (num.value &lt; boundary) {
+    <b>if</b> (self.value &lt; boundary) {
         floored_num &gt;&gt; 64
     } <b>else</b> {
-        <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num)
+        <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(self)
     }
 }
 </code></pre>
@@ -788,15 +788,15 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `sub`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> x.value &lt; y.value <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>;
-<b>ensures</b> result.value == x.value - y.value;
+<b>aborts_if</b> self.value &lt; y.value <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>;
+<b>ensures</b> result.value == self.value - y.value;
 </code></pre>
 
 
@@ -806,15 +806,15 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `add`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> (x.value <b>as</b> u256) + (y.value <b>as</b> u256) &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a> <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>;
-<b>ensures</b> result.value == x.value + y.value;
+<b>aborts_if</b> (self.value <b>as</b> u256) + (y.value <b>as</b> u256) &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a> <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>;
+<b>ensures</b> result.value == self.value + y.value;
 </code></pre>
 
 
@@ -1041,7 +1041,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `less_or_equal`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -1049,7 +1049,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">spec_less_or_equal</a>(num1, num2);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">spec_less_or_equal</a>(self, num2);
 </code></pre>
 
 
@@ -1058,8 +1058,8 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_less_or_equal"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">spec_less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-   num1.value &lt;= num2.value
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">spec_less_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   self.value &lt;= num2.value
 }
 </code></pre>
 
@@ -1070,7 +1070,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `less`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -1078,7 +1078,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_less">spec_less</a>(num1, num2);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_less">spec_less</a>(self, num2);
 </code></pre>
 
 
@@ -1087,8 +1087,8 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_less"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_less">spec_less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-   num1.value &lt; num2.value
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_less">spec_less</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   self.value &lt; num2.value
 }
 </code></pre>
 
@@ -1099,7 +1099,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `greater_or_equal`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -1107,7 +1107,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_greater_or_equal">spec_greater_or_equal</a>(num1, num2);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_greater_or_equal">spec_greater_or_equal</a>(self, num2);
 </code></pre>
 
 
@@ -1116,8 +1116,8 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_greater_or_equal"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_greater_or_equal">spec_greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-   num1.value &gt;= num2.value
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_greater_or_equal">spec_greater_or_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   self.value &gt;= num2.value
 }
 </code></pre>
 
@@ -1128,7 +1128,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `greater`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -1136,7 +1136,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_greater">spec_greater</a>(num1, num2);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_greater">spec_greater</a>(self, num2);
 </code></pre>
 
 
@@ -1145,8 +1145,8 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_greater"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_greater">spec_greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-   num1.value &gt; num2.value
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_greater">spec_greater</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   self.value &gt; num2.value
 }
 </code></pre>
 
@@ -1157,7 +1157,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `equal`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -1165,7 +1165,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_equal">spec_equal</a>(num1, num2);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_equal">spec_equal</a>(self, num2);
 </code></pre>
 
 
@@ -1174,8 +1174,8 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_equal"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_equal">spec_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-   num1.value == num2.value
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_equal">spec_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   self.value == num2.value
 }
 </code></pre>
 
@@ -1186,7 +1186,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `almost_equal`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
 </code></pre>
 
 
@@ -1194,7 +1194,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_almost_equal">spec_almost_equal</a>(num1, num2, precision);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_almost_equal">spec_almost_equal</a>(self, num2, precision);
 </code></pre>
 
 
@@ -1203,11 +1203,11 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_almost_equal"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_almost_equal">spec_almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
-   <b>if</b> (num1.value &gt; num2.value) {
-       (num1.value - num2.value &lt;= precision.value)
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_almost_equal">spec_almost_equal</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   <b>if</b> (self.value &gt; num2.value) {
+       (self.value - num2.value &lt;= precision.value)
    } <b>else</b> {
-       (num2.value - num1.value &lt;= precision.value)
+       (num2.value - self.value &lt;= precision.value)
    }
 }
 </code></pre>
@@ -1261,7 +1261,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `floor`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -1269,7 +1269,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_floor">spec_floor</a>(num);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_floor">spec_floor</a>(self);
 </code></pre>
 
 
@@ -1278,12 +1278,12 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_floor"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_floor">spec_floor</a>(val: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-   <b>let</b> fractional = val.value % (1 &lt;&lt; 64);
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_floor">spec_floor</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+   <b>let</b> fractional = self.value % (1 &lt;&lt; 64);
    <b>if</b> (fractional == 0) {
-       val.value &gt;&gt; 64
+       self.value &gt;&gt; 64
    } <b>else</b> {
-       (val.value - fractional) &gt;&gt; 64
+       (self.value - fractional) &gt;&gt; 64
    }
 }
 </code></pre>
@@ -1295,7 +1295,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `ceil`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -1304,7 +1304,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <pre><code><b>pragma</b> verify_duration_estimate = 1000;
 <b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_ceil">spec_ceil</a>(num);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_ceil">spec_ceil</a>(self);
 </code></pre>
 
 
@@ -1313,13 +1313,13 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_ceil"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_ceil">spec_ceil</a>(val: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-   <b>let</b> fractional = val.value % (1 &lt;&lt; 64);
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_ceil">spec_ceil</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+   <b>let</b> fractional = self.value % (1 &lt;&lt; 64);
    <b>let</b> one = 1 &lt;&lt; 64;
    <b>if</b> (fractional == 0) {
-       val.value &gt;&gt; 64
+       self.value &gt;&gt; 64
    } <b>else</b> {
-       (val.value - fractional + one) &gt;&gt; 64
+       (self.value - fractional + one) &gt;&gt; 64
    }
 }
 </code></pre>
@@ -1331,7 +1331,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 ### Function `round`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
 </code></pre>
 
 
@@ -1339,7 +1339,7 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_round">spec_round</a>(num);
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_round">spec_round</a>(self);
 </code></pre>
 
 
@@ -1348,14 +1348,14 @@ Returns the value of a FixedPoint64 to the nearest integer.
 <a id="0x1_fixed_point64_spec_round"></a>
 
 
-<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_round">spec_round</a>(val: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
-   <b>let</b> fractional = val.value % (1 &lt;&lt; 64);
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_round">spec_round</a>(self: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+   <b>let</b> fractional = self.value % (1 &lt;&lt; 64);
    <b>let</b> boundary = (1 &lt;&lt; 64) / 2;
    <b>let</b> one = 1 &lt;&lt; 64;
    <b>if</b> (fractional &lt; boundary) {
-       (val.value - fractional) &gt;&gt; 64
+       (self.value - fractional) &gt;&gt; 64
    } <b>else</b> {
-       (val.value - fractional + one) &gt;&gt; 64
+       (self.value - fractional + one) &gt;&gt; 64
    }
 }
 </code></pre>

--- a/aptos-move/framework/aptos-stdlib/doc/from_bcs.md
+++ b/aptos-move/framework/aptos-stdlib/doc/from_bcs.md
@@ -5,7 +5,7 @@
 
 This module provides a number of functions to convert _primitive_ types from their representation in <code>std::bcs</code>
 to values. This is the opposite of <code><a href="../../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a></code>. Note that it is not safe to define a generic public <code>from_bytes</code>
-function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
+function because this can violate implicit struct invariants, therefore only primitive types are offered. If
 a general conversion back-and-force is needed, consider the <code>aptos_std::Any</code> type which preserves invariants.
 
 Example:

--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -11,6 +11,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `min`](#0x1_math128_min)
 -  [Function `average`](#0x1_math128_average)
 -  [Function `gcd`](#0x1_math128_gcd)
+-  [Function `lcm`](#0x1_math128_lcm)
 -  [Function `mul_div`](#0x1_math128_mul_div)
 -  [Function `clamp`](#0x1_math128_clamp)
 -  [Function `pow`](#0x1_math128_pow)
@@ -154,6 +155,35 @@ Return greatest common divisor of <code>a</code> & <code>b</code>, via the Eucli
         large = tmp;
     };
     large
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math128_lcm"></a>
+
+## Function `lcm`
+
+Return least common multiple of <code>a</code> & <code>b</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_lcm">lcm</a>(a: u128, b: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math128.md#0x1_math128_lcm">lcm</a>(a: u128, b: u128): u128 {
+    <b>if</b> (a == 0 || b == 0) {
+        0
+    } <b>else</b> {
+        a / <a href="math128.md#0x1_math128_gcd">gcd</a>(a, b) * b
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -11,6 +11,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `min`](#0x1_math64_min)
 -  [Function `average`](#0x1_math64_average)
 -  [Function `gcd`](#0x1_math64_gcd)
+-  [Function `lcm`](#0x1_math64_lcm)
 -  [Function `mul_div`](#0x1_math64_mul_div)
 -  [Function `clamp`](#0x1_math64_clamp)
 -  [Function `pow`](#0x1_math64_pow)
@@ -152,6 +153,35 @@ Return greatest common divisor of <code>a</code> & <code>b</code>, via the Eucli
         large = tmp;
     };
     large
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math64_lcm"></a>
+
+## Function `lcm`
+
+Returns least common multiple of <code>a</code> & <code>b</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math64.md#0x1_math64_lcm">lcm</a>(a: u64, b: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math64.md#0x1_math64_lcm">lcm</a>(a: u64, b: u64): u64 {
+    <b>if</b> (a == 0 || b == 0) {
+        0
+    } <b>else</b> {
+        a / <a href="math64.md#0x1_math64_gcd">gcd</a>(a, b) * b
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
@@ -299,7 +299,7 @@ Create a new pool with custom <code>scaling_factor</code>.
 Destroy an empty pool. This will fail if the pool has any balance of coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_destroy_empty">destroy_empty</a>(pool: <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_destroy_empty">destroy_empty</a>(self: <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>)
 </code></pre>
 
 
@@ -308,8 +308,8 @@ Destroy an empty pool. This will fail if the pool has any balance of coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_destroy_empty">destroy_empty</a>(pool: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>) {
-    <b>assert</b>!(pool.total_coins == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="pool_u64.md#0x1_pool_u64_EPOOL_IS_NOT_EMPTY">EPOOL_IS_NOT_EMPTY</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_destroy_empty">destroy_empty</a>(self: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>) {
+    <b>assert</b>!(self.total_coins == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="pool_u64.md#0x1_pool_u64_EPOOL_IS_NOT_EMPTY">EPOOL_IS_NOT_EMPTY</a>));
     <b>let</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a> {
         shareholders_limit: _,
         total_coins: _,
@@ -317,7 +317,7 @@ Destroy an empty pool. This will fail if the pool has any balance of coins.
         shares: _,
         shareholders: _,
         scaling_factor: _,
-    } = pool;
+    } = self;
 }
 </code></pre>
 
@@ -329,10 +329,10 @@ Destroy an empty pool. This will fail if the pool has any balance of coins.
 
 ## Function `total_coins`
 
-Return <code>pool</code>'s total balance of coins.
+Return <code>self</code>'s total balance of coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_coins">total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_coins">total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): u64
 </code></pre>
 
 
@@ -341,8 +341,8 @@ Return <code>pool</code>'s total balance of coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_coins">total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): u64 {
-    pool.total_coins
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_coins">total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): u64 {
+    self.total_coins
 }
 </code></pre>
 
@@ -354,10 +354,10 @@ Return <code>pool</code>'s total balance of coins.
 
 ## Function `total_shares`
 
-Return the total number of shares across all shareholders in <code>pool</code>.
+Return the total number of shares across all shareholders in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_shares">total_shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_shares">total_shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): u64
 </code></pre>
 
 
@@ -366,8 +366,8 @@ Return the total number of shares across all shareholders in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_shares">total_shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): u64 {
-    pool.total_shares
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_total_shares">total_shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): u64 {
+    self.total_shares
 }
 </code></pre>
 
@@ -379,10 +379,10 @@ Return the total number of shares across all shareholders in <code>pool</code>.
 
 ## Function `contains`
 
-Return true if <code>shareholder</code> is in <code>pool</code>.
+Return true if <code>shareholder</code> is in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): bool
 </code></pre>
 
 
@@ -391,8 +391,8 @@ Return true if <code>shareholder</code> is in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>): bool {
-    <a href="simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&pool.shares, &shareholder)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>): bool {
+    <a href="simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&self.shares, &shareholder)
 }
 </code></pre>
 
@@ -404,10 +404,10 @@ Return true if <code>shareholder</code> is in <code>pool</code>.
 
 ## Function `shares`
 
-Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
+Return the number of shares of <code>stakeholder</code> in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
 </code></pre>
 
 
@@ -416,9 +416,9 @@ Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
-    <b>if</b> (<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool, shareholder)) {
-        *<a href="simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&pool.shares, &shareholder)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
+    <b>if</b> (<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self, shareholder)) {
+        *<a href="simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&self.shares, &shareholder)
     } <b>else</b> {
         0
     }
@@ -433,10 +433,10 @@ Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
 
 ## Function `balance`
 
-Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
+Return the balance in coins of <code>shareholder</code> in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_balance">balance</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_balance">balance</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
 </code></pre>
 
 
@@ -445,9 +445,9 @@ Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_balance">balance</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
-    <b>let</b> num_shares = <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool, shareholder);
-    <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(pool, num_shares)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_balance">balance</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
+    <b>let</b> num_shares = <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self, shareholder);
+    <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(self, num_shares)
 }
 </code></pre>
 
@@ -459,10 +459,10 @@ Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
 
 ## Function `shareholders`
 
-Return the list of shareholders in <code>pool</code>.
+Return the list of shareholders in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders">shareholders</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders">shareholders</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -471,8 +471,8 @@ Return the list of shareholders in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders">shareholders</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; {
-    pool.shareholders
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders">shareholders</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; {
+    self.shareholders
 }
 </code></pre>
 
@@ -484,10 +484,10 @@ Return the list of shareholders in <code>pool</code>.
 
 ## Function `shareholders_count`
 
-Return the number of shareholders in <code>pool</code>.
+Return the number of shareholders in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders_count">shareholders_count</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders_count">shareholders_count</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>): u64
 </code></pre>
 
 
@@ -496,8 +496,8 @@ Return the number of shareholders in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders_count">shareholders_count</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): u64 {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&pool.shareholders)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shareholders_count">shareholders_count</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>): u64 {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.shareholders)
 }
 </code></pre>
 
@@ -509,10 +509,10 @@ Return the number of shareholders in <code>pool</code>.
 
 ## Function `update_total_coins`
 
-Update <code>pool</code>'s total balance of coins.
+Update <code>self</code>'s total balance of coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_update_total_coins">update_total_coins</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, new_total_coins: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_update_total_coins">update_total_coins</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, new_total_coins: u64)
 </code></pre>
 
 
@@ -521,8 +521,8 @@ Update <code>pool</code>'s total balance of coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_update_total_coins">update_total_coins</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, new_total_coins: u64) {
-    pool.total_coins = new_total_coins;
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_update_total_coins">update_total_coins</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, new_total_coins: u64) {
+    self.total_coins = new_total_coins;
 }
 </code></pre>
 
@@ -537,7 +537,7 @@ Update <code>pool</code>'s total balance of coins.
 Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_buy_in">buy_in</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u64
 </code></pre>
 
 
@@ -546,16 +546,16 @@ Allow an existing or new shareholder to add their coins to the pool in exchange 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_buy_in">buy_in</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u64 {
     <b>if</b> (coins_amount == 0) <b>return</b> 0;
 
-    <b>let</b> new_shares = <a href="pool_u64.md#0x1_pool_u64_amount_to_shares">amount_to_shares</a>(pool, coins_amount);
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a> - pool.total_coins &gt;= coins_amount, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a> - pool.total_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
+    <b>let</b> new_shares = <a href="pool_u64.md#0x1_pool_u64_amount_to_shares">amount_to_shares</a>(self, coins_amount);
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a> - self.total_coins &gt;= coins_amount, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a> - self.total_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
 
-    pool.total_coins = pool.total_coins + coins_amount;
-    pool.total_shares = pool.total_shares + new_shares;
-    <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(pool, shareholder, new_shares);
+    self.total_coins = self.total_coins + coins_amount;
+    self.total_shares = self.total_shares + new_shares;
+    <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(self, shareholder, new_shares);
     new_shares
 }
 </code></pre>
@@ -568,11 +568,11 @@ Allow an existing or new shareholder to add their coins to the pool in exchange 
 
 ## Function `add_shares`
 
-Add the number of shares directly for <code>shareholder</code> in <code>pool</code>.
+Add the number of shares directly for <code>shareholder</code> in <code>self</code>.
 This would dilute other shareholders if the pool's balance of coins didn't change.
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, new_shares: u64): u64
+<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, new_shares: u64): u64
 </code></pre>
 
 
@@ -581,9 +581,9 @@ This would dilute other shareholders if the pool's balance of coins didn't chang
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, new_shares: u64): u64 {
-    <b>if</b> (<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool, shareholder)) {
-        <b>let</b> existing_shares = <a href="simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> pool.shares, &shareholder);
+<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, new_shares: u64): u64 {
+    <b>if</b> (<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self, shareholder)) {
+        <b>let</b> existing_shares = <a href="simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> self.shares, &shareholder);
         <b>let</b> current_shares = *existing_shares;
         <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a> - current_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_SHARES_OVERFLOW">ESHAREHOLDER_SHARES_OVERFLOW</a>));
 
@@ -591,12 +591,12 @@ This would dilute other shareholders if the pool's balance of coins didn't chang
         *existing_shares
     } <b>else</b> <b>if</b> (new_shares &gt; 0) {
         <b>assert</b>!(
-            <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&pool.shareholders) &lt; pool.shareholders_limit,
+            <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.shareholders) &lt; self.shareholders_limit,
             <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="pool_u64.md#0x1_pool_u64_ETOO_MANY_SHAREHOLDERS">ETOO_MANY_SHAREHOLDERS</a>),
         );
 
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> pool.shareholders, shareholder);
-        <a href="simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> pool.shares, shareholder, new_shares);
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.shareholders, shareholder);
+        <a href="simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> self.shares, shareholder, new_shares);
         new_shares
     } <b>else</b> {
         new_shares
@@ -612,10 +612,10 @@ This would dilute other shareholders if the pool's balance of coins didn't chang
 
 ## Function `redeem_shares`
 
-Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for coins.
+Allow <code>shareholder</code> to redeem their shares in <code>self</code> for coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_redeem_shares">redeem_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u64): u64
 </code></pre>
 
 
@@ -624,16 +624,16 @@ Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u64): u64 {
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool, shareholder) &gt;= shares_to_redeem, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_redeem_shares">redeem_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u64): u64 {
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self, shareholder) &gt;= shares_to_redeem, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
 
     <b>if</b> (shares_to_redeem == 0) <b>return</b> 0;
 
-    <b>let</b> redeemed_coins = <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(pool, shares_to_redeem);
-    pool.total_coins = pool.total_coins - redeemed_coins;
-    pool.total_shares = pool.total_shares - shares_to_redeem;
-    <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(pool, shareholder, shares_to_redeem);
+    <b>let</b> redeemed_coins = <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(self, shares_to_redeem);
+    self.total_coins = self.total_coins - redeemed_coins;
+    self.total_shares = self.total_shares - shares_to_redeem;
+    <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self, shareholder, shares_to_redeem);
 
     redeemed_coins
 }
@@ -650,7 +650,7 @@ Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for c
 Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_transfer_shares">transfer_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_transfer_shares">transfer_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u64)
 </code></pre>
 
 
@@ -660,17 +660,17 @@ Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_transfer_shares">transfer_shares</a>(
-    pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>,
+    self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>,
     shareholder_1: <b>address</b>,
     shareholder_2: <b>address</b>,
     shares_to_transfer: u64,
 ) {
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool, shareholder_1), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool, shareholder_1) &gt;= shares_to_transfer, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self, shareholder_1), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self, shareholder_1) &gt;= shares_to_transfer, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
     <b>if</b> (shares_to_transfer == 0) <b>return</b>;
 
-    <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(pool, shareholder_1, shares_to_transfer);
-    <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(pool, shareholder_2, shares_to_transfer);
+    <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self, shareholder_1, shares_to_transfer);
+    <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(self, shareholder_2, shares_to_transfer);
 }
 </code></pre>
 
@@ -682,10 +682,10 @@ Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 
 ## Function `deduct_shares`
 
-Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code> and return the number of remaining shares.
+Directly deduct <code>shareholder</code>'s number of shares in <code>self</code> and return the number of remaining shares.
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
+<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
 </code></pre>
 
 
@@ -694,19 +694,19 @@ Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64 {
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
-    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool, shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64 {
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self, shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
 
-    <b>let</b> existing_shares = <a href="simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> pool.shares, &shareholder);
+    <b>let</b> existing_shares = <a href="simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> self.shares, &shareholder);
     *existing_shares = *existing_shares - num_shares;
 
     // Remove the shareholder completely <b>if</b> they have no shares left.
     <b>let</b> remaining_shares = *existing_shares;
     <b>if</b> (remaining_shares == 0) {
-        <b>let</b> (_, shareholder_index) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(&pool.shareholders, &shareholder);
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> pool.shareholders, shareholder_index);
-        <a href="simple_map.md#0x1_simple_map_remove">simple_map::remove</a>(&<b>mut</b> pool.shares, &shareholder);
+        <b>let</b> (_, shareholder_index) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(&self.shareholders, &shareholder);
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> self.shareholders, shareholder_index);
+        <a href="simple_map.md#0x1_simple_map_remove">simple_map::remove</a>(&<b>mut</b> self.shares, &shareholder);
     };
 
     remaining_shares
@@ -721,11 +721,11 @@ Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code>
 
 ## Function `amount_to_shares`
 
-Return the number of new shares <code>coins_amount</code> can buy in <code>pool</code>.
+Return the number of new shares <code>coins_amount</code> can buy in <code>self</code>.
 <code>amount</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares">amount_to_shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, coins_amount: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares">amount_to_shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, coins_amount: u64): u64
 </code></pre>
 
 
@@ -734,8 +734,8 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares">amount_to_shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, coins_amount: u64): u64 {
-    <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool, coins_amount, pool.total_coins)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares">amount_to_shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, coins_amount: u64): u64 {
+    <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self, coins_amount, self.total_coins)
 }
 </code></pre>
 
@@ -747,11 +747,11 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 
 ## Function `amount_to_shares_with_total_coins`
 
-Return the number of new shares <code>coins_amount</code> can buy in <code>pool</code> with a custom total coins number.
+Return the number of new shares <code>coins_amount</code> can buy in <code>self</code> with a custom total coins number.
 <code>amount</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, coins_amount: u64, total_coins: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, coins_amount: u64, total_coins: u64): u64
 </code></pre>
 
 
@@ -760,17 +760,17 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, coins_amount: u64, total_coins: u64): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, coins_amount: u64, total_coins: u64): u64 {
     // No shares yet so amount is worth the same number of shares.
-    <b>if</b> (pool.total_coins == 0 || pool.total_shares == 0) {
+    <b>if</b> (self.total_coins == 0 || self.total_shares == 0) {
         // Multiply by scaling factor <b>to</b> minimize rounding errors during <b>internal</b> calculations for buy ins/redeems.
         // This can overflow but scaling factor is expected <b>to</b> be chosen carefully so this would not overflow.
-        coins_amount * pool.scaling_factor
+        coins_amount * self.scaling_factor
     } <b>else</b> {
         // Shares price = total_coins / total existing shares.
         // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
         // We rearrange the calc and do multiplication first <b>to</b> avoid rounding errors.
-        <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(pool, coins_amount, pool.total_shares, total_coins)
+        <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(self, coins_amount, self.total_shares, total_coins)
     }
 }
 </code></pre>
@@ -783,11 +783,11 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 
 ## Function `shares_to_amount`
 
-Return the number of coins <code>shares</code> are worth in <code>pool</code>.
+Return the number of coins <code>shares</code> are worth in <code>self</code>.
 <code>shares</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shares: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shares: u64): u64
 </code></pre>
 
 
@@ -796,8 +796,8 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shares: u64): u64 {
-    <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool, shares, pool.total_coins)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount">shares_to_amount</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shares: u64): u64 {
+    <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self, shares, self.total_coins)
 }
 </code></pre>
 
@@ -809,11 +809,11 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code>.
 
 ## Function `shares_to_amount_with_total_coins`
 
-Return the number of coins <code>shares</code> are worth in <code>pool</code> with a custom total coins number.
+Return the number of coins <code>shares</code> are worth in <code>self</code> with a custom total coins number.
 <code>shares</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shares: u64, total_coins: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shares: u64, total_coins: u64): u64
 </code></pre>
 
 
@@ -822,15 +822,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shares: u64, total_coins: u64): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shares: u64, total_coins: u64): u64 {
     // No shares or coins yet so shares are worthless.
-    <b>if</b> (pool.total_coins == 0 || pool.total_shares == 0) {
+    <b>if</b> (self.total_coins == 0 || self.total_shares == 0) {
         0
     } <b>else</b> {
         // Shares price = total_coins / total existing shares.
         // Shares worth = shares * shares price = shares * total_coins / total existing shares.
         // We rearrange the calc and do multiplication first <b>to</b> avoid rounding errors.
-        <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(pool, shares, total_coins, pool.total_shares)
+        <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(self, shares, total_coins, self.total_shares)
     }
 }
 </code></pre>
@@ -845,7 +845,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, x: u64, y: u64, z: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, x: u64, y: u64, z: u64): u64
 </code></pre>
 
 
@@ -854,7 +854,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, x: u64, y: u64, z: u64): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, x: u64, y: u64, z: u64): u64 {
     <b>let</b> result = (<a href="pool_u64.md#0x1_pool_u64_to_u128">to_u128</a>(x) * <a href="pool_u64.md#0x1_pool_u64_to_u128">to_u128</a>(y)) / <a href="pool_u64.md#0x1_pool_u64_to_u128">to_u128</a>(z);
     (result <b>as</b> u64)
 }
@@ -974,14 +974,14 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `contains`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): bool
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(pool, shareholder);
+<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(self, shareholder);
 </code></pre>
 
 
@@ -1007,14 +1007,14 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `shares`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(pool, shareholder);
+<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(self, shareholder);
 </code></pre>
 
 
@@ -1024,16 +1024,16 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `balance`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_balance">balance</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_balance">balance</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>): u64
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> shares = <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(pool, shareholder);
-<b>let</b> total_coins = pool.total_coins;
-<b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0 && (shares * total_coins) / pool.total_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
-<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(pool, shares, total_coins);
+<pre><code><b>let</b> shares = <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(self, shareholder);
+<b>let</b> total_coins = self.total_coins;
+<b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0 && (shares * total_coins) / self.total_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
+<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(self, shares, total_coins);
 </code></pre>
 
 
@@ -1043,19 +1043,19 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `buy_in`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_buy_in">buy_in</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u64
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> new_shares = <a href="pool_u64.md#0x1_pool_u64_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(pool, coins_amount, pool.total_coins);
-<b>aborts_if</b> pool.total_coins + coins_amount &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
-<b>aborts_if</b> pool.total_shares + new_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
+<pre><code><b>let</b> new_shares = <a href="pool_u64.md#0x1_pool_u64_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(self, coins_amount, self.total_coins);
+<b>aborts_if</b> self.total_coins + coins_amount &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
+<b>aborts_if</b> self.total_shares + new_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
 <b>include</b> coins_amount &gt; 0 ==&gt; <a href="pool_u64.md#0x1_pool_u64_AddSharesAbortsIf">AddSharesAbortsIf</a> { new_shares: new_shares };
 <b>include</b> coins_amount &gt; 0 ==&gt; <a href="pool_u64.md#0x1_pool_u64_AddSharesEnsures">AddSharesEnsures</a> { new_shares: new_shares };
-<b>ensures</b> pool.total_coins == <b>old</b>(pool.total_coins) + coins_amount;
-<b>ensures</b> pool.total_shares == <b>old</b>(pool.total_shares) + new_shares;
+<b>ensures</b> self.total_coins == <b>old</b>(self.total_coins) + coins_amount;
+<b>ensures</b> self.total_shares == <b>old</b>(self.total_shares) + new_shares;
 <b>ensures</b> result == new_shares;
 </code></pre>
 
@@ -1066,7 +1066,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `add_shares`
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, new_shares: u64): u64
+<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_add_shares">add_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, new_shares: u64): u64
 </code></pre>
 
 
@@ -1074,8 +1074,8 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 <pre><code><b>include</b> <a href="pool_u64.md#0x1_pool_u64_AddSharesAbortsIf">AddSharesAbortsIf</a>;
 <b>include</b> <a href="pool_u64.md#0x1_pool_u64_AddSharesEnsures">AddSharesEnsures</a>;
-<b>let</b> key_exists = <a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(pool.shares, shareholder);
-<b>ensures</b> result == <b>if</b> (key_exists) { <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder) }
+<b>let</b> key_exists = <a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(self.shares, shareholder);
+<b>ensures</b> result == <b>if</b> (key_exists) { <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder) }
 <b>else</b> { new_shares };
 </code></pre>
 
@@ -1086,13 +1086,13 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>schema</b> <a href="pool_u64.md#0x1_pool_u64_AddSharesAbortsIf">AddSharesAbortsIf</a> {
-    pool: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>;
+    self: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>;
     shareholder: <b>address</b>;
     new_shares: u64;
-    <b>let</b> key_exists = <a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(pool.shares, shareholder);
-    <b>let</b> current_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder);
+    <b>let</b> key_exists = <a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(self.shares, shareholder);
+    <b>let</b> current_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder);
     <b>aborts_if</b> key_exists && current_shares + new_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
-    <b>aborts_if</b> !key_exists && new_shares &gt; 0 && len(pool.shareholders) &gt;= pool.shareholders_limit;
+    <b>aborts_if</b> !key_exists && new_shares &gt; 0 && len(self.shareholders) &gt;= self.shareholders_limit;
 }
 </code></pre>
 
@@ -1103,17 +1103,17 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>schema</b> <a href="pool_u64.md#0x1_pool_u64_AddSharesEnsures">AddSharesEnsures</a> {
-    pool: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>;
+    self: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>;
     shareholder: <b>address</b>;
     new_shares: u64;
-    <b>let</b> key_exists = <a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(pool.shares, shareholder);
-    <b>let</b> current_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder);
+    <b>let</b> key_exists = <a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(self.shares, shareholder);
+    <b>let</b> current_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder);
     <b>ensures</b> key_exists ==&gt;
-        pool.shares == <a href="simple_map.md#0x1_simple_map_spec_set">simple_map::spec_set</a>(<b>old</b>(pool.shares), shareholder, current_shares + new_shares);
+        self.shares == <a href="simple_map.md#0x1_simple_map_spec_set">simple_map::spec_set</a>(<b>old</b>(self.shares), shareholder, current_shares + new_shares);
     <b>ensures</b> (!key_exists && new_shares &gt; 0) ==&gt;
-        pool.shares == <a href="simple_map.md#0x1_simple_map_spec_set">simple_map::spec_set</a>(<b>old</b>(pool.shares), shareholder, new_shares);
+        self.shares == <a href="simple_map.md#0x1_simple_map_spec_set">simple_map::spec_set</a>(<b>old</b>(self.shares), shareholder, new_shares);
     <b>ensures</b> (!key_exists && new_shares &gt; 0) ==&gt;
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_eq_push_back">vector::eq_push_back</a>(pool.shareholders, <b>old</b>(pool.shareholders), shareholder);
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_eq_push_back">vector::eq_push_back</a>(self.shareholders, <b>old</b>(self.shareholders), shareholder);
 }
 </code></pre>
 
@@ -1140,20 +1140,22 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `redeem_shares`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_redeem_shares">redeem_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u64): u64
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> redeemed_coins = <a href="pool_u64.md#0x1_pool_u64_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(pool, shares_to_redeem, pool.total_coins);
-<b>aborts_if</b> !<a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(pool, shareholder);
-<b>aborts_if</b> <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(pool, shareholder) &lt; shares_to_redeem;
-<b>aborts_if</b> pool.<a href="pool_u64.md#0x1_pool_u64_total_coins">total_coins</a> &lt; redeemed_coins;
-<b>aborts_if</b> pool.<a href="pool_u64.md#0x1_pool_u64_total_shares">total_shares</a> &lt; shares_to_redeem;
-<b>ensures</b> pool.total_coins == <b>old</b>(pool.total_coins) - redeemed_coins;
-<b>ensures</b> pool.total_shares == <b>old</b>(pool.total_shares) - shares_to_redeem;
-<b>include</b> shares_to_redeem &gt; 0 ==&gt; <a href="pool_u64.md#0x1_pool_u64_DeductSharesEnsures">DeductSharesEnsures</a> { num_shares: shares_to_redeem };
+<pre><code><b>let</b> redeemed_coins = <a href="pool_u64.md#0x1_pool_u64_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(self, shares_to_redeem, self.total_coins);
+<b>aborts_if</b> !<a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(self, shareholder);
+<b>aborts_if</b> <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(self, shareholder) &lt; shares_to_redeem;
+<b>aborts_if</b> self.<a href="pool_u64.md#0x1_pool_u64_total_coins">total_coins</a> &lt; redeemed_coins;
+<b>aborts_if</b> self.<a href="pool_u64.md#0x1_pool_u64_total_shares">total_shares</a> &lt; shares_to_redeem;
+<b>ensures</b> self.total_coins == <b>old</b>(self.total_coins) - redeemed_coins;
+<b>ensures</b> self.total_shares == <b>old</b>(self.total_shares) - shares_to_redeem;
+<b>include</b> shares_to_redeem &gt; 0 ==&gt; <a href="pool_u64.md#0x1_pool_u64_DeductSharesEnsures">DeductSharesEnsures</a> {
+    num_shares: shares_to_redeem
+};
 <b>ensures</b> result == redeemed_coins;
 </code></pre>
 
@@ -1164,15 +1166,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `transfer_shares`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_transfer_shares">transfer_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_transfer_shares">transfer_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u64)
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> aborts_if_is_partial;
-<b>aborts_if</b> !<a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(pool, shareholder_1);
-<b>aborts_if</b> <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(pool, shareholder_1) &lt; shares_to_transfer;
+<b>aborts_if</b> !<a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(self, shareholder_1);
+<b>aborts_if</b> <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(self, shareholder_1) &lt; shares_to_transfer;
 </code></pre>
 
 
@@ -1182,17 +1184,17 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `deduct_shares`
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
+<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> !<a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(pool, shareholder);
-<b>aborts_if</b> <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(pool, shareholder) &lt; num_shares;
+<pre><code><b>aborts_if</b> !<a href="pool_u64.md#0x1_pool_u64_spec_contains">spec_contains</a>(self, shareholder);
+<b>aborts_if</b> <a href="pool_u64.md#0x1_pool_u64_spec_shares">spec_shares</a>(self, shareholder) &lt; num_shares;
 <b>include</b> <a href="pool_u64.md#0x1_pool_u64_DeductSharesEnsures">DeductSharesEnsures</a>;
-<b>let</b> remaining_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder) - num_shares;
-<b>ensures</b> remaining_shares &gt; 0 ==&gt; result == <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder);
+<b>let</b> remaining_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder) - num_shares;
+<b>ensures</b> remaining_shares &gt; 0 ==&gt; result == <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder);
 <b>ensures</b> remaining_shares == 0 ==&gt; result == 0;
 </code></pre>
 
@@ -1203,13 +1205,13 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>schema</b> <a href="pool_u64.md#0x1_pool_u64_DeductSharesEnsures">DeductSharesEnsures</a> {
-    pool: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>;
+    self: <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>;
     shareholder: <b>address</b>;
     num_shares: u64;
-    <b>let</b> remaining_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder) - num_shares;
-    <b>ensures</b> remaining_shares &gt; 0 ==&gt; <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(pool.shares, shareholder) == remaining_shares;
-    <b>ensures</b> remaining_shares == 0 ==&gt; !<a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(pool.shares, shareholder);
-    <b>ensures</b> remaining_shares == 0 ==&gt; !<a href="../../move-stdlib/doc/vector.md#0x1_vector_spec_contains">vector::spec_contains</a>(pool.shareholders, shareholder);
+    <b>let</b> remaining_shares = <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder) - num_shares;
+    <b>ensures</b> remaining_shares &gt; 0 ==&gt; <a href="simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(self.shares, shareholder) == remaining_shares;
+    <b>ensures</b> remaining_shares == 0 ==&gt; !<a href="simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(self.shares, shareholder);
+    <b>ensures</b> remaining_shares == 0 ==&gt; !<a href="../../move-stdlib/doc/vector.md#0x1_vector_spec_contains">vector::spec_contains</a>(self.shareholders, shareholder);
 }
 </code></pre>
 
@@ -1220,18 +1222,18 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `amount_to_shares_with_total_coins`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, coins_amount: u64, total_coins: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, coins_amount: u64, total_coins: u64): u64
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0
-    && (coins_amount * pool.total_shares) / total_coins &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
-<b>aborts_if</b> (pool.total_coins == 0 || pool.total_shares == 0)
-    && coins_amount * pool.scaling_factor &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
-<b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0 && total_coins == 0;
-<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(pool, coins_amount, total_coins);
+<pre><code><b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0
+    && (coins_amount * self.total_shares) / total_coins &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
+<b>aborts_if</b> (self.total_coins == 0 || self.total_shares == 0)
+    && coins_amount * self.scaling_factor &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
+<b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0 && total_coins == 0;
+<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(self, coins_amount, total_coins);
 </code></pre>
 
 
@@ -1241,15 +1243,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `shares_to_amount_with_total_coins`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shares: u64, total_coins: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shares: u64, total_coins: u64): u64
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0
-    && (shares * total_coins) / pool.total_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
-<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(pool, shares, total_coins);
+<pre><code><b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0
+    && (shares * total_coins) / self.total_shares &gt; <a href="pool_u64.md#0x1_pool_u64_MAX_U64">MAX_U64</a>;
+<b>ensures</b> result == <a href="pool_u64.md#0x1_pool_u64_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(self, shares, total_coins);
 </code></pre>
 
 
@@ -1275,7 +1277,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `multiply_then_divide`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, x: u64, y: u64, z: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_multiply_then_divide">multiply_then_divide</a>(self: &<a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, x: u64, y: u64, z: u64): u64
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
@@ -296,7 +296,7 @@ Create a new pool with custom <code>scaling_factor</code>.
 Destroy an empty pool. This will fail if the pool has any balance of coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_destroy_empty">destroy_empty</a>(pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_destroy_empty">destroy_empty</a>(self: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>)
 </code></pre>
 
 
@@ -305,14 +305,14 @@ Destroy an empty pool. This will fail if the pool has any balance of coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_destroy_empty">destroy_empty</a>(pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>) {
-    <b>assert</b>!(pool.total_coins == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_IS_NOT_EMPTY">EPOOL_IS_NOT_EMPTY</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_destroy_empty">destroy_empty</a>(self: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>) {
+    <b>assert</b>!(self.total_coins == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_IS_NOT_EMPTY">EPOOL_IS_NOT_EMPTY</a>));
     <b>let</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a> {
         total_coins: _,
         total_shares: _,
         shares,
         scaling_factor: _,
-    } = pool;
+    } = self;
     table::destroy_empty&lt;<b>address</b>, u128&gt;(shares);
 }
 </code></pre>
@@ -325,10 +325,10 @@ Destroy an empty pool. This will fail if the pool has any balance of coins.
 
 ## Function `total_coins`
 
-Return <code>pool</code>'s total balance of coins.
+Return <code>self</code>'s total balance of coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u64
 </code></pre>
 
 
@@ -337,8 +337,8 @@ Return <code>pool</code>'s total balance of coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u64 {
-    pool.total_coins
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u64 {
+    self.total_coins
 }
 </code></pre>
 
@@ -350,10 +350,10 @@ Return <code>pool</code>'s total balance of coins.
 
 ## Function `total_shares`
 
-Return the total number of shares across all shareholders in <code>pool</code>.
+Return the total number of shares across all shareholders in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u128
 </code></pre>
 
 
@@ -362,8 +362,8 @@ Return the total number of shares across all shareholders in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u128 {
-    pool.total_shares
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u128 {
+    self.total_shares
 }
 </code></pre>
 
@@ -375,10 +375,10 @@ Return the total number of shares across all shareholders in <code>pool</code>.
 
 ## Function `contains`
 
-Return true if <code>shareholder</code> is in <code>pool</code>.
+Return true if <code>shareholder</code> is in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): bool
 </code></pre>
 
 
@@ -387,8 +387,8 @@ Return true if <code>shareholder</code> is in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): bool {
-    <a href="table.md#0x1_table_contains">table::contains</a>(&pool.shares, shareholder)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): bool {
+    <a href="table.md#0x1_table_contains">table::contains</a>(&self.shares, shareholder)
 }
 </code></pre>
 
@@ -400,10 +400,10 @@ Return true if <code>shareholder</code> is in <code>pool</code>.
 
 ## Function `shares`
 
-Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
+Return the number of shares of <code>stakeholder</code> in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u128
 </code></pre>
 
 
@@ -412,9 +412,9 @@ Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): u128 {
-    <b>if</b> (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder)) {
-        *<a href="table.md#0x1_table_borrow">table::borrow</a>(&pool.shares, shareholder)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): u128 {
+    <b>if</b> (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self, shareholder)) {
+        *<a href="table.md#0x1_table_borrow">table::borrow</a>(&self.shares, shareholder)
     } <b>else</b> {
         0
     }
@@ -429,10 +429,10 @@ Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
 
 ## Function `balance`
 
-Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
+Return the balance in coins of <code>shareholder</code> in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u64
 </code></pre>
 
 
@@ -441,9 +441,9 @@ Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
-    <b>let</b> num_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder);
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool, num_shares)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
+    <b>let</b> num_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self, shareholder);
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(self, num_shares)
 }
 </code></pre>
 
@@ -455,10 +455,10 @@ Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
 
 ## Function `shareholders_count`
 
-Return the number of shareholders in <code>pool</code>.
+Return the number of shareholders in <code>self</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shareholders_count">shareholders_count</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shareholders_count">shareholders_count</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u64
 </code></pre>
 
 
@@ -467,8 +467,8 @@ Return the number of shareholders in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shareholders_count">shareholders_count</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u64 {
-    table::length(&pool.shares)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shareholders_count">shareholders_count</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u64 {
+    table::length(&self.shares)
 }
 </code></pre>
 
@@ -480,10 +480,10 @@ Return the number of shareholders in <code>pool</code>.
 
 ## Function `update_total_coins`
 
-Update <code>pool</code>'s total balance of coins.
+Update <code>self</code>'s total balance of coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_update_total_coins">update_total_coins</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, new_total_coins: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_update_total_coins">update_total_coins</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, new_total_coins: u64)
 </code></pre>
 
 
@@ -492,8 +492,8 @@ Update <code>pool</code>'s total balance of coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_update_total_coins">update_total_coins</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, new_total_coins: u64) {
-    pool.total_coins = new_total_coins;
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_update_total_coins">update_total_coins</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, new_total_coins: u64) {
+    self.total_coins = new_total_coins;
 }
 </code></pre>
 
@@ -508,7 +508,7 @@ Update <code>pool</code>'s total balance of coins.
 Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
 </code></pre>
 
 
@@ -517,16 +517,16 @@ Allow an existing or new shareholder to add their coins to the pool in exchange 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128 {
     <b>if</b> (coins_amount == 0) <b>return</b> 0;
 
-    <b>let</b> new_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(pool, coins_amount);
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a> - pool.total_coins &gt;= coins_amount, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a> - pool.total_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_SHARES_OVERFLOW">EPOOL_TOTAL_SHARES_OVERFLOW</a>));
+    <b>let</b> new_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(self, coins_amount);
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a> - self.total_coins &gt;= coins_amount, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a> - self.total_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_SHARES_OVERFLOW">EPOOL_TOTAL_SHARES_OVERFLOW</a>));
 
-    pool.total_coins = pool.total_coins + coins_amount;
-    pool.total_shares = pool.total_shares + new_shares;
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool, shareholder, new_shares);
+    self.total_coins = self.total_coins + coins_amount;
+    self.total_shares = self.total_shares + new_shares;
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(self, shareholder, new_shares);
     new_shares
 }
 </code></pre>
@@ -539,11 +539,11 @@ Allow an existing or new shareholder to add their coins to the pool in exchange 
 
 ## Function `add_shares`
 
-Add the number of shares directly for <code>shareholder</code> in <code>pool</code>.
+Add the number of shares directly for <code>shareholder</code> in <code>self</code>.
 This would dilute other shareholders if the pool's balance of coins didn't change.
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128
 </code></pre>
 
 
@@ -552,16 +552,16 @@ This would dilute other shareholders if the pool's balance of coins didn't chang
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128 {
-    <b>if</b> (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder)) {
-        <b>let</b> existing_shares = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.shares, shareholder);
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128 {
+    <b>if</b> (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self, shareholder)) {
+        <b>let</b> existing_shares = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.shares, shareholder);
         <b>let</b> current_shares = *existing_shares;
         <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a> - current_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_SHARES_OVERFLOW">ESHAREHOLDER_SHARES_OVERFLOW</a>));
 
         *existing_shares = current_shares + new_shares;
         *existing_shares
     } <b>else</b> <b>if</b> (new_shares &gt; 0) {
-        <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> pool.shares, shareholder, new_shares);
+        <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> self.shares, shareholder, new_shares);
         new_shares
     } <b>else</b> {
         new_shares
@@ -577,10 +577,10 @@ This would dilute other shareholders if the pool's balance of coins didn't chang
 
 ## Function `redeem_shares`
 
-Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for coins.
+Allow <code>shareholder</code> to redeem their shares in <code>self</code> for coins.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64
 </code></pre>
 
 
@@ -589,16 +589,16 @@ Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64 {
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder) &gt;= shares_to_redeem, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64 {
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self, shareholder) &gt;= shares_to_redeem, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
 
     <b>if</b> (shares_to_redeem == 0) <b>return</b> 0;
 
-    <b>let</b> redeemed_coins = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool, shares_to_redeem);
-    pool.total_coins = pool.total_coins - redeemed_coins;
-    pool.total_shares = pool.total_shares - shares_to_redeem;
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool, shareholder, shares_to_redeem);
+    <b>let</b> redeemed_coins = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(self, shares_to_redeem);
+    self.total_coins = self.total_coins - redeemed_coins;
+    self.total_shares = self.total_shares - shares_to_redeem;
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self, shareholder, shares_to_redeem);
 
     redeemed_coins
 }
@@ -615,7 +615,7 @@ Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for c
 Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u128)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u128)
 </code></pre>
 
 
@@ -625,17 +625,17 @@ Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(
-    pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>,
+    self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>,
     shareholder_1: <b>address</b>,
     shareholder_2: <b>address</b>,
     shares_to_transfer: u128,
 ) {
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder_1), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder_1) &gt;= shares_to_transfer, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self, shareholder_1), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self, shareholder_1) &gt;= shares_to_transfer, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
     <b>if</b> (shares_to_transfer == 0) <b>return</b>;
 
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool, shareholder_1, shares_to_transfer);
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool, shareholder_2, shares_to_transfer);
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self, shareholder_1, shares_to_transfer);
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(self, shareholder_2, shares_to_transfer);
 }
 </code></pre>
 
@@ -647,10 +647,10 @@ Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 
 ## Function `deduct_shares`
 
-Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code> and return the number of remaining shares.
+Directly deduct <code>shareholder</code>'s number of shares in <code>self</code> and return the number of remaining shares.
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
 </code></pre>
 
 
@@ -659,17 +659,17 @@ Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128 {
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
-    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128 {
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self, shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
 
-    <b>let</b> existing_shares = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.shares, shareholder);
+    <b>let</b> existing_shares = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.shares, shareholder);
     *existing_shares = *existing_shares - num_shares;
 
     // Remove the shareholder completely <b>if</b> they have no shares left.
     <b>let</b> remaining_shares = *existing_shares;
     <b>if</b> (remaining_shares == 0) {
-        <a href="table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> pool.shares, shareholder);
+        <a href="table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> self.shares, shareholder);
     };
 
     remaining_shares
@@ -684,11 +684,11 @@ Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code>
 
 ## Function `amount_to_shares`
 
-Return the number of new shares <code>coins_amount</code> can buy in <code>pool</code>.
+Return the number of new shares <code>coins_amount</code> can buy in <code>self</code>.
 <code>amount</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64): u128
 </code></pre>
 
 
@@ -697,8 +697,8 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, coins_amount: u64): u128 {
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool, coins_amount, pool.total_coins)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, coins_amount: u64): u128 {
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self, coins_amount, self.total_coins)
 }
 </code></pre>
 
@@ -710,11 +710,11 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 
 ## Function `amount_to_shares_with_total_coins`
 
-Return the number of new shares <code>coins_amount</code> can buy in <code>pool</code> with a custom total coins number.
+Return the number of new shares <code>coins_amount</code> can buy in <code>self</code> with a custom total coins number.
 <code>amount</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64, total_coins: u64): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64, total_coins: u64): u128
 </code></pre>
 
 
@@ -723,17 +723,17 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, coins_amount: u64, total_coins: u64): u128 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, coins_amount: u64, total_coins: u64): u128 {
     // No shares yet so amount is worth the same number of shares.
-    <b>if</b> (pool.total_coins == 0 || pool.total_shares == 0) {
+    <b>if</b> (self.total_coins == 0 || self.total_shares == 0) {
         // Multiply by scaling factor <b>to</b> minimize rounding errors during <b>internal</b> calculations for buy ins/redeems.
         // This can overflow but scaling factor is expected <b>to</b> be chosen carefully so this would not overflow.
-        <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(coins_amount) * <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(pool.scaling_factor)
+        <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(coins_amount) * <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(self.scaling_factor)
     } <b>else</b> {
         // Shares price = total_coins / total existing shares.
         // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
         // We rearrange the calc and do multiplication first <b>to</b> avoid rounding errors.
-        <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(pool, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(coins_amount), pool.total_shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins))
+        <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(self, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(coins_amount), self.total_shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins))
     }
 }
 </code></pre>
@@ -746,11 +746,11 @@ Return the number of new shares <code>coins_amount</code> can buy in <code>pool<
 
 ## Function `shares_to_amount`
 
-Return the number of coins <code>shares</code> are worth in <code>pool</code>.
+Return the number of coins <code>shares</code> are worth in <code>self</code>.
 <code>shares</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128): u64
 </code></pre>
 
 
@@ -759,8 +759,8 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shares: u128): u64 {
-    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool, shares, pool.total_coins)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shares: u128): u64 {
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self, shares, self.total_coins)
 }
 </code></pre>
 
@@ -772,11 +772,11 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code>.
 
 ## Function `shares_to_amount_with_total_coins`
 
-Return the number of coins <code>shares</code> are worth in <code>pool</code> with a custom total coins number.
+Return the number of coins <code>shares</code> are worth in <code>self</code> with a custom total coins number.
 <code>shares</code> needs to big enough to avoid rounding number.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64): u64
 </code></pre>
 
 
@@ -785,15 +785,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shares: u128, total_coins: u64): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shares: u128, total_coins: u64): u64 {
     // No shares or coins yet so shares are worthless.
-    <b>if</b> (pool.total_coins == 0 || pool.total_shares == 0) {
+    <b>if</b> (self.total_coins == 0 || self.total_shares == 0) {
         0
     } <b>else</b> {
         // Shares price = total_coins / total existing shares.
         // Shares worth = shares * shares price = shares * total_coins / total existing shares.
         // We rearrange the calc and do multiplication first <b>to</b> avoid rounding errors.
-        (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(pool, shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins), pool.total_shares) <b>as</b> u64)
+        (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(self, shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins), self.total_shares) <b>as</b> u64)
     }
 }
 </code></pre>
@@ -809,7 +809,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 Return the number of coins <code>shares</code> are worth in <code>pool</code> with custom total coins and shares numbers.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_stats">shares_to_amount_with_total_stats</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64, total_shares: u128): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_stats">shares_to_amount_with_total_stats</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64, total_shares: u128): u64
 </code></pre>
 
 
@@ -819,15 +819,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_stats">shares_to_amount_with_total_stats</a>(
-    pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>,
+    self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>,
     shares: u128,
     total_coins: u64,
     total_shares: u128,
 ): u64 {
-    <b>if</b> (pool.total_coins == 0 || total_shares == 0) {
+    <b>if</b> (self.total_coins == 0 || total_shares == 0) {
         0
     } <b>else</b> {
-        (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(pool, shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins), total_shares) <b>as</b> u64)
+        (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(self, shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins), total_shares) <b>as</b> u64)
     }
 }
 </code></pre>
@@ -842,7 +842,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, x: u128, y: u128, z: u128): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, x: u128, y: u128, z: u128): u128
 </code></pre>
 
 
@@ -851,7 +851,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, x: u128, y: u128, z: u128): u128 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, x: u128, y: u128, z: u128): u128 {
     <b>let</b> result = (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(x) * <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(y)) / <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(z);
     (result <b>as</b> u128)
 }
@@ -975,14 +975,14 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `contains`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): bool
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder);
+<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder);
 </code></pre>
 
 
@@ -1008,14 +1008,14 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `shares`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u128
 </code></pre>
 
 
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder);
+<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder);
 </code></pre>
 
 
@@ -1025,16 +1025,16 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `balance`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u64
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder);
-<b>let</b> total_coins = pool.total_coins;
-<b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0 && (shares * total_coins) / pool.total_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>;
-<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(pool, shares, total_coins);
+<pre><code><b>let</b> shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder);
+<b>let</b> total_coins = self.total_coins;
+<b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0 && (shares * total_coins) / self.total_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>;
+<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(self, shares, total_coins);
 </code></pre>
 
 
@@ -1044,19 +1044,19 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `buy_in`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> new_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(pool, coins_amount, pool.total_coins);
-<b>aborts_if</b> pool.total_coins + coins_amount &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>;
-<b>aborts_if</b> pool.total_shares + new_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
+<pre><code><b>let</b> new_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(self, coins_amount, self.total_coins);
+<b>aborts_if</b> self.total_coins + coins_amount &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>;
+<b>aborts_if</b> self.total_shares + new_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
 <b>include</b> coins_amount &gt; 0 ==&gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_AddSharesAbortsIf">AddSharesAbortsIf</a> { new_shares: new_shares };
 <b>include</b> coins_amount &gt; 0 ==&gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_AddSharesEnsures">AddSharesEnsures</a> { new_shares: new_shares };
-<b>ensures</b> pool.total_coins == <b>old</b>(pool.total_coins) + coins_amount;
-<b>ensures</b> pool.total_shares == <b>old</b>(pool.total_shares) + new_shares;
+<b>ensures</b> self.total_coins == <b>old</b>(self.total_coins) + coins_amount;
+<b>ensures</b> self.total_shares == <b>old</b>(self.total_shares) + new_shares;
 <b>ensures</b> result == new_shares;
 </code></pre>
 
@@ -1067,7 +1067,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `add_shares`
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128
 </code></pre>
 
 
@@ -1075,8 +1075,8 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 <pre><code><b>include</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_AddSharesAbortsIf">AddSharesAbortsIf</a>;
 <b>include</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_AddSharesEnsures">AddSharesEnsures</a>;
-<b>let</b> key_exists = <a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(pool.shares, shareholder);
-<b>ensures</b> result == <b>if</b> (key_exists) { <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder) }
+<b>let</b> key_exists = <a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(self.shares, shareholder);
+<b>ensures</b> result == <b>if</b> (key_exists) { <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder) }
 <b>else</b> { new_shares };
 </code></pre>
 
@@ -1087,11 +1087,11 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>schema</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_AddSharesAbortsIf">AddSharesAbortsIf</a> {
-    pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>;
+    self: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>;
     shareholder: <b>address</b>;
     new_shares: u64;
-    <b>let</b> key_exists = <a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(pool.shares, shareholder);
-    <b>let</b> current_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder);
+    <b>let</b> key_exists = <a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(self.shares, shareholder);
+    <b>let</b> current_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder);
     <b>aborts_if</b> key_exists && current_shares + new_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
 }
 </code></pre>
@@ -1103,15 +1103,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>schema</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_AddSharesEnsures">AddSharesEnsures</a> {
-    pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>;
+    self: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>;
     shareholder: <b>address</b>;
     new_shares: u64;
-    <b>let</b> key_exists = <a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(pool.shares, shareholder);
-    <b>let</b> current_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder);
+    <b>let</b> key_exists = <a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(self.shares, shareholder);
+    <b>let</b> current_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder);
     <b>ensures</b> key_exists ==&gt;
-        pool.shares == <a href="table.md#0x1_table_spec_set">table::spec_set</a>(<b>old</b>(pool.shares), shareholder, current_shares + new_shares);
+        self.shares == <a href="table.md#0x1_table_spec_set">table::spec_set</a>(<b>old</b>(self.shares), shareholder, current_shares + new_shares);
     <b>ensures</b> (!key_exists && new_shares &gt; 0) ==&gt;
-        pool.shares == <a href="table.md#0x1_table_spec_set">table::spec_set</a>(<b>old</b>(pool.shares), shareholder, new_shares);
+        self.shares == <a href="table.md#0x1_table_spec_set">table::spec_set</a>(<b>old</b>(self.shares), shareholder, new_shares);
 }
 </code></pre>
 
@@ -1138,20 +1138,22 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `redeem_shares`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64
 </code></pre>
 
 
 
 
-<pre><code><b>let</b> redeemed_coins = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(pool, shares_to_redeem, pool.total_coins);
-<b>aborts_if</b> !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder);
-<b>aborts_if</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder) &lt; shares_to_redeem;
-<b>aborts_if</b> pool.<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a> &lt; redeemed_coins;
-<b>aborts_if</b> pool.<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a> &lt; shares_to_redeem;
-<b>ensures</b> pool.total_coins == <b>old</b>(pool.total_coins) - redeemed_coins;
-<b>ensures</b> pool.total_shares == <b>old</b>(pool.total_shares) - shares_to_redeem;
-<b>include</b> shares_to_redeem &gt; 0 ==&gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_DeductSharesEnsures">DeductSharesEnsures</a> { num_shares: shares_to_redeem };
+<pre><code><b>let</b> redeemed_coins = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(self, shares_to_redeem, self.total_coins);
+<b>aborts_if</b> !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder);
+<b>aborts_if</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder) &lt; shares_to_redeem;
+<b>aborts_if</b> self.<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a> &lt; redeemed_coins;
+<b>aborts_if</b> self.<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a> &lt; shares_to_redeem;
+<b>ensures</b> self.total_coins == <b>old</b>(self.total_coins) - redeemed_coins;
+<b>ensures</b> self.total_shares == <b>old</b>(self.total_shares) - shares_to_redeem;
+<b>include</b> shares_to_redeem &gt; 0 ==&gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_DeductSharesEnsures">DeductSharesEnsures</a> {
+    num_shares: shares_to_redeem
+};
 <b>ensures</b> result == redeemed_coins;
 </code></pre>
 
@@ -1162,27 +1164,28 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `transfer_shares`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u128)
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u128)
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> (shareholder_1 != shareholder_2) && shares_to_transfer &gt; 0 && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_2) &&
-    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder_2) + shares_to_transfer &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>);
-<b>aborts_if</b> !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_1);
-<b>aborts_if</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder_1) &lt; shares_to_transfer;
-<b>ensures</b> shareholder_1 == shareholder_2 ==&gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(pool), shareholder_1) == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder_1);
-<b>ensures</b> ((shareholder_1 != shareholder_2) && (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(pool), shareholder_1) == shares_to_transfer)) ==&gt;
-    !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_1);
+<pre><code><b>aborts_if</b> (shareholder_1 != shareholder_2) && shares_to_transfer &gt; 0 && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_2) &&
+    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder_2) + shares_to_transfer &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>);
+<b>aborts_if</b> !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_1);
+<b>aborts_if</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder_1) &lt; shares_to_transfer;
+<b>ensures</b> shareholder_1 == shareholder_2 ==&gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(self), shareholder_1) == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(
+    self, shareholder_1);
+<b>ensures</b> ((shareholder_1 != shareholder_2) && (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(self), shareholder_1) == shares_to_transfer)) ==&gt;
+    !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_1);
 <b>ensures</b> (shareholder_1 != shareholder_2 && shares_to_transfer &gt; 0) ==&gt;
-    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_2));
-<b>ensures</b> (shareholder_1 != shareholder_2 && shares_to_transfer &gt; 0 && !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(<b>old</b>(pool), shareholder_2)) ==&gt;
-    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_2) && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder_2) == shares_to_transfer);
-<b>ensures</b> (shareholder_1 != shareholder_2 && shares_to_transfer &gt; 0 && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(<b>old</b>(pool), shareholder_2)) ==&gt;
-    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_2) && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder_2) == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(pool), shareholder_2) + shares_to_transfer);
-<b>ensures</b> ((shareholder_1 != shareholder_2) && (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(pool), shareholder_1) &gt; shares_to_transfer)) ==&gt;
-    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder_1) && (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder_1) == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(pool), shareholder_1) - shares_to_transfer));
+    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_2));
+<b>ensures</b> (shareholder_1 != shareholder_2 && shares_to_transfer &gt; 0 && !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(<b>old</b>(self), shareholder_2)) ==&gt;
+    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_2) && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder_2) == shares_to_transfer);
+<b>ensures</b> (shareholder_1 != shareholder_2 && shares_to_transfer &gt; 0 && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(<b>old</b>(self), shareholder_2)) ==&gt;
+    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_2) && <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder_2) == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(self), shareholder_2) + shares_to_transfer);
+<b>ensures</b> ((shareholder_1 != shareholder_2) && (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(self), shareholder_1) &gt; shares_to_transfer)) ==&gt;
+    (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder_1) && (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder_1) == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(<b>old</b>(self), shareholder_1) - shares_to_transfer));
 </code></pre>
 
 
@@ -1192,17 +1195,17 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `deduct_shares`
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(pool, shareholder);
-<b>aborts_if</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(pool, shareholder) &lt; num_shares;
+<pre><code><b>aborts_if</b> !<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_contains">spec_contains</a>(self, shareholder);
+<b>aborts_if</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares">spec_shares</a>(self, shareholder) &lt; num_shares;
 <b>include</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_DeductSharesEnsures">DeductSharesEnsures</a>;
-<b>let</b> remaining_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder) - num_shares;
-<b>ensures</b> remaining_shares &gt; 0 ==&gt; result == <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder);
+<b>let</b> remaining_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder) - num_shares;
+<b>ensures</b> remaining_shares &gt; 0 ==&gt; result == <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder);
 <b>ensures</b> remaining_shares == 0 ==&gt; result == 0;
 </code></pre>
 
@@ -1213,12 +1216,12 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 
 
 <pre><code><b>schema</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_DeductSharesEnsures">DeductSharesEnsures</a> {
-    pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>;
+    self: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>;
     shareholder: <b>address</b>;
     num_shares: u64;
-    <b>let</b> remaining_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder) - num_shares;
-    <b>ensures</b> remaining_shares &gt; 0 ==&gt; <a href="table.md#0x1_table_spec_get">table::spec_get</a>(pool.shares, shareholder) == remaining_shares;
-    <b>ensures</b> remaining_shares == 0 ==&gt; !<a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(pool.shares, shareholder);
+    <b>let</b> remaining_shares = <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder) - num_shares;
+    <b>ensures</b> remaining_shares &gt; 0 ==&gt; <a href="table.md#0x1_table_spec_get">table::spec_get</a>(self.shares, shareholder) == remaining_shares;
+    <b>ensures</b> remaining_shares == 0 ==&gt; !<a href="table.md#0x1_table_spec_contains">table::spec_contains</a>(self.shares, shareholder);
 }
 </code></pre>
 
@@ -1229,18 +1232,18 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `amount_to_shares_with_total_coins`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64, total_coins: u64): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64, total_coins: u64): u128
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0
-    && (coins_amount * pool.total_shares) / total_coins &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
-<b>aborts_if</b> (pool.total_coins == 0 || pool.total_shares == 0)
-    && coins_amount * pool.scaling_factor &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
-<b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0 && total_coins == 0;
-<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(pool, coins_amount, total_coins);
+<pre><code><b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0
+    && (coins_amount * self.total_shares) / total_coins &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
+<b>aborts_if</b> (self.total_coins == 0 || self.total_shares == 0)
+    && coins_amount * self.scaling_factor &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>;
+<b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0 && total_coins == 0;
+<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_amount_to_shares_with_total_coins">spec_amount_to_shares_with_total_coins</a>(self, coins_amount, total_coins);
 </code></pre>
 
 
@@ -1250,15 +1253,15 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `shares_to_amount_with_total_coins`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64): u64
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> pool.total_coins &gt; 0 && pool.total_shares &gt; 0
-    && (shares * total_coins) / pool.total_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>;
-<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(pool, shares, total_coins);
+<pre><code><b>aborts_if</b> self.total_coins &gt; 0 && self.total_shares &gt; 0
+    && (shares * total_coins) / self.total_shares &gt; <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>;
+<b>ensures</b> result == <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_spec_shares_to_amount_with_total_coins">spec_shares_to_amount_with_total_coins</a>(self, shares, total_coins);
 </code></pre>
 
 
@@ -1284,7 +1287,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `multiply_then_divide`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, x: u128, y: u128, z: u128): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(self: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, x: u128, y: u128, z: u128): u128
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -149,7 +149,7 @@ Map key is not found
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_length">length</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_length">length</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): u64
 </code></pre>
 
 
@@ -158,8 +158,8 @@ Map key is not found
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_length">length</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): u64 {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&map.data)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_length">length</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): u64 {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.data)
 }
 </code></pre>
 
@@ -257,7 +257,7 @@ This function is deprecated, use <code>new</code> instead.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow">borrow</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &Value
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow">borrow</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &Value
 </code></pre>
 
 
@@ -267,13 +267,13 @@ This function is deprecated, use <code>new</code> instead.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow">borrow</a>&lt;Key: store, Value: store&gt;(
-    map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): &Value {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(self, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> idx = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
-    &<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, idx).value
+    &<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&self.data, idx).value
 }
 </code></pre>
 
@@ -287,7 +287,7 @@ This function is deprecated, use <code>new</code> instead.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow_mut">borrow_mut</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &<b>mut</b> Value
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow_mut">borrow_mut</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &<b>mut</b> Value
 </code></pre>
 
 
@@ -297,13 +297,13 @@ This function is deprecated, use <code>new</code> instead.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow_mut">borrow_mut</a>&lt;Key: store, Value: store&gt;(
-    map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): &<b>mut</b> Value {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(self, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> idx = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
-    &<b>mut</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> map.data, idx).value
+    &<b>mut</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.data, idx).value
 }
 </code></pre>
 
@@ -317,7 +317,7 @@ This function is deprecated, use <code>new</code> instead.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_contains_key">contains_key</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): bool
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_contains_key">contains_key</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): bool
 </code></pre>
 
 
@@ -327,10 +327,10 @@ This function is deprecated, use <code>new</code> instead.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_contains_key">contains_key</a>&lt;Key: store, Value: store&gt;(
-    map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): bool {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(self, key);
     <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx)
 }
 </code></pre>
@@ -345,7 +345,7 @@ This function is deprecated, use <code>new</code> instead.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(self: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;)
 </code></pre>
 
 
@@ -354,8 +354,8 @@ This function is deprecated, use <code>new</code> instead.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;) {
-    <b>let</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a> { data } = map;
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(self: <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;) {
+    <b>let</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a> { data } = self;
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(data);
 }
 </code></pre>
@@ -371,7 +371,7 @@ This function is deprecated, use <code>new</code> instead.
 Add a key/value pair to the map. The key must not already exist.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add">add</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add">add</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value)
 </code></pre>
 
 
@@ -381,14 +381,14 @@ Add a key/value pair to the map. The key must not already exist.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add">add</a>&lt;Key: store, Value: store&gt;(
-    map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: Key,
     value: Value,
 ) {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, &key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(self, &key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_ALREADY_EXISTS">EKEY_ALREADY_EXISTS</a>));
 
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> map.data, <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value });
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.data, <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value });
 }
 </code></pre>
 
@@ -403,7 +403,7 @@ Add a key/value pair to the map. The key must not already exist.
 Add multiple key/value pairs to the map. The keys must not already exist.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add_all">add_all</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add_all">add_all</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
 </code></pre>
 
 
@@ -413,12 +413,12 @@ Add multiple key/value pairs to the map. The keys must not already exist.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add_all">add_all</a>&lt;Key: store, Value: store&gt;(
-    map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;,
     values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;,
 ) {
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_zip">vector::zip</a>(keys, values, |key, value| {
-        <a href="simple_map.md#0x1_simple_map_add">add</a>(map, key, value);
+        <a href="simple_map.md#0x1_simple_map_add">add</a>(self, key, value);
     });
 }
 </code></pre>
@@ -434,7 +434,7 @@ Add multiple key/value pairs to the map. The keys must not already exist.
 Insert key/value pair or update an existing key to a new value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_upsert">upsert</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_upsert">upsert</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Value&gt;)
 </code></pre>
 
 
@@ -444,11 +444,11 @@ Insert key/value pair or update an existing key to a new value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_upsert">upsert</a>&lt;Key: store, Value: store&gt;(
-    map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: Key,
     value: Value
 ): (std::option::Option&lt;Key&gt;, std::option::Option&lt;Value&gt;) {
-    <b>let</b> data = &<b>mut</b> map.data;
+    <b>let</b> data = &<b>mut</b> self.data;
     <b>let</b> len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(data);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; len) {
@@ -461,7 +461,7 @@ Insert key/value pair or update an existing key to a new value
         };
         i = i + 1;
     };
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> map.data, <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value });
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.data, <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value });
     (std::option::none(), std::option::none())
 }
 </code></pre>
@@ -477,7 +477,7 @@ Insert key/value pair or update an existing key to a new value
 Return all keys in the map. This requires keys to be copyable.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_keys">keys</a>&lt;Key: <b>copy</b>, Value&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_keys">keys</a>&lt;Key: <b>copy</b>, Value&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;
 </code></pre>
 
 
@@ -486,8 +486,8 @@ Return all keys in the map. This requires keys to be copyable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_keys">keys</a>&lt;Key: <b>copy</b>, Value&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt; {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(&map.data, |e| {
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_keys">keys</a>&lt;Key: <b>copy</b>, Value&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt; {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(&self.data, |e| {
         <b>let</b> e: &<a href="simple_map.md#0x1_simple_map_Element">Element</a>&lt;Key, Value&gt; = e;
         e.key
     })
@@ -505,7 +505,7 @@ Return all keys in the map. This requires keys to be copyable.
 Return all values in the map. This requires values to be copyable.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_values">values</a>&lt;Key, Value: <b>copy</b>&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_values">values</a>&lt;Key, Value: <b>copy</b>&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -514,8 +514,8 @@ Return all values in the map. This requires values to be copyable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_values">values</a>&lt;Key, Value: <b>copy</b>&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt; {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(&map.data, |e| {
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_values">values</a>&lt;Key, Value: <b>copy</b>&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt; {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(&self.data, |e| {
         <b>let</b> e: &<a href="simple_map.md#0x1_simple_map_Element">Element</a>&lt;Key, Value&gt; = e;
         e.value
     })
@@ -534,7 +534,7 @@ Transform the map into two vectors with the keys and values respectively
 Primarily used to destroy a map
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>&lt;Key: store, Value: store&gt;(self: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
 </code></pre>
 
 
@@ -544,10 +544,10 @@ Primarily used to destroy a map
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>&lt;Key: store, Value: store&gt;(
-    map: <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;) {
+    self: <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;) {
     <b>let</b> keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt; = <a href="../../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <b>let</b> values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt; = <a href="../../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>let</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a> { data } = map;
+    <b>let</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a> { data } = self;
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(data, |e| {
         <b>let</b> <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value } = e;
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> keys, key);
@@ -569,7 +569,7 @@ For maps that cannot be dropped this is a utility to destroy them
 using lambdas to destroy the individual keys and values.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy">destroy</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, dk: |Key|, dv: |Value|)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy">destroy</a>&lt;Key: store, Value: store&gt;(self: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, dk: |Key|, dv: |Value|)
 </code></pre>
 
 
@@ -579,11 +579,11 @@ using lambdas to destroy the individual keys and values.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy">destroy</a>&lt;Key: store, Value: store&gt;(
-    map: <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     dk: |Key|,
     dv: |Value|
 ) {
-    <b>let</b> (keys, values) = <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>(map);
+    <b>let</b> (keys, values) = <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>(self);
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy">vector::destroy</a>(keys, |_k| dk(_k));
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy">vector::destroy</a>(values, |_v| dv(_v));
 }
@@ -600,7 +600,7 @@ using lambdas to destroy the individual keys and values.
 Remove a key/value pair from the map. The key must exist.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_remove">remove</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): (Key, Value)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_remove">remove</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): (Key, Value)
 </code></pre>
 
 
@@ -610,13 +610,13 @@ Remove a key/value pair from the map. The key must exist.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_remove">remove</a>&lt;Key: store, Value: store&gt;(
-    map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): (Key, Value) {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(self, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> placement = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
-    <b>let</b> <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value } = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(&<b>mut</b> map.data, placement);
+    <b>let</b> <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value } = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(&<b>mut</b> self.data, placement);
     (key, value)
 }
 </code></pre>
@@ -631,7 +631,7 @@ Remove a key/value pair from the map. The key must exist.
 
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
 </code></pre>
 
 
@@ -641,13 +641,13 @@ Remove a key/value pair from the map. The key must exist.
 
 
 <pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(
-    map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt; {
-    <b>let</b> leng = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&map.data);
+    <b>let</b> leng = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.data);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; leng) {
-        <b>let</b> element = <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, i);
+        <b>let</b> element = <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&self.data, i);
         <b>if</b> (&element.key == key) {
             <b>return</b> <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(i)
         };
@@ -710,7 +710,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `length`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_length">length</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_length">length</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): u64
 </code></pre>
 
 
@@ -785,7 +785,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `borrow`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow">borrow</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &Value
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow">borrow</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &Value
 </code></pre>
 
 
@@ -801,7 +801,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `borrow_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow_mut">borrow_mut</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &<b>mut</b> Value
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_borrow_mut">borrow_mut</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): &<b>mut</b> Value
 </code></pre>
 
 
@@ -817,7 +817,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `contains_key`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_contains_key">contains_key</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): bool
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_contains_key">contains_key</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): bool
 </code></pre>
 
 
@@ -833,7 +833,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `destroy_empty`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy_empty">destroy_empty</a>&lt;Key: store, Value: store&gt;(self: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;)
 </code></pre>
 
 
@@ -849,7 +849,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `add`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add">add</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add">add</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value)
 </code></pre>
 
 
@@ -865,7 +865,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `add_all`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add_all">add_all</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_add_all">add_all</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
 </code></pre>
 
 
@@ -881,7 +881,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `upsert`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_upsert">upsert</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_upsert">upsert</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: Key, value: Value): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;Value&gt;)
 </code></pre>
 
 
@@ -890,12 +890,14 @@ Remove a key/value pair from the map. The key must exist.
 <pre><code><b>pragma</b> intrinsic;
 <b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>false</b>;
-<b>ensures</b> [abstract] !<a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(result_1);
-<b>ensures</b> [abstract] !<a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(result_2);
-<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(map, key);
-<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(map, key) == value;
-<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; ((<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(result_1)) && (<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(result_1) == key));
-<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; ((<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(result_2)) && (<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(result_2) == <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(<b>old</b>(map), key)));
+<b>ensures</b> [abstract] !<a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), key) ==&gt; <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(result_1);
+<b>ensures</b> [abstract] !<a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), key) ==&gt; <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(result_2);
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(self, key);
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(self, key) == value;
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), key) ==&gt; ((<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(result_1)) && (<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(result_1) == key));
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), key) ==&gt; ((<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(result_2)) && (<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(result_2) == <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(<b>old</b>(
+    self
+), key)));
 </code></pre>
 
 
@@ -950,7 +952,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `keys`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_keys">keys</a>&lt;Key: <b>copy</b>, Value&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_keys">keys</a>&lt;Key: <b>copy</b>, Value&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;
 </code></pre>
 
 
@@ -966,7 +968,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `values`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_values">values</a>&lt;Key, Value: <b>copy</b>&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_values">values</a>&lt;Key, Value: <b>copy</b>&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -982,7 +984,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `to_vec_pair`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_to_vec_pair">to_vec_pair</a>&lt;Key: store, Value: store&gt;(self: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Key&gt;, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Value&gt;)
 </code></pre>
 
 
@@ -992,9 +994,9 @@ Remove a key/value pair from the map. The key must exist.
 <b>pragma</b> opaque;
 <b>ensures</b> [abstract]
     <b>forall</b> k: Key: <a href="../../move-stdlib/doc/vector.md#0x1_vector_spec_contains">vector::spec_contains</a>(result_1, k) &lt;==&gt;
-        <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(map, k);
+        <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(self, k);
 <b>ensures</b> [abstract] <b>forall</b> i in 0..len(result_1):
-    <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(map, <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(result_1, i)) == <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(result_2, i);
+    <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(self, <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(result_1, i)) == <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(result_2, i);
 </code></pre>
 
 
@@ -1004,7 +1006,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_remove">remove</a>&lt;Key: store, Value: store&gt;(map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): (Key, Value)
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_remove">remove</a>&lt;Key: store, Value: store&gt;(self: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): (Key, Value)
 </code></pre>
 
 
@@ -1020,7 +1022,7 @@ Remove a key/value pair from the map. The key must exist.
 ### Function `find`
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(self: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/smart_table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_table.md
@@ -360,7 +360,7 @@ Destroy empty table.
 Aborts if it's not empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy_empty">destroy_empty</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy_empty">destroy_empty</a>&lt;K, V&gt;(self: <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -369,14 +369,14 @@ Aborts if it's not empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy_empty">destroy_empty</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
-    <b>assert</b>!(<a href="table.md#0x1_table">table</a>.size == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_table.md#0x1_smart_table_ENOT_EMPTY">ENOT_EMPTY</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy_empty">destroy_empty</a>&lt;K, V&gt;(self: <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
+    <b>assert</b>!(self.size == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_table.md#0x1_smart_table_ENOT_EMPTY">ENOT_EMPTY</a>));
     <b>let</b> i = 0;
-    <b>while</b> (i &lt; <a href="table.md#0x1_table">table</a>.num_buckets) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, i));
+    <b>while</b> (i &lt; self.num_buckets) {
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(<a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, i));
         i = i + 1;
     };
-    <b>let</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a> { buckets, num_buckets: _, level: _, size: _, split_load_threshold: _, target_bucket_size: _ } = <a href="table.md#0x1_table">table</a>;
+    <b>let</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a> { buckets, num_buckets: _, level: _, size: _, split_load_threshold: _, target_bucket_size: _ } = self;
     <a href="table_with_length.md#0x1_table_with_length_destroy_empty">table_with_length::destroy_empty</a>(buckets);
 }
 </code></pre>
@@ -392,7 +392,7 @@ Aborts if it's not empty.
 Destroy a table completely when V has <code>drop</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy">destroy</a>&lt;K: drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy">destroy</a>&lt;K: drop, V: drop&gt;(self: <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -401,9 +401,9 @@ Destroy a table completely when V has <code>drop</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy">destroy</a>&lt;K: drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
-    <a href="smart_table.md#0x1_smart_table_clear">clear</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>);
-    <a href="smart_table.md#0x1_smart_table_destroy_empty">destroy_empty</a>(<a href="table.md#0x1_table">table</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy">destroy</a>&lt;K: drop, V: drop&gt;(self: <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
+    <a href="smart_table.md#0x1_smart_table_clear">clear</a>(&<b>mut</b> self);
+    <a href="smart_table.md#0x1_smart_table_destroy_empty">destroy_empty</a>(self);
 }
 </code></pre>
 
@@ -418,7 +418,7 @@ Destroy a table completely when V has <code>drop</code>.
 Clear a table completely when T has <code>drop</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_clear">clear</a>&lt;K: drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_clear">clear</a>&lt;K: drop, V: drop&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -427,16 +427,16 @@ Clear a table completely when T has <code>drop</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_clear">clear</a>&lt;K: drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
-    *<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, 0) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_clear">clear</a>&lt;K: drop, V: drop&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
+    *<a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, 0) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <b>let</b> i = 1;
-    <b>while</b> (i &lt; <a href="table.md#0x1_table">table</a>.num_buckets) {
-        <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, i);
+    <b>while</b> (i &lt; self.num_buckets) {
+        <a href="table_with_length.md#0x1_table_with_length_remove">table_with_length::remove</a>(&<b>mut</b> self.buckets, i);
         i = i + 1;
     };
-    <a href="table.md#0x1_table">table</a>.num_buckets = 1;
-    <a href="table.md#0x1_table">table</a>.level = 0;
-    <a href="table.md#0x1_table">table</a>.size = 0;
+    self.num_buckets = 1;
+    self.level = 0;
+    self.size = 0;
 }
 </code></pre>
 
@@ -455,7 +455,7 @@ Abort if <code>key</code> already exists.
 Note: This method may occasionally cost much more gas when triggering bucket split.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add">add</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add">add</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, value: V)
 </code></pre>
 
 
@@ -464,10 +464,10 @@ Note: This method may occasionally cost much more gas when triggering bucket spl
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add">add</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K, value: V) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add">add</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K, value: V) {
     <b>let</b> <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a> = sip_hash_from_value(&key);
-    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(<a href="table.md#0x1_table">table</a>.level, <a href="table.md#0x1_table">table</a>.num_buckets, <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>);
-    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, index);
+    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(self.level, self.num_buckets, <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>);
+    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, index);
     // We set a per-bucket limit here <b>with</b> a upper bound (10000) that nobody should normally reach.
     <b>assert</b>!(<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket) &lt;= 10000, <a href="../../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="smart_table.md#0x1_smart_table_EEXCEED_MAX_BUCKET_SIZE">EEXCEED_MAX_BUCKET_SIZE</a>));
     <b>assert</b>!(<a href="../../move-stdlib/doc/vector.md#0x1_vector_all">vector::all</a>(bucket, | entry | {
@@ -475,15 +475,15 @@ Note: This method may occasionally cost much more gas when triggering bucket spl
         &e.key != &key
     }), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_table.md#0x1_smart_table_EALREADY_EXIST">EALREADY_EXIST</a>));
     <b>let</b> e = <a href="smart_table.md#0x1_smart_table_Entry">Entry</a> { <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>, key, value };
-    <b>if</b> (<a href="table.md#0x1_table">table</a>.target_bucket_size == 0) {
+    <b>if</b> (self.target_bucket_size == 0) {
         <b>let</b> estimated_entry_size = max(size_of_val(&e), 1);
-        <a href="table.md#0x1_table">table</a>.target_bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
+        self.target_bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(bucket, e);
-    <a href="table.md#0x1_table">table</a>.size = <a href="table.md#0x1_table">table</a>.size + 1;
+    self.size = self.size + 1;
 
-    <b>if</b> (<a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>(<a href="table.md#0x1_table">table</a>) &gt;= (<a href="table.md#0x1_table">table</a>.split_load_threshold <b>as</b> u64)) {
-        <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>(<a href="table.md#0x1_table">table</a>);
+    <b>if</b> (<a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>(self) &gt;= (self.split_load_threshold <b>as</b> u64)) {
+        <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>(self);
     }
 }
 </code></pre>
@@ -499,7 +499,7 @@ Note: This method may occasionally cost much more gas when triggering bucket spl
 Add multiple key/value pairs to the smart table. The keys must not already exist.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add_all">add_all</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add_all">add_all</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;)
 </code></pre>
 
 
@@ -508,8 +508,8 @@ Add multiple key/value pairs to the smart table. The keys must not already exist
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add_all">add_all</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;) {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_zip">vector::zip</a>(keys, values, |key, value| { <a href="smart_table.md#0x1_smart_table_add">add</a>(<a href="table.md#0x1_table">table</a>, key, value); });
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add_all">add_all</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;) {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_zip">vector::zip</a>(keys, values, |key, value| { <a href="smart_table.md#0x1_smart_table_add">add</a>(self, key, value); });
 }
 </code></pre>
 
@@ -557,7 +557,7 @@ view of the whole table.
 Disclaimer: This function may be costly as the smart table may be huge in size. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_to_simple_map">to_simple_map</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;K, V&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_to_simple_map">to_simple_map</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;K, V&gt;
 </code></pre>
 
 
@@ -567,12 +567,12 @@ Disclaimer: This function may be costly as the smart table may be huge in size. 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_to_simple_map">to_simple_map</a>&lt;K: store + <b>copy</b> + drop, V: store + <b>copy</b>&gt;(
-    <a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
+    self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
 ): SimpleMap&lt;K, V&gt; {
     <b>let</b> i = 0;
     <b>let</b> res = <a href="simple_map.md#0x1_simple_map_new">simple_map::new</a>&lt;K, V&gt;();
-    <b>while</b> (i &lt; <a href="table.md#0x1_table">table</a>.num_buckets) {
-        <b>let</b> (keys, values) = <a href="smart_table.md#0x1_smart_table_unzip_entries">unzip_entries</a>(<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&<a href="table.md#0x1_table">table</a>.buckets, i));
+    <b>while</b> (i &lt; self.num_buckets) {
+        <b>let</b> (keys, values) = <a href="smart_table.md#0x1_smart_table_unzip_entries">unzip_entries</a>(<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&self.buckets, i));
         <a href="simple_map.md#0x1_simple_map_add_all">simple_map::add_all</a>(&<b>mut</b> res, keys, values);
         i = i + 1;
     };
@@ -594,7 +594,7 @@ For a large enough smart table this function will fail due to execution gas limi
 <code>keys_paginated</code> should be used instead.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;
 </code></pre>
 
 
@@ -604,9 +604,9 @@ For a large enough smart table this function will fail due to execution gas limi
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: store + <b>copy</b> + drop, V: store + <b>copy</b>&gt;(
-    table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;
+    self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;
 ): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt; {
-    <b>let</b> (keys, _, _) = <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>(table_ref, 0, 0, <a href="smart_table.md#0x1_smart_table_length">length</a>(table_ref));
+    <b>let</b> (keys, _, _) = <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>(self, 0, 0, <a href="smart_table.md#0x1_smart_table_length">length</a>(self));
     keys
 }
 </code></pre>
@@ -634,7 +634,7 @@ returned bucket index and vector index value options are both none, which means 
 pagination is complete. For an example, see <code>test_keys()</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -644,7 +644,7 @@ pagination is complete. For an example, see <code>test_keys()</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: store + <b>copy</b> + drop, V: store + <b>copy</b>&gt;(
-    table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
+    self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
     starting_bucket_index: u64,
     starting_vector_index: u64,
     num_keys_to_get: u64,
@@ -653,8 +653,8 @@ pagination is complete. For an example, see <code>test_keys()</code>.
     Option&lt;u64&gt;,
     Option&lt;u64&gt;,
 ) {
-    <b>let</b> num_buckets = table_ref.num_buckets;
-    <b>let</b> buckets_ref = &table_ref.buckets;
+    <b>let</b> num_buckets = self.num_buckets;
+    <b>let</b> buckets_ref = &self.buckets;
     <b>assert</b>!(starting_bucket_index &lt; num_buckets, <a href="smart_table.md#0x1_smart_table_EINVALID_BUCKET_INDEX">EINVALID_BUCKET_INDEX</a>);
     <b>let</b> bucket_ref = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(buckets_ref, starting_bucket_index);
     <b>let</b> bucket_length = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket_ref);
@@ -707,7 +707,7 @@ pagination is complete. For an example, see <code>test_keys()</code>.
 Decide which is the next bucket to split and split it into two with the elements inside the bucket.
 
 
-<pre><code><b>fun</b> <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>fun</b> <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -716,23 +716,23 @@ Decide which is the next bucket to split and split it into two with the elements
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
-    <b>let</b> new_bucket_index = <a href="table.md#0x1_table">table</a>.num_buckets;
+<pre><code><b>fun</b> <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;) {
+    <b>let</b> new_bucket_index = self.num_buckets;
     // the next bucket <b>to</b> split is num_bucket without the most significant bit.
-    <b>let</b> to_split = new_bucket_index ^ (1 &lt;&lt; <a href="table.md#0x1_table">table</a>.level);
-    <a href="table.md#0x1_table">table</a>.num_buckets = new_bucket_index + 1;
+    <b>let</b> to_split = new_bucket_index ^ (1 &lt;&lt; self.level);
+    self.num_buckets = new_bucket_index + 1;
     // <b>if</b> the whole level is splitted once, bump the level.
-    <b>if</b> (to_split + 1 == 1 &lt;&lt; <a href="table.md#0x1_table">table</a>.level) {
-        <a href="table.md#0x1_table">table</a>.level = <a href="table.md#0x1_table">table</a>.level + 1;
+    <b>if</b> (to_split + 1 == 1 &lt;&lt; self.level) {
+        self.level = self.level + 1;
     };
-    <b>let</b> old_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, to_split);
+    <b>let</b> old_bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, to_split);
     // partition the bucket, [0..p) stays in <b>old</b> bucket, [p..len) goes <b>to</b> new bucket
     <b>let</b> p = <a href="../../move-stdlib/doc/vector.md#0x1_vector_partition">vector::partition</a>(old_bucket, |e| {
         <b>let</b> entry: &<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt; = e; // Explicit type <b>to</b> satisfy compiler
-        <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(<a href="table.md#0x1_table">table</a>.level, <a href="table.md#0x1_table">table</a>.num_buckets, entry.<a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>) != new_bucket_index
+        <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(self.level, self.num_buckets, entry.<a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>) != new_bucket_index
     });
     <b>let</b> new_bucket = <a href="../../move-stdlib/doc/vector.md#0x1_vector_trim_reverse">vector::trim_reverse</a>(old_bucket, p);
-    <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, new_bucket_index, new_bucket);
+    <a href="table_with_length.md#0x1_table_with_length_add">table_with_length::add</a>(&<b>mut</b> self.buckets, new_bucket_index, new_bucket);
 }
 </code></pre>
 
@@ -782,7 +782,7 @@ Acquire an immutable reference to the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow">borrow</a>&lt;K: drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow">borrow</a>&lt;K: drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): &V
 </code></pre>
 
 
@@ -791,9 +791,9 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow">borrow</a>&lt;K: drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): &V {
-    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(<a href="table.md#0x1_table">table</a>.level, <a href="table.md#0x1_table">table</a>.num_buckets, sip_hash_from_value(&key));
-    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&<a href="table.md#0x1_table">table</a>.buckets, index);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow">borrow</a>&lt;K: drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): &V {
+    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(self.level, self.num_buckets, sip_hash_from_value(&key));
+    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&self.buckets, index);
     <b>let</b> i = 0;
     <b>let</b> len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket);
     <b>while</b> (i &lt; len) {
@@ -819,7 +819,7 @@ Acquire an immutable reference to the value which <code>key</code> maps to.
 Returns specified default value if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, default: &V): &V
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, default: &V): &V
 </code></pre>
 
 
@@ -828,11 +828,11 @@ Returns specified default value if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K, default: &V): &V {
-    <b>if</b> (!<a href="smart_table.md#0x1_smart_table_contains">contains</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K, default: &V): &V {
+    <b>if</b> (!<a href="smart_table.md#0x1_smart_table_contains">contains</a>(self, <b>copy</b> key)) {
         default
     } <b>else</b> {
-        <a href="smart_table.md#0x1_smart_table_borrow">borrow</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)
+        <a href="smart_table.md#0x1_smart_table_borrow">borrow</a>(self, <b>copy</b> key)
     }
 }
 </code></pre>
@@ -849,7 +849,7 @@ Acquire a mutable reference to the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>&lt;K: drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>&lt;K: drop, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -858,9 +858,9 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>&lt;K: drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): &<b>mut</b> V {
-    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(<a href="table.md#0x1_table">table</a>.level, <a href="table.md#0x1_table">table</a>.num_buckets, sip_hash_from_value(&key));
-    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, index);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>&lt;K: drop, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): &<b>mut</b> V {
+    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(self.level, self.num_buckets, sip_hash_from_value(&key));
+    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, index);
     <b>let</b> i = 0;
     <b>let</b> len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket);
     <b>while</b> (i &lt; len) {
@@ -886,7 +886,7 @@ Acquire a mutable reference to the value which <code>key</code> maps to.
 Insert the pair (<code>key</code>, <code>default</code>) first if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
 </code></pre>
 
 
@@ -896,14 +896,14 @@ Insert the pair (<code>key</code>, <code>default</code>) first if there is no en
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(
-    <a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
+    self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
     key: K,
     default: V
 ): &<b>mut</b> V {
-    <b>if</b> (!<a href="smart_table.md#0x1_smart_table_contains">contains</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)) {
-        <a href="smart_table.md#0x1_smart_table_add">add</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key, default)
+    <b>if</b> (!<a href="smart_table.md#0x1_smart_table_contains">contains</a>(self, <b>copy</b> key)) {
+        <a href="smart_table.md#0x1_smart_table_add">add</a>(self, <b>copy</b> key, default)
     };
-    <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>(<a href="table.md#0x1_table">table</a>, key)
+    <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>(self, key)
 }
 </code></pre>
 
@@ -918,7 +918,7 @@ Insert the pair (<code>key</code>, <code>default</code>) first if there is no en
 Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_contains">contains</a>&lt;K: drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_contains">contains</a>&lt;K: drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): bool
 </code></pre>
 
 
@@ -927,10 +927,10 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_contains">contains</a>&lt;K: drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_contains">contains</a>&lt;K: drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): bool {
     <b>let</b> <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a> = sip_hash_from_value(&key);
-    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(<a href="table.md#0x1_table">table</a>.level, <a href="table.md#0x1_table">table</a>.num_buckets, <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>);
-    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&<a href="table.md#0x1_table">table</a>.buckets, index);
+    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(self.level, self.num_buckets, <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>);
+    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&self.buckets, index);
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_any">vector::any</a>(bucket, | entry | {
         <b>let</b> e: &<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt; = entry;
         e.<a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a> == <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a> && &e.key == &key
@@ -950,7 +950,7 @@ Remove from <code><a href="table.md#0x1_table">table</a></code> and return the v
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K): V
 </code></pre>
 
 
@@ -959,16 +959,16 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): V {
-    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(<a href="table.md#0x1_table">table</a>.level, <a href="table.md#0x1_table">table</a>.num_buckets, sip_hash_from_value(&key));
-    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets, index);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K): V {
+    <b>let</b> index = <a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a>(self.level, self.num_buckets, sip_hash_from_value(&key));
+    <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, index);
     <b>let</b> i = 0;
     <b>let</b> len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket);
     <b>while</b> (i &lt; len) {
         <b>let</b> entry = <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(bucket, i);
         <b>if</b> (&entry.key == &key) {
             <b>let</b> <a href="smart_table.md#0x1_smart_table_Entry">Entry</a> { <a href="../../move-stdlib/doc/hash.md#0x1_hash">hash</a>: _, key: _, value } = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(bucket, i);
-            <a href="table.md#0x1_table">table</a>.size = <a href="table.md#0x1_table">table</a>.size - 1;
+            self.size = self.size - 1;
             <b>return</b> value
         };
         i = i + 1;
@@ -989,7 +989,7 @@ Insert the pair (<code>key</code>, <code>value</code>) if there is no entry for 
 update the value of the entry for <code>key</code> to <code>value</code> otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, value: V)
 </code></pre>
 
 
@@ -998,11 +998,11 @@ update the value of the entry for <code>key</code> to <code>value</code> otherwi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_upsert">upsert</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K, value: V) {
-    <b>if</b> (!<a href="smart_table.md#0x1_smart_table_contains">contains</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)) {
-        <a href="smart_table.md#0x1_smart_table_add">add</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key, value)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_upsert">upsert</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, key: K, value: V) {
+    <b>if</b> (!<a href="smart_table.md#0x1_smart_table_contains">contains</a>(self, <b>copy</b> key)) {
+        <a href="smart_table.md#0x1_smart_table_add">add</a>(self, <b>copy</b> key, value)
     } <b>else</b> {
-        <b>let</b> ref = <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>(<a href="table.md#0x1_table">table</a>, key);
+        <b>let</b> ref = <a href="smart_table.md#0x1_smart_table_borrow_mut">borrow_mut</a>(self, key);
         *ref = value;
     };
 }
@@ -1019,7 +1019,7 @@ update the value of the entry for <code>key</code> to <code>value</code> otherwi
 Returns the length of the table, i.e. the number of entries.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_length">length</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_length">length</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -1028,8 +1028,8 @@ Returns the length of the table, i.e. the number of entries.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_length">length</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): u64 {
-    <a href="table.md#0x1_table">table</a>.size
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_length">length</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): u64 {
+    self.size
 }
 </code></pre>
 
@@ -1044,7 +1044,7 @@ Returns the length of the table, i.e. the number of entries.
 Return the load factor of the hashtable.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -1053,8 +1053,8 @@ Return the load factor of the hashtable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): u64 {
-    <a href="table.md#0x1_table">table</a>.size * 100 / <a href="table.md#0x1_table">table</a>.num_buckets / <a href="table.md#0x1_table">table</a>.target_bucket_size
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): u64 {
+    self.size * 100 / self.num_buckets / self.target_bucket_size
 }
 </code></pre>
 
@@ -1069,7 +1069,7 @@ Return the load factor of the hashtable.
 Update <code>split_load_threshold</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_split_load_threshold">update_split_load_threshold</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, split_load_threshold: u8)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_split_load_threshold">update_split_load_threshold</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, split_load_threshold: u8)
 </code></pre>
 
 
@@ -1078,12 +1078,12 @@ Update <code>split_load_threshold</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_split_load_threshold">update_split_load_threshold</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, split_load_threshold: u8) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_split_load_threshold">update_split_load_threshold</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, split_load_threshold: u8) {
     <b>assert</b>!(
         split_load_threshold &lt;= 100 && split_load_threshold &gt; 0,
         <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_table.md#0x1_smart_table_EINVALID_LOAD_THRESHOLD_PERCENT">EINVALID_LOAD_THRESHOLD_PERCENT</a>)
     );
-    <a href="table.md#0x1_table">table</a>.split_load_threshold = split_load_threshold;
+    self.split_load_threshold = split_load_threshold;
 }
 </code></pre>
 
@@ -1098,7 +1098,7 @@ Update <code>split_load_threshold</code>.
 Update <code>target_bucket_size</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_target_bucket_size">update_target_bucket_size</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, target_bucket_size: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_target_bucket_size">update_target_bucket_size</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, target_bucket_size: u64)
 </code></pre>
 
 
@@ -1107,9 +1107,9 @@ Update <code>target_bucket_size</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_target_bucket_size">update_target_bucket_size</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, target_bucket_size: u64) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_target_bucket_size">update_target_bucket_size</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, target_bucket_size: u64) {
     <b>assert</b>!(target_bucket_size &gt; 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_table.md#0x1_smart_table_EINVALID_TARGET_BUCKET_SIZE">EINVALID_TARGET_BUCKET_SIZE</a>));
-    <a href="table.md#0x1_table">table</a>.target_bucket_size = target_bucket_size;
+    self.target_bucket_size = target_bucket_size;
 }
 </code></pre>
 
@@ -1124,7 +1124,7 @@ Update <code>target_bucket_size</code>.
 Apply the function to a reference of each key-value pair in the table.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &V)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &V)|)
 </code></pre>
 
 
@@ -1133,11 +1133,11 @@ Apply the function to a reference of each key-value pair in the table.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, f: |&K, &V|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, f: |&K, &V|) {
     <b>let</b> i = 0;
-    <b>while</b> (i &lt; aptos_std::smart_table::num_buckets(<a href="table.md#0x1_table">table</a>)) {
+    <b>while</b> (i &lt; aptos_std::smart_table::num_buckets(self)) {
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(
-            aptos_std::table_with_length::borrow(aptos_std::smart_table::borrow_buckets(<a href="table.md#0x1_table">table</a>), i),
+            aptos_std::table_with_length::borrow(aptos_std::smart_table::borrow_buckets(self), i),
             |elem| {
                 <b>let</b> (key, value) = aptos_std::smart_table::borrow_kv(elem);
                 f(key, value)
@@ -1159,7 +1159,7 @@ Apply the function to a reference of each key-value pair in the table.
 Apply the function to a mutable reference of each key-value pair in the table.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_mut">for_each_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &<b>mut</b> V)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_mut">for_each_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &<b>mut</b> V)|)
 </code></pre>
 
 
@@ -1168,11 +1168,11 @@ Apply the function to a mutable reference of each key-value pair in the table.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_mut">for_each_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, f: |&K, &<b>mut</b> V|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_mut">for_each_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;, f: |&K, &<b>mut</b> V|) {
     <b>let</b> i = 0;
-    <b>while</b> (i &lt; aptos_std::smart_table::num_buckets(<a href="table.md#0x1_table">table</a>)) {
+    <b>while</b> (i &lt; aptos_std::smart_table::num_buckets(self)) {
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_for_each_mut">vector::for_each_mut</a>(
-            <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(aptos_std::smart_table::borrow_buckets_mut(<a href="table.md#0x1_table">table</a>), i),
+            <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(aptos_std::smart_table::borrow_buckets_mut(self), i),
             |elem| {
                 <b>let</b> (key, value) = aptos_std::smart_table::borrow_kv_mut(elem);
                 f(key, value)
@@ -1194,7 +1194,7 @@ Apply the function to a mutable reference of each key-value pair in the table.
 Map the function over the references of key-value pairs in the table without modifying it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_map_ref">map_ref</a>&lt;K: <b>copy</b>, drop, store, V1, V2: store&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V1&gt;, f: |&V1|V2): <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V2&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_map_ref">map_ref</a>&lt;K: <b>copy</b>, drop, store, V1, V2: store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V1&gt;, f: |&V1|V2): <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V2&gt;
 </code></pre>
 
 
@@ -1204,11 +1204,11 @@ Map the function over the references of key-value pairs in the table without mod
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_table.md#0x1_smart_table_map_ref">map_ref</a>&lt;K: <b>copy</b> + drop + store, V1, V2: store&gt;(
-    <a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V1&gt;,
+    self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V1&gt;,
     f: |&V1|V2
 ): <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V2&gt; {
     <b>let</b> new_table = <a href="smart_table.md#0x1_smart_table_new">new</a>&lt;K, V2&gt;();
-    <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>(<a href="table.md#0x1_table">table</a>, |key, value| <a href="smart_table.md#0x1_smart_table_add">add</a>(&<b>mut</b> new_table, *key, f(value)));
+    <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>(self, |key, value| <a href="smart_table.md#0x1_smart_table_add">add</a>(&<b>mut</b> new_table, *key, f(value)));
     new_table
 }
 </code></pre>
@@ -1224,7 +1224,7 @@ Map the function over the references of key-value pairs in the table without mod
 Return true if any key-value pair in the table satisfies the predicate.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any">any</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, p: |(&K, &V)|bool): bool
+<pre><code><b>public</b> <b>fun</b> <a href="any.md#0x1_any">any</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, p: |(&K, &V)|bool): bool
 </code></pre>
 
 
@@ -1234,13 +1234,13 @@ Return true if any key-value pair in the table satisfies the predicate.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="any.md#0x1_any">any</a>&lt;K, V&gt;(
-    <a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
+    self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
     p: |&K, &V|bool
 ): bool {
     <b>let</b> found = <b>false</b>;
     <b>let</b> i = 0;
-    <b>while</b> (i &lt; aptos_std::smart_table::num_buckets(<a href="table.md#0x1_table">table</a>)) {
-        found = <a href="../../move-stdlib/doc/vector.md#0x1_vector_any">vector::any</a>(<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(aptos_std::smart_table::borrow_buckets(<a href="table.md#0x1_table">table</a>), i), |elem| {
+    <b>while</b> (i &lt; aptos_std::smart_table::num_buckets(self)) {
+        found = <a href="../../move-stdlib/doc/vector.md#0x1_vector_any">vector::any</a>(<a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(aptos_std::smart_table::borrow_buckets(self), i), |elem| {
             <b>let</b> (key, value) = aptos_std::smart_table::borrow_kv(elem);
             p(key, value)
         });
@@ -1261,7 +1261,7 @@ Return true if any key-value pair in the table satisfies the predicate.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv">borrow_kv</a>&lt;K, V&gt;(e: &<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&K, &V)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv">borrow_kv</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&K, &V)
 </code></pre>
 
 
@@ -1270,8 +1270,8 @@ Return true if any key-value pair in the table satisfies the predicate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv">borrow_kv</a>&lt;K, V&gt;(e: &<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;): (&K, &V) {
-    (&e.key, &e.value)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv">borrow_kv</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;): (&K, &V) {
+    (&self.key, &self.value)
 }
 </code></pre>
 
@@ -1285,7 +1285,7 @@ Return true if any key-value pair in the table satisfies the predicate.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv_mut">borrow_kv_mut</a>&lt;K, V&gt;(e: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&<b>mut</b> K, &<b>mut</b> V)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv_mut">borrow_kv_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&<b>mut</b> K, &<b>mut</b> V)
 </code></pre>
 
 
@@ -1294,8 +1294,8 @@ Return true if any key-value pair in the table satisfies the predicate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv_mut">borrow_kv_mut</a>&lt;K, V&gt;(e: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;): (&<b>mut</b> K, &<b>mut</b> V) {
-    (&<b>mut</b> e.key, &<b>mut</b> e.value)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv_mut">borrow_kv_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;): (&<b>mut</b> K, &<b>mut</b> V) {
+    (&<b>mut</b> self.key, &<b>mut</b> self.value)
 }
 </code></pre>
 
@@ -1309,7 +1309,7 @@ Return true if any key-value pair in the table satisfies the predicate.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_num_buckets">num_buckets</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_num_buckets">num_buckets</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -1318,8 +1318,8 @@ Return true if any key-value pair in the table satisfies the predicate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_num_buckets">num_buckets</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): u64 {
-    <a href="table.md#0x1_table">table</a>.num_buckets
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_num_buckets">num_buckets</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): u64 {
+    self.num_buckets
 }
 </code></pre>
 
@@ -1333,7 +1333,7 @@ Return true if any key-value pair in the table satisfies the predicate.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets">borrow_buckets</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets">borrow_buckets</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
 </code></pre>
 
 
@@ -1342,8 +1342,8 @@ Return true if any key-value pair in the table satisfies the predicate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets">borrow_buckets</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): &TableWithLength&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;&gt;&gt; {
-    &<a href="table.md#0x1_table">table</a>.buckets
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets">borrow_buckets</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): &TableWithLength&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;&gt;&gt; {
+    &self.buckets
 }
 </code></pre>
 
@@ -1357,7 +1357,7 @@ Return true if any key-value pair in the table satisfies the predicate.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets_mut">borrow_buckets_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets_mut">borrow_buckets_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
 </code></pre>
 
 
@@ -1366,8 +1366,8 @@ Return true if any key-value pair in the table satisfies the predicate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets_mut">borrow_buckets_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): &<b>mut</b> TableWithLength&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;&gt;&gt; {
-    &<b>mut</b> <a href="table.md#0x1_table">table</a>.buckets
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets_mut">borrow_buckets_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;): &<b>mut</b> TableWithLength&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">Entry</a>&lt;K, V&gt;&gt;&gt; {
+    &<b>mut</b> self.buckets
 }
 </code></pre>
 
@@ -1472,7 +1472,7 @@ map_spec_has_key = spec_contains;
 ### Function `destroy`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy">destroy</a>&lt;K: drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_destroy">destroy</a>&lt;K: drop, V: drop&gt;(self: <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -1488,7 +1488,7 @@ map_spec_has_key = spec_contains;
 ### Function `clear`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_clear">clear</a>&lt;K: drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_clear">clear</a>&lt;K: drop, V: drop&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -1504,7 +1504,7 @@ map_spec_has_key = spec_contains;
 ### Function `add_all`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add_all">add_all</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_add_all">add_all</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, keys: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;)
 </code></pre>
 
 
@@ -1520,7 +1520,7 @@ map_spec_has_key = spec_contains;
 ### Function `to_simple_map`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_to_simple_map">to_simple_map</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;K, V&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_to_simple_map">to_simple_map</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;K, V&gt;
 </code></pre>
 
 
@@ -1536,7 +1536,7 @@ map_spec_has_key = spec_contains;
 ### Function `keys`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;
 </code></pre>
 
 
@@ -1552,7 +1552,7 @@ map_spec_has_key = spec_contains;
 ### Function `keys_paginated`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -1568,7 +1568,7 @@ map_spec_has_key = spec_contains;
 ### Function `split_one_bucket`
 
 
-<pre><code><b>fun</b> <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
+<pre><code><b>fun</b> <a href="smart_table.md#0x1_smart_table_split_one_bucket">split_one_bucket</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -1600,7 +1600,7 @@ map_spec_has_key = spec_contains;
 ### Function `borrow_with_default`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, default: &V): &V
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, key: K, default: &V): &V
 </code></pre>
 
 
@@ -1616,7 +1616,7 @@ map_spec_has_key = spec_contains;
 ### Function `load_factor`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_load_factor">load_factor</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -1632,7 +1632,7 @@ map_spec_has_key = spec_contains;
 ### Function `update_split_load_threshold`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_split_load_threshold">update_split_load_threshold</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, split_load_threshold: u8)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_split_load_threshold">update_split_load_threshold</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, split_load_threshold: u8)
 </code></pre>
 
 
@@ -1648,7 +1648,7 @@ map_spec_has_key = spec_contains;
 ### Function `update_target_bucket_size`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_target_bucket_size">update_target_bucket_size</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, target_bucket_size: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_update_target_bucket_size">update_target_bucket_size</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, target_bucket_size: u64)
 </code></pre>
 
 
@@ -1664,7 +1664,7 @@ map_spec_has_key = spec_contains;
 ### Function `borrow_kv`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv">borrow_kv</a>&lt;K, V&gt;(e: &<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&K, &V)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv">borrow_kv</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&K, &V)
 </code></pre>
 
 
@@ -1680,7 +1680,7 @@ map_spec_has_key = spec_contains;
 ### Function `borrow_kv_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv_mut">borrow_kv_mut</a>&lt;K, V&gt;(e: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&<b>mut</b> K, &<b>mut</b> V)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_kv_mut">borrow_kv_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;): (&<b>mut</b> K, &<b>mut</b> V)
 </code></pre>
 
 
@@ -1696,7 +1696,7 @@ map_spec_has_key = spec_contains;
 ### Function `num_buckets`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_num_buckets">num_buckets</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_num_buckets">num_buckets</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -1712,7 +1712,7 @@ map_spec_has_key = spec_contains;
 ### Function `borrow_buckets`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets">borrow_buckets</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets">borrow_buckets</a>&lt;K, V&gt;(self: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
 </code></pre>
 
 
@@ -1728,7 +1728,7 @@ map_spec_has_key = spec_contains;
 ### Function `borrow_buckets_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets_mut">borrow_buckets_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_borrow_buckets_mut">borrow_buckets_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;u64, <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="smart_table.md#0x1_smart_table_Entry">smart_table::Entry</a>&lt;K, V&gt;&gt;&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
@@ -297,11 +297,11 @@ Create a vector of length 1 containing the passed in T.
 
 ## Function `destroy_empty`
 
-Destroy the vector <code>v</code>.
-Aborts if <code>v</code> is not empty.
+Destroy the vector <code>self</code>.
+Aborts if <code>self</code> is not empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -310,9 +310,9 @@ Aborts if <code>v</code> is not empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
-    <b>assert</b>!(<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(&v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EVECTOR_NOT_EMPTY">EVECTOR_NOT_EMPTY</a>));
-    <b>let</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a> { inline_vec, big_vec, inline_capacity: _, bucket_size: _ } = v;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
+    <b>assert</b>!(<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(&self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EVECTOR_NOT_EMPTY">EVECTOR_NOT_EMPTY</a>));
+    <b>let</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a> { inline_vec, big_vec, inline_capacity: _, bucket_size: _ } = self;
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(inline_vec);
     <a href="../../move-stdlib/doc/option.md#0x1_option_destroy_none">option::destroy_none</a>(big_vec);
 }
@@ -329,7 +329,7 @@ Aborts if <code>v</code> is not empty.
 Destroy a vector completely when T has <code>drop</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy">destroy</a>&lt;T: drop&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy">destroy</a>&lt;T: drop&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -338,9 +338,9 @@ Destroy a vector completely when T has <code>drop</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy">destroy</a>&lt;T: drop&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
-    <a href="smart_vector.md#0x1_smart_vector_clear">clear</a>(&<b>mut</b> v);
-    <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>(v);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy">destroy</a>&lt;T: drop&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
+    <a href="smart_vector.md#0x1_smart_vector_clear">clear</a>(&<b>mut</b> self);
+    <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>(self);
 }
 </code></pre>
 
@@ -355,7 +355,7 @@ Destroy a vector completely when T has <code>drop</code>.
 Clear a vector completely when T has <code>drop</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_clear">clear</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_clear">clear</a>&lt;T: drop&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -364,10 +364,10 @@ Clear a vector completely when T has <code>drop</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_clear">clear</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
-    v.inline_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.big_vec)) {
-        <a href="big_vector.md#0x1_big_vector_destroy">big_vector::destroy</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> v.big_vec));
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_clear">clear</a>&lt;T: drop&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
+    self.inline_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&self.big_vec)) {
+        <a href="big_vector.md#0x1_big_vector_destroy">big_vector::destroy</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.big_vec));
     }
 }
 </code></pre>
@@ -380,11 +380,11 @@ Clear a vector completely when T has <code>drop</code>.
 
 ## Function `borrow`
 
-Acquire an immutable reference to the <code>i</code>th T of the vector <code>v</code>.
+Acquire an immutable reference to the <code>i</code>th T of the vector <code>self</code>.
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &T
 </code></pre>
 
 
@@ -393,13 +393,13 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): &T {
-    <b>assert</b>!(i &lt; <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): &T {
+    <b>assert</b>!(i &lt; <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
     <b>if</b> (i &lt; inline_len) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&v.inline_vec, i)
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&self.inline_vec, i)
     } <b>else</b> {
-        <a href="big_vector.md#0x1_big_vector_borrow">big_vector::borrow</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec), i - inline_len)
+        <a href="big_vector.md#0x1_big_vector_borrow">big_vector::borrow</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&self.big_vec), i - inline_len)
     }
 }
 </code></pre>
@@ -412,11 +412,11 @@ Aborts if <code>i</code> is out of bounds.
 
 ## Function `borrow_mut`
 
-Return a mutable reference to the <code>i</code>th T in the vector <code>v</code>.
+Return a mutable reference to the <code>i</code>th T in the vector <code>self</code>.
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T
 </code></pre>
 
 
@@ -425,13 +425,13 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T {
-    <b>assert</b>!(i &lt; <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow_mut">borrow_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): &<b>mut</b> T {
+    <b>assert</b>!(i &lt; <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
     <b>if</b> (i &lt; inline_len) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.inline_vec, i)
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.inline_vec, i)
     } <b>else</b> {
-        <a href="big_vector.md#0x1_big_vector_borrow_mut">big_vector::borrow_mut</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec), i - inline_len)
+        <a href="big_vector.md#0x1_big_vector_borrow_mut">big_vector::borrow_mut</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> self.big_vec), i - inline_len)
     }
 }
 </code></pre>
@@ -444,12 +444,12 @@ Aborts if <code>i</code> is out of bounds.
 
 ## Function `append`
 
-Empty and destroy the other vector, and push each of the Ts in the other vector onto the lhs vector in the
+Empty and destroy the other vector, and push each of the Ts in the other vector onto the self vector in the
 same order as they occurred in other.
 Disclaimer: This function may be costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_append">append</a>&lt;T: store&gt;(lhs: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, other: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_append">append</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, other: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -458,16 +458,16 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_append">append</a>&lt;T: store&gt;(lhs: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, other: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_append">append</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, other: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
     <b>let</b> other_len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(&other);
     <b>let</b> half_other_len = other_len / 2;
     <b>let</b> i = 0;
     <b>while</b> (i &lt; half_other_len) {
-        <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(lhs, <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>(&<b>mut</b> other, i));
+        <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(self, <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>(&<b>mut</b> other, i));
         i = i + 1;
     };
     <b>while</b> (i &lt; other_len) {
-        <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(lhs, <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>(&<b>mut</b> other));
+        <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(self, <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>(&<b>mut</b> other));
         i = i + 1;
     };
     <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>(other);
@@ -485,7 +485,7 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 Add multiple values to the vector at once.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_add_all">add_all</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, vals: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_add_all">add_all</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, vals: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -494,8 +494,8 @@ Add multiple values to the vector at once.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_add_all">add_all</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, vals: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;) {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(vals, |val| { <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(v, val); })
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_add_all">add_all</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, vals: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;) {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(vals, |val| { <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(self, val); })
 }
 </code></pre>
 
@@ -512,7 +512,7 @@ atomic view of the whole vector.
 Disclaimer: This function may be costly as the smart vector may be huge in size. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_to_vector">to_vector</a>&lt;T: <b>copy</b>, store&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_to_vector">to_vector</a>&lt;T: <b>copy</b>, store&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;
 </code></pre>
 
 
@@ -521,10 +521,10 @@ Disclaimer: This function may be costly as the smart vector may be huge in size.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_to_vector">to_vector</a>&lt;T: store + <b>copy</b>&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt; {
-    <b>let</b> res = v.inline_vec;
-    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.big_vec)) {
-        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_to_vector">to_vector</a>&lt;T: store + <b>copy</b>&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt; {
+    <b>let</b> res = self.inline_vec;
+    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&self.big_vec)) {
+        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&self.big_vec);
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> res, <a href="big_vector.md#0x1_big_vector_to_vector">big_vector::to_vector</a>(big_vec));
     };
     res
@@ -539,11 +539,11 @@ Disclaimer: This function may be costly as the smart vector may be huge in size.
 
 ## Function `push_back`
 
-Add T <code>val</code> to the end of the vector <code>v</code>. It grows the buckets when the current buckets are full.
+Add T <code>val</code> to the end of the vector <code>self</code>. It grows the buckets when the current buckets are full.
 This operation will cost more gas when it adds new bucket.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: T)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: T)
 </code></pre>
 
 
@@ -552,28 +552,28 @@ This operation will cost more gas when it adds new bucket.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, val: T) {
-    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, val: T) {
+    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
     <b>if</b> (len == inline_len) {
-        <b>let</b> bucket_size = <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.inline_capacity)) {
-            <b>if</b> (len &lt; *<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.inline_capacity)) {
-                <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> v.inline_vec, val);
+        <b>let</b> bucket_size = <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&self.inline_capacity)) {
+            <b>if</b> (len &lt; *<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&self.inline_capacity)) {
+                <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.inline_vec, val);
                 <b>return</b>
             };
-            *<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.bucket_size)
+            *<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&self.bucket_size)
         } <b>else</b> {
             <b>let</b> val_size = size_of_val(&val);
             <b>if</b> (val_size * (inline_len + 1) &lt; 150 /* magic number */) {
-                <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> v.inline_vec, val);
+                <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.inline_vec, val);
                 <b>return</b>
             };
-            <b>let</b> estimated_avg_size = max((size_of_val(&v.inline_vec) + val_size) / (inline_len + 1), 1);
+            <b>let</b> estimated_avg_size = max((size_of_val(&self.inline_vec) + val_size) / (inline_len + 1), 1);
             max(1024 /* free_write_quota */ / estimated_avg_size, 1)
         };
-        <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(&<b>mut</b> v.big_vec, <a href="big_vector.md#0x1_big_vector_empty">big_vector::empty</a>(bucket_size));
+        <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(&<b>mut</b> self.big_vec, <a href="big_vector.md#0x1_big_vector_empty">big_vector::empty</a>(bucket_size));
     };
-    <a href="big_vector.md#0x1_big_vector_push_back">big_vector::push_back</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec), val);
+    <a href="big_vector.md#0x1_big_vector_push_back">big_vector::push_back</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> self.big_vec), val);
 }
 </code></pre>
 
@@ -585,11 +585,11 @@ This operation will cost more gas when it adds new bucket.
 
 ## Function `pop_back`
 
-Pop an T from the end of vector <code>v</code>. It does shrink the buckets if they're empty.
-Aborts if <code>v</code> is empty.
+Pop an T from the end of vector <code>self</code>. It does shrink the buckets if they're empty.
+Aborts if <code>self</code> is empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): T
 </code></pre>
 
 
@@ -598,9 +598,9 @@ Aborts if <code>v</code> is empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): T {
-    <b>assert</b>!(!<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="smart_vector.md#0x1_smart_vector_EVECTOR_EMPTY">EVECTOR_EMPTY</a>));
-    <b>let</b> big_vec_wrapper = &<b>mut</b> v.big_vec;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): T {
+    <b>assert</b>!(!<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(self), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="smart_vector.md#0x1_smart_vector_EVECTOR_EMPTY">EVECTOR_EMPTY</a>));
+    <b>let</b> big_vec_wrapper = &<b>mut</b> self.big_vec;
     <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(big_vec_wrapper)) {
         <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
         <b>let</b> val = <a href="big_vector.md#0x1_big_vector_pop_back">big_vector::pop_back</a>(&<b>mut</b> big_vec);
@@ -611,7 +611,7 @@ Aborts if <code>v</code> is empty.
         };
         val
     } <b>else</b> {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> v.inline_vec)
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> self.inline_vec)
     }
 }
 </code></pre>
@@ -624,12 +624,12 @@ Aborts if <code>v</code> is empty.
 
 ## Function `remove`
 
-Remove the T at index i in the vector v and return the owned value that was previously stored at i in v.
+Remove the T at index i in the vector self and return the owned value that was previously stored at i in self.
 All Ts occurring at indices greater than i will be shifted down by 1. Will abort if i is out of bounds.
 Disclaimer: This function may be costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_remove">remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_remove">remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
@@ -638,14 +638,14 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_remove">remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): T {
-    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_remove">remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): T {
+    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
     <b>assert</b>!(i &lt; len, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
     <b>if</b> (i &lt; inline_len) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> v.inline_vec, i)
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> self.inline_vec, i)
     } <b>else</b> {
-        <b>let</b> big_vec_wrapper = &<b>mut</b> v.big_vec;
+        <b>let</b> big_vec_wrapper = &<b>mut</b> self.big_vec;
         <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
         <b>let</b> val = <a href="big_vector.md#0x1_big_vector_remove">big_vector::remove</a>(&<b>mut</b> big_vec, i - inline_len);
         <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">big_vector::is_empty</a>(&big_vec)) {
@@ -666,12 +666,12 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 
 ## Function `swap_remove`
 
-Swap the <code>i</code>th T of the vector <code>v</code> with the last T and then pop the vector.
+Swap the <code>i</code>th T of the vector <code>self</code> with the last T and then pop the vector.
 This is O(1), but does not preserve ordering of Ts in the vector.
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
@@ -680,12 +680,12 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): T {
-    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64): T {
+    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
     <b>assert</b>!(i &lt; len, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
-    <b>let</b> big_vec_wrapper = &<b>mut</b> v.big_vec;
-    <b>let</b> inline_vec = &<b>mut</b> v.inline_vec;
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
+    <b>let</b> big_vec_wrapper = &<b>mut</b> self.big_vec;
+    <b>let</b> inline_vec = &<b>mut</b> self.inline_vec;
     <b>if</b> (i &gt;= inline_len) {
         <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
         <b>let</b> val = <a href="big_vector.md#0x1_big_vector_swap_remove">big_vector::swap_remove</a>(&<b>mut</b> big_vec, i - inline_len);
@@ -720,10 +720,10 @@ Aborts if <code>i</code> is out of bounds.
 ## Function `swap`
 
 Swap the Ts at the i'th and j'th indices in the vector v. Will abort if either of i or j are out of bounds
-for v.
+for self.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64, j: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64, j: u64)
 </code></pre>
 
 
@@ -732,20 +732,20 @@ for v.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64, j: u64) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, i: u64, j: u64) {
     <b>if</b> (i &gt; j) {
-        <b>return</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>(v, j, i)
+        <b>return</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>(self, j, i)
     };
-    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
+    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
     <b>assert</b>!(j &lt; len, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
     <b>if</b> (i &gt;= inline_len) {
-        <a href="big_vector.md#0x1_big_vector_swap">big_vector::swap</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec), i - inline_len, j - inline_len);
+        <a href="big_vector.md#0x1_big_vector_swap">big_vector::swap</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> self.big_vec), i - inline_len, j - inline_len);
     } <b>else</b> <b>if</b> (j &lt; inline_len) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(&<b>mut</b> v.inline_vec, i, j);
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(&<b>mut</b> self.inline_vec, i, j);
     } <b>else</b> {
-        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec);
-        <b>let</b> inline_vec = &<b>mut</b> v.inline_vec;
+        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> self.big_vec);
+        <b>let</b> inline_vec = &<b>mut</b> self.inline_vec;
         <b>let</b> element_i = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(inline_vec, i);
         <b>let</b> element_j = <a href="big_vector.md#0x1_big_vector_swap_remove">big_vector::swap_remove</a>(big_vec, j - inline_len);
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(inline_vec, element_j);
@@ -764,11 +764,11 @@ for v.
 
 ## Function `reverse`
 
-Reverse the order of the Ts in the vector v in-place.
+Reverse the order of the Ts in the vector self in-place.
 Disclaimer: This function may be costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_reverse">reverse</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_reverse">reverse</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -777,33 +777,33 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_reverse">reverse</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
-    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_reverse">reverse</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;) {
+    <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec);
     <b>let</b> i = 0;
     <b>let</b> new_inline_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     // Push the last `inline_len` Ts into a temp <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>.
     <b>while</b> (i &lt; inline_len) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> new_inline_vec, <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>(v));
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> new_inline_vec, <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>(self));
         i = i + 1;
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_reverse">vector::reverse</a>(&<b>mut</b> new_inline_vec);
     // Reverse the <a href="big_vector.md#0x1_big_vector">big_vector</a> left <b>if</b> <b>exists</b>.
-    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.big_vec)) {
-        <a href="big_vector.md#0x1_big_vector_reverse">big_vector::reverse</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec));
+    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&self.big_vec)) {
+        <a href="big_vector.md#0x1_big_vector_reverse">big_vector::reverse</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> self.big_vec));
     };
     // Mem::swap the two vectors.
     <b>let</b> temp_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>while</b> (!<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<b>mut</b> v.inline_vec)) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> temp_vec, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> v.inline_vec));
+    <b>while</b> (!<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<b>mut</b> self.inline_vec)) {
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> temp_vec, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> self.inline_vec));
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_reverse">vector::reverse</a>(&<b>mut</b> temp_vec);
     <b>while</b> (!<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<b>mut</b> new_inline_vec)) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> v.inline_vec, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> new_inline_vec));
+        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.inline_vec, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> new_inline_vec));
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(new_inline_vec);
     // Push the rest Ts originally left in inline_vector back <b>to</b> the end of the smart <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>.
     <b>while</b> (!<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<b>mut</b> temp_vec)) {
-        <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(v, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> temp_vec));
+        <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(self, <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> temp_vec));
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(temp_vec);
 }
@@ -817,12 +817,12 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 
 ## Function `index_of`
 
-Return <code>(<b>true</b>, i)</code> if <code>val</code> is in the vector <code>v</code> at index <code>i</code>.
+Return <code>(<b>true</b>, i)</code> if <code>val</code> is in the vector <code>self</code> at index <code>i</code>.
 Otherwise, returns <code>(<b>false</b>, 0)</code>.
 Disclaimer: This function may be costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_index_of">index_of</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: &T): (bool, u64)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_index_of">index_of</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: &T): (bool, u64)
 </code></pre>
 
 
@@ -831,13 +831,13 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_index_of">index_of</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, val: &T): (bool, u64) {
-    <b>let</b> (found, i) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(&v.inline_vec, val);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_index_of">index_of</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, val: &T): (bool, u64) {
+    <b>let</b> (found, i) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(&self.inline_vec, val);
     <b>if</b> (found) {
         (<b>true</b>, i)
-    } <b>else</b> <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.big_vec)) {
-        <b>let</b> (found, i) = <a href="big_vector.md#0x1_big_vector_index_of">big_vector::index_of</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec), val);
-        (found, i + <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec))
+    } <b>else</b> <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&self.big_vec)) {
+        <b>let</b> (found, i) = <a href="big_vector.md#0x1_big_vector_index_of">big_vector::index_of</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&self.big_vec), val);
+        (found, i + <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec))
     } <b>else</b> {
         (<b>false</b>, 0)
     }
@@ -852,11 +852,11 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 
 ## Function `contains`
 
-Return true if <code>val</code> is in the vector <code>v</code>.
+Return true if <code>val</code> is in the vector <code>self</code>.
 Disclaimer: This function may be costly. Use it at your own discretion.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_contains">contains</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: &T): bool
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_contains">contains</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: &T): bool
 </code></pre>
 
 
@@ -865,9 +865,9 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_contains">contains</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, val: &T): bool {
-    <b>if</b> (<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v)) <b>return</b> <b>false</b>;
-    <b>let</b> (exist, _) = <a href="smart_vector.md#0x1_smart_vector_index_of">index_of</a>(v, val);
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_contains">contains</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, val: &T): bool {
+    <b>if</b> (<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(self)) <b>return</b> <b>false</b>;
+    <b>let</b> (exist, _) = <a href="smart_vector.md#0x1_smart_vector_index_of">index_of</a>(self, val);
     exist
 }
 </code></pre>
@@ -883,7 +883,7 @@ Disclaimer: This function may be costly. Use it at your own discretion.
 Return the length of the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): u64
 </code></pre>
 
 
@@ -892,11 +892,11 @@ Return the length of the vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): u64 {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec) + <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&v.big_vec)) {
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): u64 {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&self.inline_vec) + <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&self.big_vec)) {
         0
     } <b>else</b> {
-        <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec))
+        <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&self.big_vec))
     }
 }
 </code></pre>
@@ -909,10 +909,10 @@ Return the length of the vector.
 
 ## Function `is_empty`
 
-Return <code><b>true</b></code> if the vector <code>v</code> has no Ts and <code><b>false</b></code> otherwise.
+Return <code><b>true</b></code> if the vector <code>self</code> has no Ts and <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): bool
 </code></pre>
 
 
@@ -921,8 +921,8 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no Ts and <code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): bool {
-    <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v) == 0
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): bool {
+    <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self) == 0
 }
 </code></pre>
 
@@ -937,7 +937,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no Ts and <code
 Apply the function to each T in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each">for_each</a>&lt;T: store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each">for_each</a>&lt;T: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|)
 </code></pre>
 
 
@@ -946,9 +946,9 @@ Apply the function to each T in the vector, consuming it.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each">for_each</a>&lt;T: store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |T|) {
-    aptos_std::smart_vector::reverse(&<b>mut</b> v); // We need <b>to</b> reverse the <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a> <b>to</b> consume it efficiently
-    aptos_std::smart_vector::for_each_reverse(v, |e| f(e));
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each">for_each</a>&lt;T: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |T|) {
+    aptos_std::smart_vector::reverse(&<b>mut</b> self); // We need <b>to</b> reverse the <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a> <b>to</b> consume it efficiently
+    aptos_std::smart_vector::for_each_reverse(self, |e| f(e));
 }
 </code></pre>
 
@@ -963,7 +963,7 @@ Apply the function to each T in the vector, consuming it.
 Apply the function to each T in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_reverse">for_each_reverse</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_reverse">for_each_reverse</a>&lt;T&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|)
 </code></pre>
 
 
@@ -972,13 +972,13 @@ Apply the function to each T in the vector, consuming it.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_reverse">for_each_reverse</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |T|) {
-    <b>let</b> len = aptos_std::smart_vector::length(&v);
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_reverse">for_each_reverse</a>&lt;T&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |T|) {
+    <b>let</b> len = aptos_std::smart_vector::length(&self);
     <b>while</b> (len &gt; 0) {
-        f(aptos_std::smart_vector::pop_back(&<b>mut</b> v));
+        f(aptos_std::smart_vector::pop_back(&<b>mut</b> self));
         len = len - 1;
     };
-    aptos_std::smart_vector::destroy_empty(v)
+    aptos_std::smart_vector::destroy_empty(self)
 }
 </code></pre>
 
@@ -993,7 +993,7 @@ Apply the function to each T in the vector, consuming it.
 Apply the function to a reference of each T in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_ref">for_each_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&T|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_ref">for_each_ref</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&T|)
 </code></pre>
 
 
@@ -1002,11 +1002,11 @@ Apply the function to a reference of each T in the vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_ref">for_each_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |&T|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_ref">for_each_ref</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |&T|) {
     <b>let</b> i = 0;
-    <b>let</b> len = aptos_std::smart_vector::length(v);
+    <b>let</b> len = aptos_std::smart_vector::length(self);
     <b>while</b> (i &lt; len) {
-        f(aptos_std::smart_vector::borrow(v, i));
+        f(aptos_std::smart_vector::borrow(self, i));
         i = i + 1
     }
 }
@@ -1023,7 +1023,7 @@ Apply the function to a reference of each T in the vector.
 Apply the function to a mutable reference to each T in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_mut">for_each_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&<b>mut</b> T|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_mut">for_each_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&<b>mut</b> T|)
 </code></pre>
 
 
@@ -1032,11 +1032,11 @@ Apply the function to a mutable reference to each T in the vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_mut">for_each_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |&<b>mut</b> T|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_mut">for_each_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |&<b>mut</b> T|) {
     <b>let</b> i = 0;
-    <b>let</b> len = aptos_std::smart_vector::length(v);
+    <b>let</b> len = aptos_std::smart_vector::length(self);
     <b>while</b> (i &lt; len) {
-        f(aptos_std::smart_vector::borrow_mut(v, i));
+        f(aptos_std::smart_vector::borrow_mut(self, i));
         i = i + 1
     }
 }
@@ -1053,7 +1053,7 @@ Apply the function to a mutable reference to each T in the vector.
 Apply the function to a reference of each T in the vector with its index.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_ref">enumerate_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &T)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_ref">enumerate_ref</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &T)|)
 </code></pre>
 
 
@@ -1062,11 +1062,11 @@ Apply the function to a reference of each T in the vector with its index.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_ref">enumerate_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |u64, &T|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_ref">enumerate_ref</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |u64, &T|) {
     <b>let</b> i = 0;
-    <b>let</b> len = aptos_std::smart_vector::length(v);
+    <b>let</b> len = aptos_std::smart_vector::length(self);
     <b>while</b> (i &lt; len) {
-        f(i, aptos_std::smart_vector::borrow(v, i));
+        f(i, aptos_std::smart_vector::borrow(self, i));
         i = i + 1;
     };
 }
@@ -1083,7 +1083,7 @@ Apply the function to a reference of each T in the vector with its index.
 Apply the function to a mutable reference of each T in the vector with its index.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_mut">enumerate_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &<b>mut</b> T)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_mut">enumerate_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &<b>mut</b> T)|)
 </code></pre>
 
 
@@ -1092,11 +1092,11 @@ Apply the function to a mutable reference of each T in the vector with its index
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_mut">enumerate_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |u64, &<b>mut</b> T|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_mut">enumerate_mut</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;, f: |u64, &<b>mut</b> T|) {
     <b>let</b> i = 0;
-    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
+    <b>let</b> len = <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
     <b>while</b> (i &lt; len) {
-        f(i, <a href="smart_vector.md#0x1_smart_vector_borrow_mut">borrow_mut</a>(v, i));
+        f(i, <a href="smart_vector.md#0x1_smart_vector_borrow_mut">borrow_mut</a>(self, i));
         i = i + 1;
     };
 }
@@ -1114,7 +1114,7 @@ Fold the function over the Ts. For example, <code><a href="smart_vector.md#0x1_s
 <code>f(f(f(0, 1), 2), 3)</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_fold">fold</a>&lt;Accumulator, T: store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, init: Accumulator, f: |(Accumulator, T)|Accumulator): Accumulator
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_fold">fold</a>&lt;Accumulator, T: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, init: Accumulator, f: |(Accumulator, T)|Accumulator): Accumulator
 </code></pre>
 
 
@@ -1124,12 +1124,12 @@ Fold the function over the Ts. For example, <code><a href="smart_vector.md#0x1_s
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_fold">fold</a>&lt;Accumulator, T: store&gt;(
-    v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;,
+    self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;,
     init: Accumulator,
     f: |Accumulator, T|Accumulator
 ): Accumulator {
     <b>let</b> accu = init;
-    aptos_std::smart_vector::for_each(v, |elem| accu = f(accu, elem));
+    aptos_std::smart_vector::for_each(self, |elem| accu = f(accu, elem));
     accu
 }
 </code></pre>
@@ -1146,7 +1146,7 @@ Fold right like fold above but working right to left. For example, <code><a href
 <code>f(1, f(2, f(3, 0)))</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_foldr">foldr</a>&lt;Accumulator, T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, init: Accumulator, f: |(T, Accumulator)|Accumulator): Accumulator
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_foldr">foldr</a>&lt;Accumulator, T&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, init: Accumulator, f: |(T, Accumulator)|Accumulator): Accumulator
 </code></pre>
 
 
@@ -1156,12 +1156,12 @@ Fold right like fold above but working right to left. For example, <code><a href
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_foldr">foldr</a>&lt;Accumulator, T&gt;(
-    v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;,
+    self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;,
     init: Accumulator,
     f: |T, Accumulator|Accumulator
 ): Accumulator {
     <b>let</b> accu = init;
-    aptos_std::smart_vector::for_each_reverse(v, |elem| accu = f(elem, accu));
+    aptos_std::smart_vector::for_each_reverse(self, |elem| accu = f(elem, accu));
     accu
 }
 </code></pre>
@@ -1178,7 +1178,7 @@ Map the function over the references of the Ts of the vector, producing a new ve
 original vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_map_ref">map_ref</a>&lt;T1, T2: store&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, f: |&T1|T2): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_map_ref">map_ref</a>&lt;T1, T2: store&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, f: |&T1|T2): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;
 </code></pre>
 
 
@@ -1188,11 +1188,11 @@ original vector.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_map_ref">map_ref</a>&lt;T1, T2: store&gt;(
-    v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     f: |&T1|T2
 ): <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt; {
     <b>let</b> result = aptos_std::smart_vector::new&lt;T2&gt;();
-    aptos_std::smart_vector::for_each_ref(v, |elem| aptos_std::smart_vector::push_back(&<b>mut</b> result, f(elem)));
+    aptos_std::smart_vector::for_each_ref(self, |elem| aptos_std::smart_vector::push_back(&<b>mut</b> result, f(elem)));
     result
 }
 </code></pre>
@@ -1208,7 +1208,7 @@ original vector.
 Map the function over the Ts of the vector, producing a new vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_map">map</a>&lt;T1: store, T2: store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, f: |T1|T2): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_map">map</a>&lt;T1: store, T2: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, f: |T1|T2): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;
 </code></pre>
 
 
@@ -1218,11 +1218,11 @@ Map the function over the Ts of the vector, producing a new vector.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_map">map</a>&lt;T1: store, T2: store&gt;(
-    v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     f: |T1|T2
 ): <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt; {
     <b>let</b> result = aptos_std::smart_vector::new&lt;T2&gt;();
-    aptos_std::smart_vector::for_each(v, |elem| <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(&<b>mut</b> result, f(elem)));
+    aptos_std::smart_vector::for_each(self, |elem| <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(&<b>mut</b> result, f(elem)));
     result
 }
 </code></pre>
@@ -1238,7 +1238,7 @@ Map the function over the Ts of the vector, producing a new vector.
 Filter the vector using the boolean function, removing all Ts for which <code>p(e)</code> is not true.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_filter">filter</a>&lt;T: drop, store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, p: |&T|bool): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_filter">filter</a>&lt;T: drop, store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, p: |&T|bool): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;
 </code></pre>
 
 
@@ -1248,11 +1248,11 @@ Filter the vector using the boolean function, removing all Ts for which <code>p(
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_filter">filter</a>&lt;T: store + drop&gt;(
-    v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;,
+    self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;,
     p: |&T|bool
 ): <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt; {
     <b>let</b> result = aptos_std::smart_vector::new&lt;T&gt;();
-    aptos_std::smart_vector::for_each(v, |elem| {
+    aptos_std::smart_vector::for_each(self, |elem| {
         <b>if</b> (p(&elem)) aptos_std::smart_vector::push_back(&<b>mut</b> result, elem);
     });
     result
@@ -1269,7 +1269,7 @@ Filter the vector using the boolean function, removing all Ts for which <code>p(
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip">zip</a>&lt;T1: store, T2: store&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip">zip</a>&lt;T1: store, T2: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|)
 </code></pre>
 
 
@@ -1278,11 +1278,11 @@ Filter the vector using the boolean function, removing all Ts for which <code>p(
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip">zip</a>&lt;T1: store, T2: store&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;, f: |T1, T2|) {
+<pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip">zip</a>&lt;T1: store, T2: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;, f: |T1, T2|) {
     // We need <b>to</b> reverse the vectors <b>to</b> consume it efficiently
-    aptos_std::smart_vector::reverse(&<b>mut</b> v1);
+    aptos_std::smart_vector::reverse(&<b>mut</b> self);
     aptos_std::smart_vector::reverse(&<b>mut</b> v2);
-    aptos_std::smart_vector::zip_reverse(v1, v2, |e1, e2| f(e1, e2));
+    aptos_std::smart_vector::zip_reverse(self, v2, |e1, e2| f(e1, e2));
 }
 </code></pre>
 
@@ -1298,7 +1298,7 @@ Apply the function to each pair of elements in the two given vectors in the reve
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_reverse">zip_reverse</a>&lt;T1, T2&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_reverse">zip_reverse</a>&lt;T1, T2&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|)
 </code></pre>
 
 
@@ -1308,19 +1308,19 @@ This errors out if the vectors are not of the same length.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_reverse">zip_reverse</a>&lt;T1, T2&gt;(
-    v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;,
     f: |T1, T2|,
 ) {
-    <b>let</b> len = aptos_std::smart_vector::length(&v1);
+    <b>let</b> len = aptos_std::smart_vector::length(&self);
     // We can't <b>use</b> the constant <a href="smart_vector.md#0x1_smart_vector_ESMART_VECTORS_LENGTH_MISMATCH">ESMART_VECTORS_LENGTH_MISMATCH</a> here <b>as</b> all calling code would then need <b>to</b> define it
     // due <b>to</b> how inline functions work.
     <b>assert</b>!(len == aptos_std::smart_vector::length(&v2), 0x20005);
     <b>while</b> (len &gt; 0) {
-        f(aptos_std::smart_vector::pop_back(&<b>mut</b> v1), aptos_std::smart_vector::pop_back(&<b>mut</b> v2));
+        f(aptos_std::smart_vector::pop_back(&<b>mut</b> self), aptos_std::smart_vector::pop_back(&<b>mut</b> v2));
         len = len - 1;
     };
-    aptos_std::smart_vector::destroy_empty(v1);
+    aptos_std::smart_vector::destroy_empty(self);
     aptos_std::smart_vector::destroy_empty(v2);
 }
 </code></pre>
@@ -1337,7 +1337,7 @@ Apply the function to the references of each pair of elements in the two given v
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_ref">zip_ref</a>&lt;T1, T2&gt;(v1: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&T1, &T2)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_ref">zip_ref</a>&lt;T1, T2&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&T1, &T2)|)
 </code></pre>
 
 
@@ -1347,17 +1347,17 @@ This errors out if the vectors are not of the same length.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_ref">zip_ref</a>&lt;T1, T2&gt;(
-    v1: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;,
     f: |&T1, &T2|,
 ) {
-    <b>let</b> len = aptos_std::smart_vector::length(v1);
+    <b>let</b> len = aptos_std::smart_vector::length(self);
     // We can't <b>use</b> the constant <a href="smart_vector.md#0x1_smart_vector_ESMART_VECTORS_LENGTH_MISMATCH">ESMART_VECTORS_LENGTH_MISMATCH</a> here <b>as</b> all calling code would then need <b>to</b> define it
     // due <b>to</b> how inline functions work.
     <b>assert</b>!(len == aptos_std::smart_vector::length(v2), 0x20005);
     <b>let</b> i = 0;
     <b>while</b> (i &lt; len) {
-        f(aptos_std::smart_vector::borrow(v1, i), aptos_std::smart_vector::borrow(v2, i));
+        f(aptos_std::smart_vector::borrow(self, i), aptos_std::smart_vector::borrow(v2, i));
         i = i + 1
     }
 }
@@ -1375,7 +1375,7 @@ Apply the function to mutable references to each pair of elements in the two giv
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_mut">zip_mut</a>&lt;T1, T2&gt;(v1: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&<b>mut</b> T1, &<b>mut</b> T2)|)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_mut">zip_mut</a>&lt;T1, T2&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&<b>mut</b> T1, &<b>mut</b> T2)|)
 </code></pre>
 
 
@@ -1385,17 +1385,17 @@ This errors out if the vectors are not of the same length.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_mut">zip_mut</a>&lt;T1, T2&gt;(
-    v1: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     v2: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;,
     f: |&<b>mut</b> T1, &<b>mut</b> T2|,
 ) {
     <b>let</b> i = 0;
-    <b>let</b> len = aptos_std::smart_vector::length(v1);
+    <b>let</b> len = aptos_std::smart_vector::length(self);
     // We can't <b>use</b> the constant <a href="smart_vector.md#0x1_smart_vector_ESMART_VECTORS_LENGTH_MISMATCH">ESMART_VECTORS_LENGTH_MISMATCH</a> here <b>as</b> all calling code would then need <b>to</b> define it
     // due <b>to</b> how inline functions work.
     <b>assert</b>!(len == aptos_std::smart_vector::length(v2), 0x20005);
     <b>while</b> (i &lt; len) {
-        f(aptos_std::smart_vector::borrow_mut(v1, i), aptos_std::smart_vector::borrow_mut(v2, i));
+        f(aptos_std::smart_vector::borrow_mut(self, i), aptos_std::smart_vector::borrow_mut(v2, i));
         i = i + 1
     }
 }
@@ -1412,7 +1412,7 @@ This errors out if the vectors are not of the same length.
 Map the function over the element pairs of the two vectors, producing a new vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_map">zip_map</a>&lt;T1: store, T2: store, NewT: store&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|NewT): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;NewT&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_map">zip_map</a>&lt;T1: store, T2: store, NewT: store&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|NewT): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;NewT&gt;
 </code></pre>
 
 
@@ -1422,16 +1422,16 @@ Map the function over the element pairs of the two vectors, producing a new vect
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_map">zip_map</a>&lt;T1: store, T2: store, NewT: store&gt;(
-    v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;,
     f: |T1, T2|NewT
 ): <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;NewT&gt; {
     // We can't <b>use</b> the constant <a href="smart_vector.md#0x1_smart_vector_ESMART_VECTORS_LENGTH_MISMATCH">ESMART_VECTORS_LENGTH_MISMATCH</a> here <b>as</b> all calling code would then need <b>to</b> define it
     // due <b>to</b> how inline functions work.
-    <b>assert</b>!(aptos_std::smart_vector::length(&v1) == aptos_std::smart_vector::length(&v2), 0x20005);
+    <b>assert</b>!(aptos_std::smart_vector::length(&self) == aptos_std::smart_vector::length(&v2), 0x20005);
 
     <b>let</b> result = aptos_std::smart_vector::new&lt;NewT&gt;();
-    aptos_std::smart_vector::zip(v1, v2, |e1, e2| <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(&<b>mut</b> result, f(e1, e2)));
+    aptos_std::smart_vector::zip(self, v2, |e1, e2| <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(&<b>mut</b> result, f(e1, e2)));
     result
 }
 </code></pre>
@@ -1448,7 +1448,7 @@ Map the function over the references of the element pairs of two vectors, produc
 values without modifying the original vectors.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_map_ref">zip_map_ref</a>&lt;T1, T2, NewT: store&gt;(v1: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&T1, &T2)|NewT): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;NewT&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_map_ref">zip_map_ref</a>&lt;T1, T2, NewT: store&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&T1, &T2)|NewT): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;NewT&gt;
 </code></pre>
 
 
@@ -1458,16 +1458,16 @@ values without modifying the original vectors.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_map_ref">zip_map_ref</a>&lt;T1, T2, NewT: store&gt;(
-    v1: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
+    self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T1&gt;,
     v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T2&gt;,
     f: |&T1, &T2|NewT
 ): <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;NewT&gt; {
     // We can't <b>use</b> the constant <a href="smart_vector.md#0x1_smart_vector_ESMART_VECTORS_LENGTH_MISMATCH">ESMART_VECTORS_LENGTH_MISMATCH</a> here <b>as</b> all calling code would then need <b>to</b> define it
     // due <b>to</b> how inline functions work.
-    <b>assert</b>!(aptos_std::smart_vector::length(v1) == aptos_std::smart_vector::length(v2), 0x20005);
+    <b>assert</b>!(aptos_std::smart_vector::length(self) == aptos_std::smart_vector::length(v2), 0x20005);
 
     <b>let</b> result = aptos_std::smart_vector::new&lt;NewT&gt;();
-    aptos_std::smart_vector::zip_ref(v1, v2, |e1, e2| <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(&<b>mut</b> result, f(e1, e2)));
+    aptos_std::smart_vector::zip_ref(self, v2, |e1, e2| <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>(&<b>mut</b> result, f(e1, e2)));
     result
 }
 </code></pre>
@@ -1568,15 +1568,15 @@ values without modifying the original vectors.
 ### Function `destroy_empty`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(self: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> !(<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v));
-<b>aborts_if</b> len(v.inline_vec) != 0
-    || <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec);
+<pre><code><b>aborts_if</b> !(<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(self));
+<b>aborts_if</b> len(self.inline_vec) != 0
+    || <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(self.big_vec);
 </code></pre>
 
 
@@ -1586,15 +1586,15 @@ values without modifying the original vectors.
 ### Function `borrow`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &T
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
-<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
-    (len(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64
+<pre><code><b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
+<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(self.big_vec) && (
+    (len(self.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(self.big_vec))) &gt; MAX_U64
 );
 </code></pre>
 
@@ -1605,7 +1605,7 @@ values without modifying the original vectors.
 ### Function `append`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_append">append</a>&lt;T: store&gt;(lhs: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, other: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_append">append</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, other: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -1621,7 +1621,7 @@ values without modifying the original vectors.
 ### Function `push_back`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: T)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_push_back">push_back</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, val: T)
 </code></pre>
 
 
@@ -1637,21 +1637,21 @@ values without modifying the original vectors.
 ### Function `pop_back`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): T
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> verify_duration_estimate = 120;
-<b>aborts_if</b>  <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec)
+<b>aborts_if</b>  <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(self.big_vec)
     &&
-    (<a href="table_with_length.md#0x1_table_with_length_spec_len">table_with_length::spec_len</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec).buckets) == 0);
-<b>aborts_if</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v);
-<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
-    (len(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64
+    (<a href="table_with_length.md#0x1_table_with_length_spec_len">table_with_length::spec_len</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(self.big_vec).buckets) == 0);
+<b>aborts_if</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(self);
+<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(self.big_vec) && (
+    (len(self.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(self.big_vec))) &gt; MAX_U64
 );
-<b>ensures</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v) == <a href="smart_vector.md#0x1_smart_vector_length">length</a>(<b>old</b>(v)) - 1;
+<b>ensures</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self) == <a href="smart_vector.md#0x1_smart_vector_length">length</a>(<b>old</b>(self)) - 1;
 </code></pre>
 
 
@@ -1661,7 +1661,7 @@ values without modifying the original vectors.
 ### Function `remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_remove">remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_remove">remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
@@ -1677,18 +1677,18 @@ values without modifying the original vectors.
 ### Function `swap_remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
-<b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
-<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
-    (len(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64
+<b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self);
+<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(self.big_vec) && (
+    (len(self.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(self.big_vec))) &gt; MAX_U64
 );
-<b>ensures</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v) == <a href="smart_vector.md#0x1_smart_vector_length">length</a>(<b>old</b>(v)) - 1;
+<b>ensures</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>(self) == <a href="smart_vector.md#0x1_smart_vector_length">length</a>(<b>old</b>(self)) - 1;
 </code></pre>
 
 
@@ -1698,7 +1698,7 @@ values without modifying the original vectors.
 ### Function `swap`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>&lt;T: store&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64, j: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap">swap</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64, j: u64)
 </code></pre>
 
 
@@ -1714,13 +1714,14 @@ values without modifying the original vectors.
 ### Function `length`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(self: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): u64
 </code></pre>
 
 
 
 
-<pre><code><b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && len(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(v.big_vec)) &gt; MAX_U64;
+<pre><code><b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(self.big_vec) && len(self.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(
+    self.big_vec)) &gt; MAX_U64;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/table.md
@@ -140,7 +140,7 @@ key already exists. The entry itself is not stored in the
 table, and cannot be discovered from it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, val: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, val: V)
 </code></pre>
 
 
@@ -149,8 +149,8 @@ table, and cannot be discovered from it.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_add">add</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, val: V) {
-    <a href="table.md#0x1_table_add_box">add_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(<a href="table.md#0x1_table">table</a>, key, <a href="table.md#0x1_table_Box">Box</a> { val })
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_add">add</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, val: V) {
+    <a href="table.md#0x1_table_add_box">add_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(self, key, <a href="table.md#0x1_table_Box">Box</a> { val })
 }
 </code></pre>
 
@@ -166,7 +166,7 @@ Acquire an immutable reference to the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &V
 </code></pre>
 
 
@@ -175,8 +175,8 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): &V {
-    &<a href="table.md#0x1_table_borrow_box">borrow_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(<a href="table.md#0x1_table">table</a>, key).val
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): &V {
+    &<a href="table.md#0x1_table_borrow_box">borrow_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(self, key).val
 }
 </code></pre>
 
@@ -192,7 +192,7 @@ Acquire an immutable reference to the value which <code>key</code> maps to.
 Returns specified default value if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, default: &V): &V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, default: &V): &V
 </code></pre>
 
 
@@ -201,11 +201,11 @@ Returns specified default value if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, default: &V): &V {
-    <b>if</b> (!<a href="table.md#0x1_table_contains">contains</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)) {
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_with_default">borrow_with_default</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, default: &V): &V {
+    <b>if</b> (!<a href="table.md#0x1_table_contains">contains</a>(self, <b>copy</b> key)) {
         default
     } <b>else</b> {
-        <a href="table.md#0x1_table_borrow">borrow</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)
+        <a href="table.md#0x1_table_borrow">borrow</a>(self, <b>copy</b> key)
     }
 }
 </code></pre>
@@ -222,7 +222,7 @@ Acquire a mutable reference to the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -231,8 +231,8 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): &<b>mut</b> V {
-    &<b>mut</b> <a href="table.md#0x1_table_borrow_box_mut">borrow_box_mut</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(<a href="table.md#0x1_table">table</a>, key).val
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): &<b>mut</b> V {
+    &<b>mut</b> <a href="table.md#0x1_table_borrow_box_mut">borrow_box_mut</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(self, key).val
 }
 </code></pre>
 
@@ -248,7 +248,7 @@ Acquire a mutable reference to the value which <code>key</code> maps to.
 Insert the pair (<code>key</code>, <code>default</code>) first if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
 </code></pre>
 
 
@@ -257,11 +257,11 @@ Insert the pair (<code>key</code>, <code>default</code>) first if there is no en
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V {
-    <b>if</b> (!<a href="table.md#0x1_table_contains">contains</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)) {
-        <a href="table.md#0x1_table_add">add</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key, default)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V {
+    <b>if</b> (!<a href="table.md#0x1_table_contains">contains</a>(self, <b>copy</b> key)) {
+        <a href="table.md#0x1_table_add">add</a>(self, <b>copy</b> key, default)
     };
-    <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>(<a href="table.md#0x1_table">table</a>, key)
+    <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>(self, key)
 }
 </code></pre>
 
@@ -277,7 +277,7 @@ Insert the pair (<code>key</code>, <code>value</code>) if there is no entry for 
 update the value of the entry for <code>key</code> to <code>value</code> otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, value: V)
 </code></pre>
 
 
@@ -286,11 +286,11 @@ update the value of the entry for <code>key</code> to <code>value</code> otherwi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_upsert">upsert</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, value: V) {
-    <b>if</b> (!<a href="table.md#0x1_table_contains">contains</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key)) {
-        <a href="table.md#0x1_table_add">add</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key, value)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_upsert">upsert</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K, value: V) {
+    <b>if</b> (!<a href="table.md#0x1_table_contains">contains</a>(self, <b>copy</b> key)) {
+        <a href="table.md#0x1_table_add">add</a>(self, <b>copy</b> key, value)
     } <b>else</b> {
-        <b>let</b> ref = <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>(<a href="table.md#0x1_table">table</a>, key);
+        <b>let</b> ref = <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>(self, key);
         *ref = value;
     };
 }
@@ -304,11 +304,11 @@ update the value of the entry for <code>key</code> to <code>value</code> otherwi
 
 ## Function `remove`
 
-Remove from <code><a href="table.md#0x1_table">table</a></code> and return the value which <code>key</code> maps to.
+Remove from <code>self</code> and return the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): V
 </code></pre>
 
 
@@ -317,8 +317,8 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): V {
-    <b>let</b> <a href="table.md#0x1_table_Box">Box</a> { val } = <a href="table.md#0x1_table_remove_box">remove_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(<a href="table.md#0x1_table">table</a>, key);
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): V {
+    <b>let</b> <a href="table.md#0x1_table_Box">Box</a> { val } = <a href="table.md#0x1_table_remove_box">remove_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(self, key);
     val
 }
 </code></pre>
@@ -331,10 +331,10 @@ Aborts if there is no entry for <code>key</code>.
 
 ## Function `contains`
 
-Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an entry for <code>key</code>.
+Returns true iff <code>self</code> contains an entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): bool
 </code></pre>
 
 
@@ -343,8 +343,8 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_contains">contains</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): bool {
-    <a href="table.md#0x1_table_contains_box">contains_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(<a href="table.md#0x1_table">table</a>, key)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_contains">contains</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;, key: K): bool {
+    <a href="table.md#0x1_table_contains_box">contains_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(self, key)
 }
 </code></pre>
 
@@ -358,7 +358,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x1_table_destroy">destroy</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x1_table_destroy">destroy</a>&lt;K: <b>copy</b>, drop, V&gt;(self: <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -367,9 +367,9 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x1_table_destroy">destroy</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;) {
-    <a href="table.md#0x1_table_destroy_empty_box">destroy_empty_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(&<a href="table.md#0x1_table">table</a>);
-    <a href="table.md#0x1_table_drop_unchecked_box">drop_unchecked_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(<a href="table.md#0x1_table">table</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x1_table_destroy">destroy</a>&lt;K: <b>copy</b> + drop, V&gt;(self: <a href="table.md#0x1_table_Table">Table</a>&lt;K, V&gt;) {
+    <a href="table.md#0x1_table_destroy_empty_box">destroy_empty_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(&self);
+    <a href="table.md#0x1_table_drop_unchecked_box">drop_unchecked_box</a>&lt;K, V, <a href="table.md#0x1_table_Box">Box</a>&lt;V&gt;&gt;(self)
 }
 </code></pre>
 
@@ -618,7 +618,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `add`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, val: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, val: V)
 </code></pre>
 
 
@@ -634,7 +634,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `borrow`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &V
 </code></pre>
 
 
@@ -650,7 +650,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `borrow_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -666,7 +666,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `borrow_mut_with_default`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
 </code></pre>
 
 
@@ -682,7 +682,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `upsert`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K, value: V)
 </code></pre>
 
 
@@ -698,7 +698,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): V
 </code></pre>
 
 
@@ -714,7 +714,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `contains`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="table.md#0x1_table_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;, key: K): bool
 </code></pre>
 
 
@@ -766,7 +766,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `destroy`
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x1_table_destroy">destroy</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="table.md#0x1_table_destroy">destroy</a>&lt;K: <b>copy</b>, drop, V&gt;(self: <a href="table.md#0x1_table_Table">table::Table</a>&lt;K, V&gt;)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/table_with_length.md
+++ b/aptos-move/framework/aptos-stdlib/doc/table_with_length.md
@@ -141,7 +141,7 @@ Create a new Table.
 Destroy a table. The table must be empty to succeed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, V&gt;(self: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -150,9 +150,9 @@ Destroy a table. The table must be empty to succeed.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;) {
-    <b>assert</b>!(<a href="table.md#0x1_table">table</a>.length == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="table_with_length.md#0x1_table_with_length_ENOT_EMPTY">ENOT_EMPTY</a>));
-    <b>let</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a> { inner, length: _ } = <a href="table.md#0x1_table">table</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop, V&gt;(self: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;) {
+    <b>assert</b>!(self.length == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="table_with_length.md#0x1_table_with_length_ENOT_EMPTY">ENOT_EMPTY</a>));
+    <b>let</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a> { inner, length: _ } = self;
     <a href="table.md#0x1_table_destroy">table::destroy</a>(inner)
 }
 </code></pre>
@@ -170,7 +170,7 @@ key already exists. The entry itself is not stored in the
 table, and cannot be discovered from it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, val: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, val: V)
 </code></pre>
 
 
@@ -179,9 +179,9 @@ table, and cannot be discovered from it.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_add">add</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K, val: V) {
-    <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key, val);
-    <a href="table.md#0x1_table">table</a>.length = <a href="table.md#0x1_table">table</a>.length + 1;
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_add">add</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K, val: V) {
+    <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> self.inner, key, val);
+    self.length = self.length + 1;
 }
 </code></pre>
 
@@ -197,7 +197,7 @@ Acquire an immutable reference to the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &V
 </code></pre>
 
 
@@ -206,8 +206,8 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow">borrow</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): &V {
-    <a href="table.md#0x1_table_borrow">table::borrow</a>(&<a href="table.md#0x1_table">table</a>.inner, key)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow">borrow</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): &V {
+    <a href="table.md#0x1_table_borrow">table::borrow</a>(&self.inner, key)
 }
 </code></pre>
 
@@ -223,7 +223,7 @@ Acquire a mutable reference to the value which <code>key</code> maps to.
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -232,8 +232,8 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): &<b>mut</b> V {
-    <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): &<b>mut</b> V {
+    <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inner, key)
 }
 </code></pre>
 
@@ -248,7 +248,7 @@ Aborts if there is no entry for <code>key</code>.
 Returns the length of the table, i.e. the number of entries.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_length">length</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_length">length</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -257,8 +257,8 @@ Returns the length of the table, i.e. the number of entries.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_length">length</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;): u64 {
-    <a href="table.md#0x1_table">table</a>.length
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_length">length</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;): u64 {
+    self.length
 }
 </code></pre>
 
@@ -273,7 +273,7 @@ Returns the length of the table, i.e. the number of entries.
 Returns true if this table is empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_empty">empty</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_empty">empty</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): bool
 </code></pre>
 
 
@@ -282,8 +282,8 @@ Returns true if this table is empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_empty">empty</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;): bool {
-    <a href="table.md#0x1_table">table</a>.length == 0
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_empty">empty</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;): bool {
+    self.length == 0
 }
 </code></pre>
 
@@ -299,7 +299,7 @@ Acquire a mutable reference to the value which <code>key</code> maps to.
 Insert the pair (<code>key</code>, <code>default</code>) first if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
 </code></pre>
 
 
@@ -308,13 +308,13 @@ Insert the pair (<code>key</code>, <code>default</code>) first if there is no en
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V {
-    <b>if</b> (<a href="table.md#0x1_table_contains">table::contains</a>(&<a href="table.md#0x1_table">table</a>.inner, key)) {
-        <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V {
+    <b>if</b> (<a href="table.md#0x1_table_contains">table::contains</a>(&self.inner, key)) {
+        <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inner, key)
     } <b>else</b> {
-        <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key, default);
-        <a href="table.md#0x1_table">table</a>.length = <a href="table.md#0x1_table">table</a>.length + 1;
-        <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key)
+        <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> self.inner, key, default);
+        self.length = self.length + 1;
+        <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inner, key)
     }
 }
 </code></pre>
@@ -331,7 +331,7 @@ Insert the pair (<code>key</code>, <code>value</code>) if there is no entry for 
 update the value of the entry for <code>key</code> to <code>value</code> otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, value: V)
 </code></pre>
 
 
@@ -340,11 +340,11 @@ update the value of the entry for <code>key</code> to <code>value</code> otherwi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_upsert">upsert</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K, value: V) {
-    <b>if</b> (!<a href="table.md#0x1_table_contains">table::contains</a>(&<a href="table.md#0x1_table">table</a>.inner, key)) {
-        <a href="table_with_length.md#0x1_table_with_length_add">add</a>(<a href="table.md#0x1_table">table</a>, <b>copy</b> key, value)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_upsert">upsert</a>&lt;K: <b>copy</b> + drop, V: drop&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K, value: V) {
+    <b>if</b> (!<a href="table.md#0x1_table_contains">table::contains</a>(&self.inner, key)) {
+        <a href="table_with_length.md#0x1_table_with_length_add">add</a>(self, <b>copy</b> key, value)
     } <b>else</b> {
-        <b>let</b> ref = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key);
+        <b>let</b> ref = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inner, key);
         *ref = value;
     };
 }
@@ -362,7 +362,7 @@ Remove from <code><a href="table.md#0x1_table">table</a></code> and return the v
 Aborts if there is no entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): V
 </code></pre>
 
 
@@ -371,9 +371,9 @@ Aborts if there is no entry for <code>key</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): V {
-    <b>let</b> val = <a href="table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> <a href="table.md#0x1_table">table</a>.inner, key);
-    <a href="table.md#0x1_table">table</a>.length = <a href="table.md#0x1_table">table</a>.length - 1;
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_remove">remove</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): V {
+    <b>let</b> val = <a href="table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> self.inner, key);
+    self.length = self.length - 1;
     val
 }
 </code></pre>
@@ -389,7 +389,7 @@ Aborts if there is no entry for <code>key</code>.
 Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an entry for <code>key</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): bool
 </code></pre>
 
 
@@ -398,8 +398,8 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_contains">contains</a>&lt;K: <b>copy</b> + drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): bool {
-    <a href="table.md#0x1_table_contains">table::contains</a>(&<a href="table.md#0x1_table">table</a>.inner, key)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_contains">contains</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">TableWithLength</a>&lt;K, V&gt;, key: K): bool {
+    <a href="table.md#0x1_table_contains">table::contains</a>(&self.inner, key)
 }
 </code></pre>
 
@@ -481,7 +481,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `destroy_empty`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, V&gt;(self: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -497,7 +497,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `add`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, val: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_add">add</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, val: V)
 </code></pre>
 
 
@@ -513,7 +513,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `borrow`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow">borrow</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &V
 </code></pre>
 
 
@@ -529,7 +529,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `borrow_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -545,7 +545,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `length`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_length">length</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_length">length</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -561,7 +561,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `empty`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_empty">empty</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_empty">empty</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;): bool
 </code></pre>
 
 
@@ -577,7 +577,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `borrow_mut_with_default`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_borrow_mut_with_default">borrow_mut_with_default</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, default: V): &<b>mut</b> V
 </code></pre>
 
 
@@ -594,7 +594,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `upsert`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_upsert">upsert</a>&lt;K: <b>copy</b>, drop, V: drop&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K, value: V)
 </code></pre>
 
 
@@ -610,7 +610,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `remove`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_remove">remove</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): V
 </code></pre>
 
 
@@ -626,7 +626,7 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 ### Function `contains`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="table_with_length.md#0x1_table_with_length_contains">contains</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;K, V&gt;, key: K): bool
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -93,7 +93,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_account_address">account_address</a>(<a href="type_info.md#0x1_type_info">type_info</a>: &<a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_account_address">account_address</a>(self: &<a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>): <b>address</b>
 </code></pre>
 
 
@@ -102,8 +102,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_account_address">account_address</a>(<a href="type_info.md#0x1_type_info">type_info</a>: &<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>): <b>address</b> {
-    <a href="type_info.md#0x1_type_info">type_info</a>.account_address
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_account_address">account_address</a>(self: &<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>): <b>address</b> {
+    self.account_address
 }
 </code></pre>
 
@@ -117,7 +117,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_module_name">module_name</a>(<a href="type_info.md#0x1_type_info">type_info</a>: &<a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_module_name">module_name</a>(self: &<a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -126,8 +126,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_module_name">module_name</a>(<a href="type_info.md#0x1_type_info">type_info</a>: &<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="type_info.md#0x1_type_info">type_info</a>.module_name
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_module_name">module_name</a>(self: &<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    self.module_name
 }
 </code></pre>
 
@@ -141,7 +141,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(<a href="type_info.md#0x1_type_info">type_info</a>: &<a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(self: &<a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -150,8 +150,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(<a href="type_info.md#0x1_type_info">type_info</a>: &<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="type_info.md#0x1_type_info">type_info</a>.struct_name
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(self: &<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    self.struct_name
 }
 </code></pre>
 
@@ -283,7 +283,6 @@ analysis of vector size dynamism.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_size_of_val">size_of_val</a>&lt;T&gt;(val_ref: &T): u64 {
-    // Return <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a> length of vectorized BCS representation.
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&<a href="../../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(val_ref))
 }
 </code></pre>
@@ -451,8 +450,7 @@ analysis of vector size dynamism.
 
 
 
-<pre><code><b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="type_info.md#0x1_type_info_spec_size_of_val">spec_size_of_val</a>&lt;T&gt;(val_ref);
+<pre><code><b>ensures</b> result == <a href="type_info.md#0x1_type_info_spec_size_of_val">spec_size_of_val</a>&lt;T&gt;(val_ref);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.move
@@ -36,14 +36,14 @@ module aptos_std::any {
     }
 
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
-    public fun unpack<T>(x: Any): T {
-        assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
-        from_bytes<T>(x.data)
+    public fun unpack<T>(self: Any): T {
+        assert!(type_info::type_name<T>() == self.type_name, error::invalid_argument(ETYPE_MISMATCH));
+        from_bytes<T>(self.data)
     }
 
     /// Returns the type name of this Any
-    public fun type_name(x: &Any): &String {
-        &x.type_name
+    public fun type_name(self: &Any): &String {
+        &self.type_name
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/any.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.spec.move
@@ -15,28 +15,28 @@ spec aptos_std::any {
         ensures [abstract] from_bcs::deserializable<T>(result.data);
     }
 
-    spec unpack<T>(x: Any): T {
+    spec unpack<T>(self: Any): T {
         use aptos_std::from_bcs;
         include UnpackAbortsIf<T>;
-        ensures result == from_bcs::deserialize<T>(x.data);
+        ensures result == from_bcs::deserialize<T>(self.data);
     }
 
     spec schema UnpackAbortsIf<T> {
         use aptos_std::from_bcs;
-        x: Any;
-        aborts_if type_info::type_name<T>() != x.type_name;
-        aborts_if !from_bcs::deserializable<T>(x.data);
+        self: Any;
+        aborts_if type_info::type_name<T>() != self.type_name;
+        aborts_if !from_bcs::deserializable<T>(self.data);
     }
 
     spec schema UnpackRequirement<T> {
         use aptos_std::from_bcs;
-        x: Any;
-        requires type_info::type_name<T>() == x.type_name;
-        requires from_bcs::deserializable<T>(x.data);
+        self: Any;
+        requires type_info::type_name<T>() == self.type_name;
+        requires from_bcs::deserializable<T>(self.data);
     }
 
-    spec type_name(x: &Any): &String {
+    spec type_name(self: &Any): &String {
         aborts_if false;
-        ensures result == x.type_name;
+        ensures result == self.type_name;
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/capability.move
+++ b/aptos-move/framework/aptos-stdlib/sources/capability.move
@@ -146,34 +146,34 @@ module aptos_std::capability {
 
     /// Returns the root address associated with the given capability token. Only the owner
     /// of the feature can do this.
-    public fun root_addr<Feature>(cap: Cap<Feature>, _feature_witness: &Feature): address {
-        cap.root
+    public fun root_addr<Feature>(self: Cap<Feature>, _feature_witness: &Feature): address {
+        self.root
     }
 
     /// Returns the root address associated with the given linear capability token.
-    public fun linear_root_addr<Feature>(cap: LinearCap<Feature>, _feature_witness: &Feature): address {
-        cap.root
+    public fun linear_root_addr<Feature>(self: LinearCap<Feature>, _feature_witness: &Feature): address {
+        self.root
     }
 
     /// Registers a delegation relation. If the relation already exists, this function does
     /// nothing.
     // TODO: explore whether this should be idempotent like now or abort
-    public fun delegate<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, to: &signer)
+    public fun delegate<Feature>(self: Cap<Feature>, _feature_witness: &Feature, to: &signer)
     acquires CapState {
         let addr = signer::address_of(to);
         if (exists<CapDelegateState<Feature>>(addr)) return;
-        move_to(to, CapDelegateState<Feature> { root: cap.root });
-        add_element(&mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, addr);
+        move_to(to, CapDelegateState<Feature> { root: self.root });
+        add_element(&mut borrow_global_mut<CapState<Feature>>(self.root).delegates, addr);
     }
 
     /// Revokes a delegation relation. If no relation exists, this function does nothing.
     // TODO: explore whether this should be idempotent like now or abort
-    public fun revoke<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, from: address)
+    public fun revoke<Feature>(self: Cap<Feature>, _feature_witness: &Feature, from: address)
     acquires CapState, CapDelegateState
     {
         if (!exists<CapDelegateState<Feature>>(from)) return;
         let CapDelegateState { root: _root } = move_from<CapDelegateState<Feature>>(from);
-        remove_element(&mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, &from);
+        remove_element(&mut borrow_global_mut<CapState<Feature>>(self.root).delegates, &from);
     }
 
     /// Helper to remove an element from a vector.

--- a/aptos-move/framework/aptos-stdlib/sources/capability.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/capability.spec.move
@@ -44,14 +44,14 @@ spec aptos_std::capability {
         aborts_if !spec_has_delegate_cap<Feature>(addr) && !spec_has_cap<Feature>(addr);
     }
 
-    spec delegate<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, to: &signer) {
+    spec delegate<Feature>(self: Cap<Feature>, _feature_witness: &Feature, to: &signer) {
         let addr = signer::address_of(to);
         ensures spec_has_delegate_cap<Feature>(addr);
-        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==> global<CapDelegateState<Feature>>(addr).root == cap.root;
-        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==> vector::spec_contains(spec_delegates<Feature>(cap.root), addr);
+        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==> global<CapDelegateState<Feature>>(addr).root == self.root;
+        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==> vector::spec_contains(spec_delegates<Feature>(self.root), addr);
     }
 
-    spec revoke<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, from: address) {
+    spec revoke<Feature>(self: Cap<Feature>, _feature_witness: &Feature, from: address) {
         ensures !spec_has_delegate_cap<Feature>(from);
         // TODO: this cannot be proved. See issue #7422
         // ensures old(spec_has_delegate_cap<Feature>(from))

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.move
@@ -11,16 +11,16 @@ module aptos_std::comparator {
         inner: u8,
     }
 
-    public fun is_equal(result: &Result): bool {
-        result.inner == EQUAL
+    public fun is_equal(self: &Result): bool {
+        self.inner == EQUAL
     }
 
-    public fun is_smaller_than(result: &Result): bool {
-        result.inner == SMALLER
+    public fun is_smaller_than(self: &Result): bool {
+        self.inner == SMALLER
     }
 
-    public fun is_greater_than(result: &Result): bool {
-        result.inner == GREATER
+    public fun is_greater_than(self: &Result): bool {
+        self.inner == GREATER
     }
 
     // Performs a comparison of two types after BCS serialization.

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.spec.move
@@ -3,21 +3,21 @@ spec aptos_std::comparator {
         invariant inner == EQUAL || inner == SMALLER || inner == GREATER;
     }
 
-    spec is_equal(result: &Result): bool {
+    spec is_equal(self: &Result): bool {
         aborts_if false;
-        let res = result;
+        let res = self;
         ensures result == (res.inner == EQUAL);
     }
 
-    spec is_smaller_than(result: &Result): bool {
+    spec is_smaller_than(self: &Result): bool {
         aborts_if false;
-        let res = result;
+        let res = self;
         ensures result == (res.inner == SMALLER);
     }
 
-    spec is_greater_than(result: &Result): bool {
+    spec is_greater_than(self: &Result): bool {
         aborts_if false;
-        let res = result;
+        let res = self;
         ensures result == (res.inner == GREATER);
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/copyable_any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/copyable_any.move
@@ -24,14 +24,14 @@ module aptos_std::copyable_any {
     }
 
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
-    public fun unpack<T>(x: Any): T {
-        assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
-        from_bytes<T>(x.data)
+    public fun unpack<T>(self: Any): T {
+        assert!(type_info::type_name<T>() == self.type_name, error::invalid_argument(ETYPE_MISMATCH));
+        from_bytes<T>(self.data)
     }
 
     /// Returns the type name of this Any
-    public fun type_name(x: &Any): &String {
-        &x.type_name
+    public fun type_name(self: &Any): &String {
+        &self.type_name
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/copyable_any.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/copyable_any.spec.move
@@ -16,21 +16,21 @@ spec aptos_std::copyable_any {
         ensures [abstract] from_bcs::deserializable<T>(result.data);
     }
 
-    spec unpack<T>(x: Any): T {
+    spec unpack<T>(self: Any): T {
         use aptos_std::from_bcs;
         include UnpackAbortsIf<T>;
-        ensures result == from_bcs::deserialize<T>(x.data);
+        ensures result == from_bcs::deserialize<T>(self.data);
     }
 
     spec schema UnpackAbortsIf<T> {
         use aptos_std::from_bcs;
-        x: Any;
-        aborts_if type_info::type_name<T>() != x.type_name;
-        aborts_if !from_bcs::deserializable<T>(x.data);
+        self: Any;
+        aborts_if type_info::type_name<T>() != self.type_name;
+        aborts_if !from_bcs::deserializable<T>(self.data);
     }
 
-    spec type_name(x: &Any): &String {
+    spec type_name(self: &Any): &String {
         aborts_if false;
-        ensures result == x.type_name;
+        ensures result == self.type_name;
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
@@ -52,75 +52,75 @@ spec aptos_std::big_vector {
         ensures result.bucket_size == bucket_size;
     }
 
-    spec destroy_empty<T>(v: BigVector<T>) {
-        aborts_if !is_empty(v);
+    spec destroy_empty<T>(self: BigVector<T>) {
+        aborts_if !is_empty(self);
     }
 
-    spec borrow<T>(v: &BigVector<T>, i: u64): &T {
-        aborts_if i >= length(v);
-        ensures result == spec_at(v, i);
+    spec borrow<T>(self: &BigVector<T>, i: u64): &T {
+        aborts_if i >= length(self);
+        ensures result == spec_at(self, i);
     }
 
-    spec borrow_mut<T>(v: &mut BigVector<T>, i: u64): &mut T {
-        aborts_if i >= length(v);
-        ensures result == spec_at(v, i);
+    spec borrow_mut<T>(self: &mut BigVector<T>, i: u64): &mut T {
+        aborts_if i >= length(self);
+        ensures result == spec_at(self, i);
     }
 
-    spec push_back<T: store>(v: &mut BigVector<T>, val: T) {
-        let num_buckets = spec_table_len(v.buckets);
+    spec push_back<T: store>(self: &mut BigVector<T>, val: T) {
+        let num_buckets = spec_table_len(self.buckets);
         include PushbackAbortsIf<T>;
-        ensures length(v) == length(old(v)) + 1;
-        ensures v.end_index == old(v.end_index) + 1;
-        ensures spec_at(v, v.end_index-1) == val;
-        ensures forall i in 0..v.end_index-1: spec_at(v, i) == spec_at(old(v), i);
-        ensures v.bucket_size == old(v).bucket_size;
+        ensures length(self) == length(old(self)) + 1;
+        ensures self.end_index == old(self.end_index) + 1;
+        ensures spec_at(self, self.end_index-1) == val;
+        ensures forall i in 0..self.end_index-1: spec_at(self, i) == spec_at(old(self), i);
+        ensures self.bucket_size == old(self).bucket_size;
     }
 
     spec schema PushbackAbortsIf<T> {
-        v: BigVector<T>;
-        let num_buckets = spec_table_len(v.buckets);
-        aborts_if num_buckets * v.bucket_size > MAX_U64;
-        aborts_if v.end_index + 1 > MAX_U64;
+        self: BigVector<T>;
+        let num_buckets = spec_table_len(self.buckets);
+        aborts_if num_buckets * self.bucket_size > MAX_U64;
+        aborts_if self.end_index + 1 > MAX_U64;
     }
 
-    spec pop_back<T>(v: &mut BigVector<T>): T {
-        aborts_if is_empty(v);
-        ensures length(v) == length(old(v)) - 1;
-        ensures result == old(spec_at(v, v.end_index-1));
-        ensures forall i in 0..v.end_index: spec_at(v, i) == spec_at(old(v), i);
+    spec pop_back<T>(self: &mut BigVector<T>): T {
+        aborts_if is_empty(self);
+        ensures length(self) == length(old(self)) - 1;
+        ensures result == old(spec_at(self, self.end_index-1));
+        ensures forall i in 0..self.end_index: spec_at(self, i) == spec_at(old(self), i);
     }
 
-    spec swap_remove<T>(v: &mut BigVector<T>, i: u64): T {
+    spec swap_remove<T>(self: &mut BigVector<T>, i: u64): T {
         pragma verify_duration_estimate = 120;
-        aborts_if i >= length(v);
-        ensures length(v) == length(old(v)) - 1;
-        ensures result == spec_at(old(v), i);
+        aborts_if i >= length(self);
+        ensures length(self) == length(old(self)) - 1;
+        ensures result == spec_at(old(self), i);
     }
 
-    spec swap<T>(v: &mut BigVector<T>, i: u64, j: u64) {
+    spec swap<T>(self: &mut BigVector<T>, i: u64, j: u64) {
         pragma verify_duration_estimate = 1000;
-        aborts_if i >= length(v) || j >= length(v);
-        ensures length(v) == length(old(v));
-        ensures spec_at(v, i) == spec_at(old(v), j);
-        ensures spec_at(v, j) == spec_at(old(v), i);
-        ensures forall idx in 0..length(v)
+        aborts_if i >= length(self) || j >= length(self);
+        ensures length(self) == length(old(self));
+        ensures spec_at(self, i) == spec_at(old(self), j);
+        ensures spec_at(self, j) == spec_at(old(self), i);
+        ensures forall idx in 0..length(self)
             where idx != i && idx != j:
-            spec_at(v, idx) == spec_at(old(v), idx);
+            spec_at(self, idx) == spec_at(old(self), idx);
     }
 
-    spec append<T: store>(lhs: &mut BigVector<T>, other: BigVector<T>) {
+    spec append<T: store>(self: &mut BigVector<T>, other: BigVector<T>) {
         pragma verify=false;
     }
 
-    spec remove<T>(v: &mut BigVector<T>, i: u64): T {
+    spec remove<T>(self: &mut BigVector<T>, i: u64): T {
         pragma verify=false;
     }
 
-    spec reverse<T>(v: &mut BigVector<T>) {
+    spec reverse<T>(self: &mut BigVector<T>) {
         pragma verify=false;
     }
 
-    spec index_of<T>(v: &BigVector<T>, val: &T): (bool, u64) {
+    spec index_of<T>(self: &BigVector<T>, val: &T): (bool, u64) {
         pragma verify=false;
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.spec.move
@@ -22,15 +22,15 @@ spec aptos_std::smart_table {
         pragma verify = false;
     }
 
-    spec destroy<K: drop, V: drop>(table: SmartTable<K, V>) {
+    spec destroy<K: drop, V: drop>(self: SmartTable<K, V>) {
         pragma verify = false;
     }
 
-    spec clear<K: drop, V: drop>(table: &mut SmartTable<K, V>) {
+    spec clear<K: drop, V: drop>(self: &mut SmartTable<K, V>) {
         pragma verify = false;
     }
 
-    spec split_one_bucket<K, V>(table: &mut SmartTable<K, V>) {
+    spec split_one_bucket<K, V>(self: &mut SmartTable<K, V>) {
         pragma verify = false;
     }
 
@@ -38,26 +38,26 @@ spec aptos_std::smart_table {
         pragma verify = false;
     }
 
-    spec borrow_with_default<K: copy + drop, V>(table: &SmartTable<K, V>, key: K, default: &V): &V {
+    spec borrow_with_default<K: copy + drop, V>(self: &SmartTable<K, V>, key: K, default: &V): &V {
         pragma verify = false;
     }
 
-    spec load_factor<K, V>(table: &SmartTable<K, V>): u64 {
+    spec load_factor<K, V>(self: &SmartTable<K, V>): u64 {
         pragma verify = false;
     }
 
     spec to_simple_map<K: store + copy + drop, V: store + copy>(
-    table: &SmartTable<K, V>,
+    self: &SmartTable<K, V>,
     ): SimpleMap<K, V> {
         pragma verify = false;
     }
 
-    spec keys<K: store + copy + drop, V: store + copy>(table_ref: &SmartTable<K, V>): vector<K> {
+    spec keys<K: store + copy + drop, V: store + copy>(self: &SmartTable<K, V>): vector<K> {
         pragma verify = false;
     }
 
     spec keys_paginated<K: store + copy + drop, V: store + copy>(
-        table_ref: &SmartTable<K, V>,
+        self: &SmartTable<K, V>,
         starting_bucket_index: u64,
         starting_vector_index: u64,
         num_keys_to_get: u64,
@@ -69,35 +69,35 @@ spec aptos_std::smart_table {
         pragma verify = false;
     }
 
-    spec add_all<K, V>(table: &mut SmartTable<K, V>, keys: vector<K>, values: vector<V>) {
+    spec add_all<K, V>(self: &mut SmartTable<K, V>, keys: vector<K>, values: vector<V>) {
         pragma verify = false;
     }
 
-    spec update_split_load_threshold<K, V>(table: &mut SmartTable<K, V>, split_load_threshold: u8) {
+    spec update_split_load_threshold<K, V>(self: &mut SmartTable<K, V>, split_load_threshold: u8) {
         pragma verify = false;
     }
 
-    spec update_target_bucket_size<K, V>(table: &mut SmartTable<K, V>, target_bucket_size: u64) {
+    spec update_target_bucket_size<K, V>(self: &mut SmartTable<K, V>, target_bucket_size: u64) {
         pragma verify = false;
     }
 
-    spec borrow_kv<K, V>(e: &Entry<K, V>): (&K, &V) {
+    spec borrow_kv<K, V>(self: &Entry<K, V>): (&K, &V) {
         pragma verify = false;
     }
 
-    spec borrow_kv_mut<K, V>(e: &mut Entry<K, V>): (&mut K, &mut V) {
+    spec borrow_kv_mut<K, V>(self: &mut Entry<K, V>): (&mut K, &mut V) {
         pragma verify = false;
     }
 
-    spec num_buckets<K, V>(table: &SmartTable<K, V>): u64 {
+    spec num_buckets<K, V>(self: &SmartTable<K, V>): u64 {
         pragma verify = false;
     }
 
-    spec borrow_buckets<K, V>(table: &SmartTable<K, V>): &TableWithLength<u64, vector<Entry<K, V>>> {
+    spec borrow_buckets<K, V>(self: &SmartTable<K, V>): &TableWithLength<u64, vector<Entry<K, V>>> {
         pragma verify = false;
     }
 
-    spec borrow_buckets_mut<K, V>(table: &mut SmartTable<K, V>): &mut TableWithLength<u64, vector<Entry<K, V>>> {
+    spec borrow_buckets_mut<K, V>(self: &mut SmartTable<K, V>): &mut TableWithLength<u64, vector<Entry<K, V>>> {
         pragma verify = false;
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.move
@@ -67,119 +67,119 @@ module aptos_std::smart_vector {
         v
     }
 
-    /// Destroy the vector `v`.
-    /// Aborts if `v` is not empty.
-    public fun destroy_empty<T>(v: SmartVector<T>) {
-        assert!(is_empty(&v), error::invalid_argument(EVECTOR_NOT_EMPTY));
-        let SmartVector { inline_vec, big_vec, inline_capacity: _, bucket_size: _ } = v;
+    /// Destroy the vector `self`.
+    /// Aborts if `self` is not empty.
+    public fun destroy_empty<T>(self: SmartVector<T>) {
+        assert!(is_empty(&self), error::invalid_argument(EVECTOR_NOT_EMPTY));
+        let SmartVector { inline_vec, big_vec, inline_capacity: _, bucket_size: _ } = self;
         vector::destroy_empty(inline_vec);
         option::destroy_none(big_vec);
     }
 
     /// Destroy a vector completely when T has `drop`.
-    public fun destroy<T: drop>(v: SmartVector<T>) {
-        clear(&mut v);
-        destroy_empty(v);
+    public fun destroy<T: drop>(self: SmartVector<T>) {
+        clear(&mut self);
+        destroy_empty(self);
     }
 
     /// Clear a vector completely when T has `drop`.
-    public fun clear<T: drop>(v: &mut SmartVector<T>) {
-        v.inline_vec = vector[];
-        if (option::is_some(&v.big_vec)) {
-            big_vector::destroy(option::extract(&mut v.big_vec));
+    public fun clear<T: drop>(self: &mut SmartVector<T>) {
+        self.inline_vec = vector[];
+        if (option::is_some(&self.big_vec)) {
+            big_vector::destroy(option::extract(&mut self.big_vec));
         }
     }
 
-    /// Acquire an immutable reference to the `i`th T of the vector `v`.
+    /// Acquire an immutable reference to the `i`th T of the vector `self`.
     /// Aborts if `i` is out of bounds.
-    public fun borrow<T>(v: &SmartVector<T>, i: u64): &T {
-        assert!(i < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        let inline_len = vector::length(&v.inline_vec);
+    public fun borrow<T>(self: &SmartVector<T>, i: u64): &T {
+        assert!(i < length(self), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
+        let inline_len = vector::length(&self.inline_vec);
         if (i < inline_len) {
-            vector::borrow(&v.inline_vec, i)
+            vector::borrow(&self.inline_vec, i)
         } else {
-            big_vector::borrow(option::borrow(&v.big_vec), i - inline_len)
+            big_vector::borrow(option::borrow(&self.big_vec), i - inline_len)
         }
     }
 
-    /// Return a mutable reference to the `i`th T in the vector `v`.
+    /// Return a mutable reference to the `i`th T in the vector `self`.
     /// Aborts if `i` is out of bounds.
-    public fun borrow_mut<T>(v: &mut SmartVector<T>, i: u64): &mut T {
-        assert!(i < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        let inline_len = vector::length(&v.inline_vec);
+    public fun borrow_mut<T>(self: &mut SmartVector<T>, i: u64): &mut T {
+        assert!(i < length(self), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
+        let inline_len = vector::length(&self.inline_vec);
         if (i < inline_len) {
-            vector::borrow_mut(&mut v.inline_vec, i)
+            vector::borrow_mut(&mut self.inline_vec, i)
         } else {
-            big_vector::borrow_mut(option::borrow_mut(&mut v.big_vec), i - inline_len)
+            big_vector::borrow_mut(option::borrow_mut(&mut self.big_vec), i - inline_len)
         }
     }
 
-    /// Empty and destroy the other vector, and push each of the Ts in the other vector onto the lhs vector in the
+    /// Empty and destroy the other vector, and push each of the Ts in the other vector onto the self vector in the
     /// same order as they occurred in other.
     /// Disclaimer: This function may be costly. Use it at your own discretion.
-    public fun append<T: store>(lhs: &mut SmartVector<T>, other: SmartVector<T>) {
+    public fun append<T: store>(self: &mut SmartVector<T>, other: SmartVector<T>) {
         let other_len = length(&other);
         let half_other_len = other_len / 2;
         let i = 0;
         while (i < half_other_len) {
-            push_back(lhs, swap_remove(&mut other, i));
+            push_back(self, swap_remove(&mut other, i));
             i = i + 1;
         };
         while (i < other_len) {
-            push_back(lhs, pop_back(&mut other));
+            push_back(self, pop_back(&mut other));
             i = i + 1;
         };
         destroy_empty(other);
     }
 
     /// Add multiple values to the vector at once.
-    public fun add_all<T: store>(v: &mut SmartVector<T>, vals: vector<T>) {
-        vector::for_each(vals, |val| { push_back(v, val); })
+    public fun add_all<T: store>(self: &mut SmartVector<T>, vals: vector<T>) {
+        vector::for_each(vals, |val| { push_back(self, val); })
     }
 
     /// Convert a smart vector to a native vector, which is supposed to be called mostly by view functions to get an
     /// atomic view of the whole vector.
     /// Disclaimer: This function may be costly as the smart vector may be huge in size. Use it at your own discretion.
-    public fun to_vector<T: store + copy>(v: &SmartVector<T>): vector<T> {
-        let res = v.inline_vec;
-        if (option::is_some(&v.big_vec)) {
-            let big_vec = option::borrow(&v.big_vec);
+    public fun to_vector<T: store + copy>(self: &SmartVector<T>): vector<T> {
+        let res = self.inline_vec;
+        if (option::is_some(&self.big_vec)) {
+            let big_vec = option::borrow(&self.big_vec);
             vector::append(&mut res, big_vector::to_vector(big_vec));
         };
         res
     }
 
-    /// Add T `val` to the end of the vector `v`. It grows the buckets when the current buckets are full.
+    /// Add T `val` to the end of the vector `self`. It grows the buckets when the current buckets are full.
     /// This operation will cost more gas when it adds new bucket.
-    public fun push_back<T: store>(v: &mut SmartVector<T>, val: T) {
-        let len = length(v);
-        let inline_len = vector::length(&v.inline_vec);
+    public fun push_back<T: store>(self: &mut SmartVector<T>, val: T) {
+        let len = length(self);
+        let inline_len = vector::length(&self.inline_vec);
         if (len == inline_len) {
-            let bucket_size = if (option::is_some(&v.inline_capacity)) {
-                if (len < *option::borrow(&v.inline_capacity)) {
-                    vector::push_back(&mut v.inline_vec, val);
+            let bucket_size = if (option::is_some(&self.inline_capacity)) {
+                if (len < *option::borrow(&self.inline_capacity)) {
+                    vector::push_back(&mut self.inline_vec, val);
                     return
                 };
-                *option::borrow(&v.bucket_size)
+                *option::borrow(&self.bucket_size)
             } else {
                 let val_size = size_of_val(&val);
                 if (val_size * (inline_len + 1) < 150 /* magic number */) {
-                    vector::push_back(&mut v.inline_vec, val);
+                    vector::push_back(&mut self.inline_vec, val);
                     return
                 };
-                let estimated_avg_size = max((size_of_val(&v.inline_vec) + val_size) / (inline_len + 1), 1);
+                let estimated_avg_size = max((size_of_val(&self.inline_vec) + val_size) / (inline_len + 1), 1);
                 max(1024 /* free_write_quota */ / estimated_avg_size, 1)
             };
-            option::fill(&mut v.big_vec, big_vector::empty(bucket_size));
+            option::fill(&mut self.big_vec, big_vector::empty(bucket_size));
         };
-        big_vector::push_back(option::borrow_mut(&mut v.big_vec), val);
+        big_vector::push_back(option::borrow_mut(&mut self.big_vec), val);
     }
 
-    /// Pop an T from the end of vector `v`. It does shrink the buckets if they're empty.
-    /// Aborts if `v` is empty.
-    public fun pop_back<T>(v: &mut SmartVector<T>): T {
-        assert!(!is_empty(v), error::invalid_state(EVECTOR_EMPTY));
-        let big_vec_wrapper = &mut v.big_vec;
+    /// Pop an T from the end of vector `self`. It does shrink the buckets if they're empty.
+    /// Aborts if `self` is empty.
+    public fun pop_back<T>(self: &mut SmartVector<T>): T {
+        assert!(!is_empty(self), error::invalid_state(EVECTOR_EMPTY));
+        let big_vec_wrapper = &mut self.big_vec;
         if (option::is_some(big_vec_wrapper)) {
             let big_vec = option::extract(big_vec_wrapper);
             let val = big_vector::pop_back(&mut big_vec);
@@ -190,21 +190,21 @@ module aptos_std::smart_vector {
             };
             val
         } else {
-            vector::pop_back(&mut v.inline_vec)
+            vector::pop_back(&mut self.inline_vec)
         }
     }
 
-    /// Remove the T at index i in the vector v and return the owned value that was previously stored at i in v.
+    /// Remove the T at index i in the vector self and return the owned value that was previously stored at i in self.
     /// All Ts occurring at indices greater than i will be shifted down by 1. Will abort if i is out of bounds.
     /// Disclaimer: This function may be costly. Use it at your own discretion.
-    public fun remove<T>(v: &mut SmartVector<T>, i: u64): T {
-        let len = length(v);
+    public fun remove<T>(self: &mut SmartVector<T>, i: u64): T {
+        let len = length(self);
         assert!(i < len, error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        let inline_len = vector::length(&v.inline_vec);
+        let inline_len = vector::length(&self.inline_vec);
         if (i < inline_len) {
-            vector::remove(&mut v.inline_vec, i)
+            vector::remove(&mut self.inline_vec, i)
         } else {
-            let big_vec_wrapper = &mut v.big_vec;
+            let big_vec_wrapper = &mut self.big_vec;
             let big_vec = option::extract(big_vec_wrapper);
             let val = big_vector::remove(&mut big_vec, i - inline_len);
             if (big_vector::is_empty(&big_vec)) {
@@ -216,15 +216,15 @@ module aptos_std::smart_vector {
         }
     }
 
-    /// Swap the `i`th T of the vector `v` with the last T and then pop the vector.
+    /// Swap the `i`th T of the vector `self` with the last T and then pop the vector.
     /// This is O(1), but does not preserve ordering of Ts in the vector.
     /// Aborts if `i` is out of bounds.
-    public fun swap_remove<T>(v: &mut SmartVector<T>, i: u64): T {
-        let len = length(v);
+    public fun swap_remove<T>(self: &mut SmartVector<T>, i: u64): T {
+        let len = length(self);
         assert!(i < len, error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        let inline_len = vector::length(&v.inline_vec);
-        let big_vec_wrapper = &mut v.big_vec;
-        let inline_vec = &mut v.inline_vec;
+        let inline_len = vector::length(&self.inline_vec);
+        let big_vec_wrapper = &mut self.big_vec;
+        let inline_vec = &mut self.inline_vec;
         if (i >= inline_len) {
             let big_vec = option::extract(big_vec_wrapper);
             let val = big_vector::swap_remove(&mut big_vec, i - inline_len);
@@ -250,21 +250,21 @@ module aptos_std::smart_vector {
     }
 
     /// Swap the Ts at the i'th and j'th indices in the vector v. Will abort if either of i or j are out of bounds
-    /// for v.
-    public fun swap<T: store>(v: &mut SmartVector<T>, i: u64, j: u64) {
+    /// for self.
+    public fun swap<T: store>(self: &mut SmartVector<T>, i: u64, j: u64) {
         if (i > j) {
-            return swap(v, j, i)
+            return swap(self, j, i)
         };
-        let len = length(v);
+        let len = length(self);
         assert!(j < len, error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        let inline_len = vector::length(&v.inline_vec);
+        let inline_len = vector::length(&self.inline_vec);
         if (i >= inline_len) {
-            big_vector::swap(option::borrow_mut(&mut v.big_vec), i - inline_len, j - inline_len);
+            big_vector::swap(option::borrow_mut(&mut self.big_vec), i - inline_len, j - inline_len);
         } else if (j < inline_len) {
-            vector::swap(&mut v.inline_vec, i, j);
+            vector::swap(&mut self.inline_vec, i, j);
         } else {
-            let big_vec = option::borrow_mut(&mut v.big_vec);
-            let inline_vec = &mut v.inline_vec;
+            let big_vec = option::borrow_mut(&mut self.big_vec);
+            let inline_vec = &mut self.inline_vec;
             let element_i = vector::swap_remove(inline_vec, i);
             let element_j = big_vector::swap_remove(big_vec, j - inline_len);
             vector::push_back(inline_vec, element_j);
@@ -274,128 +274,128 @@ module aptos_std::smart_vector {
         }
     }
 
-    /// Reverse the order of the Ts in the vector v in-place.
+    /// Reverse the order of the Ts in the vector self in-place.
     /// Disclaimer: This function may be costly. Use it at your own discretion.
-    public fun reverse<T: store>(v: &mut SmartVector<T>) {
-        let inline_len = vector::length(&v.inline_vec);
+    public fun reverse<T: store>(self: &mut SmartVector<T>) {
+        let inline_len = vector::length(&self.inline_vec);
         let i = 0;
         let new_inline_vec = vector[];
         // Push the last `inline_len` Ts into a temp vector.
         while (i < inline_len) {
-            vector::push_back(&mut new_inline_vec, pop_back(v));
+            vector::push_back(&mut new_inline_vec, pop_back(self));
             i = i + 1;
         };
         vector::reverse(&mut new_inline_vec);
         // Reverse the big_vector left if exists.
-        if (option::is_some(&v.big_vec)) {
-            big_vector::reverse(option::borrow_mut(&mut v.big_vec));
+        if (option::is_some(&self.big_vec)) {
+            big_vector::reverse(option::borrow_mut(&mut self.big_vec));
         };
         // Mem::swap the two vectors.
         let temp_vec = vector[];
-        while (!vector::is_empty(&mut v.inline_vec)) {
-            vector::push_back(&mut temp_vec, vector::pop_back(&mut v.inline_vec));
+        while (!vector::is_empty(&mut self.inline_vec)) {
+            vector::push_back(&mut temp_vec, vector::pop_back(&mut self.inline_vec));
         };
         vector::reverse(&mut temp_vec);
         while (!vector::is_empty(&mut new_inline_vec)) {
-            vector::push_back(&mut v.inline_vec, vector::pop_back(&mut new_inline_vec));
+            vector::push_back(&mut self.inline_vec, vector::pop_back(&mut new_inline_vec));
         };
         vector::destroy_empty(new_inline_vec);
         // Push the rest Ts originally left in inline_vector back to the end of the smart vector.
         while (!vector::is_empty(&mut temp_vec)) {
-            push_back(v, vector::pop_back(&mut temp_vec));
+            push_back(self, vector::pop_back(&mut temp_vec));
         };
         vector::destroy_empty(temp_vec);
     }
 
-    /// Return `(true, i)` if `val` is in the vector `v` at index `i`.
+    /// Return `(true, i)` if `val` is in the vector `self` at index `i`.
     /// Otherwise, returns `(false, 0)`.
     /// Disclaimer: This function may be costly. Use it at your own discretion.
-    public fun index_of<T>(v: &SmartVector<T>, val: &T): (bool, u64) {
-        let (found, i) = vector::index_of(&v.inline_vec, val);
+    public fun index_of<T>(self: &SmartVector<T>, val: &T): (bool, u64) {
+        let (found, i) = vector::index_of(&self.inline_vec, val);
         if (found) {
             (true, i)
-        } else if (option::is_some(&v.big_vec)) {
-            let (found, i) = big_vector::index_of(option::borrow(&v.big_vec), val);
-            (found, i + vector::length(&v.inline_vec))
+        } else if (option::is_some(&self.big_vec)) {
+            let (found, i) = big_vector::index_of(option::borrow(&self.big_vec), val);
+            (found, i + vector::length(&self.inline_vec))
         } else {
             (false, 0)
         }
     }
 
-    /// Return true if `val` is in the vector `v`.
+    /// Return true if `val` is in the vector `self`.
     /// Disclaimer: This function may be costly. Use it at your own discretion.
-    public fun contains<T>(v: &SmartVector<T>, val: &T): bool {
-        if (is_empty(v)) return false;
-        let (exist, _) = index_of(v, val);
+    public fun contains<T>(self: &SmartVector<T>, val: &T): bool {
+        if (is_empty(self)) return false;
+        let (exist, _) = index_of(self, val);
         exist
     }
 
     /// Return the length of the vector.
-    public fun length<T>(v: &SmartVector<T>): u64 {
-        vector::length(&v.inline_vec) + if (option::is_none(&v.big_vec)) {
+    public fun length<T>(self: &SmartVector<T>): u64 {
+        vector::length(&self.inline_vec) + if (option::is_none(&self.big_vec)) {
             0
         } else {
-            big_vector::length(option::borrow(&v.big_vec))
+            big_vector::length(option::borrow(&self.big_vec))
         }
     }
 
-    /// Return `true` if the vector `v` has no Ts and `false` otherwise.
-    public fun is_empty<T>(v: &SmartVector<T>): bool {
-        length(v) == 0
+    /// Return `true` if the vector `self` has no Ts and `false` otherwise.
+    public fun is_empty<T>(self: &SmartVector<T>): bool {
+        length(self) == 0
     }
 
     /// Apply the function to each T in the vector, consuming it.
-    public inline fun for_each<T: store>(v: SmartVector<T>, f: |T|) {
-        aptos_std::smart_vector::reverse(&mut v); // We need to reverse the vector to consume it efficiently
-        aptos_std::smart_vector::for_each_reverse(v, |e| f(e));
+    public inline fun for_each<T: store>(self: SmartVector<T>, f: |T|) {
+        aptos_std::smart_vector::reverse(&mut self); // We need to reverse the vector to consume it efficiently
+        aptos_std::smart_vector::for_each_reverse(self, |e| f(e));
     }
 
     /// Apply the function to each T in the vector, consuming it.
-    public inline fun for_each_reverse<T>(v: SmartVector<T>, f: |T|) {
-        let len = aptos_std::smart_vector::length(&v);
+    public inline fun for_each_reverse<T>(self: SmartVector<T>, f: |T|) {
+        let len = aptos_std::smart_vector::length(&self);
         while (len > 0) {
-            f(aptos_std::smart_vector::pop_back(&mut v));
+            f(aptos_std::smart_vector::pop_back(&mut self));
             len = len - 1;
         };
-        aptos_std::smart_vector::destroy_empty(v)
+        aptos_std::smart_vector::destroy_empty(self)
     }
 
     /// Apply the function to a reference of each T in the vector.
-    public inline fun for_each_ref<T>(v: &SmartVector<T>, f: |&T|) {
+    public inline fun for_each_ref<T>(self: &SmartVector<T>, f: |&T|) {
         let i = 0;
-        let len = aptos_std::smart_vector::length(v);
+        let len = aptos_std::smart_vector::length(self);
         while (i < len) {
-            f(aptos_std::smart_vector::borrow(v, i));
+            f(aptos_std::smart_vector::borrow(self, i));
             i = i + 1
         }
     }
 
     /// Apply the function to a mutable reference to each T in the vector.
-    public inline fun for_each_mut<T>(v: &mut SmartVector<T>, f: |&mut T|) {
+    public inline fun for_each_mut<T>(self: &mut SmartVector<T>, f: |&mut T|) {
         let i = 0;
-        let len = aptos_std::smart_vector::length(v);
+        let len = aptos_std::smart_vector::length(self);
         while (i < len) {
-            f(aptos_std::smart_vector::borrow_mut(v, i));
+            f(aptos_std::smart_vector::borrow_mut(self, i));
             i = i + 1
         }
     }
 
     /// Apply the function to a reference of each T in the vector with its index.
-    public inline fun enumerate_ref<T>(v: &SmartVector<T>, f: |u64, &T|) {
+    public inline fun enumerate_ref<T>(self: &SmartVector<T>, f: |u64, &T|) {
         let i = 0;
-        let len = aptos_std::smart_vector::length(v);
+        let len = aptos_std::smart_vector::length(self);
         while (i < len) {
-            f(i, aptos_std::smart_vector::borrow(v, i));
+            f(i, aptos_std::smart_vector::borrow(self, i));
             i = i + 1;
         };
     }
 
     /// Apply the function to a mutable reference of each T in the vector with its index.
-    public inline fun enumerate_mut<T>(v: &mut SmartVector<T>, f: |u64, &mut T|) {
+    public inline fun enumerate_mut<T>(self: &mut SmartVector<T>, f: |u64, &mut T|) {
         let i = 0;
-        let len = length(v);
+        let len = length(self);
         while (i < len) {
-            f(i, borrow_mut(v, i));
+            f(i, borrow_mut(self, i));
             i = i + 1;
         };
     }
@@ -403,100 +403,100 @@ module aptos_std::smart_vector {
     /// Fold the function over the Ts. For example, `fold(vector[1,2,3], 0, f)` will execute
     /// `f(f(f(0, 1), 2), 3)`
     public inline fun fold<Accumulator, T: store>(
-        v: SmartVector<T>,
+        self: SmartVector<T>,
         init: Accumulator,
         f: |Accumulator, T|Accumulator
     ): Accumulator {
         let accu = init;
-        aptos_std::smart_vector::for_each(v, |elem| accu = f(accu, elem));
+        aptos_std::smart_vector::for_each(self, |elem| accu = f(accu, elem));
         accu
     }
 
     /// Fold right like fold above but working right to left. For example, `fold(vector[1,2,3], 0, f)` will execute
     /// `f(1, f(2, f(3, 0)))`
     public inline fun foldr<Accumulator, T>(
-        v: SmartVector<T>,
+        self: SmartVector<T>,
         init: Accumulator,
         f: |T, Accumulator|Accumulator
     ): Accumulator {
         let accu = init;
-        aptos_std::smart_vector::for_each_reverse(v, |elem| accu = f(elem, accu));
+        aptos_std::smart_vector::for_each_reverse(self, |elem| accu = f(elem, accu));
         accu
     }
 
     /// Map the function over the references of the Ts of the vector, producing a new vector without modifying the
     /// original vector.
     public inline fun map_ref<T1, T2: store>(
-        v: &SmartVector<T1>,
+        self: &SmartVector<T1>,
         f: |&T1|T2
     ): SmartVector<T2> {
         let result = aptos_std::smart_vector::new<T2>();
-        aptos_std::smart_vector::for_each_ref(v, |elem| aptos_std::smart_vector::push_back(&mut result, f(elem)));
+        aptos_std::smart_vector::for_each_ref(self, |elem| aptos_std::smart_vector::push_back(&mut result, f(elem)));
         result
     }
 
     /// Map the function over the Ts of the vector, producing a new vector.
     public inline fun map<T1: store, T2: store>(
-        v: SmartVector<T1>,
+        self: SmartVector<T1>,
         f: |T1|T2
     ): SmartVector<T2> {
         let result = aptos_std::smart_vector::new<T2>();
-        aptos_std::smart_vector::for_each(v, |elem| push_back(&mut result, f(elem)));
+        aptos_std::smart_vector::for_each(self, |elem| push_back(&mut result, f(elem)));
         result
     }
 
     /// Filter the vector using the boolean function, removing all Ts for which `p(e)` is not true.
     public inline fun filter<T: store + drop>(
-        v: SmartVector<T>,
+        self: SmartVector<T>,
         p: |&T|bool
     ): SmartVector<T> {
         let result = aptos_std::smart_vector::new<T>();
-        aptos_std::smart_vector::for_each(v, |elem| {
+        aptos_std::smart_vector::for_each(self, |elem| {
             if (p(&elem)) aptos_std::smart_vector::push_back(&mut result, elem);
         });
         result
     }
 
-    public inline fun zip<T1: store, T2: store>(v1: SmartVector<T1>, v2: SmartVector<T2>, f: |T1, T2|) {
+    public inline fun zip<T1: store, T2: store>(self: SmartVector<T1>, v2: SmartVector<T2>, f: |T1, T2|) {
         // We need to reverse the vectors to consume it efficiently
-        aptos_std::smart_vector::reverse(&mut v1);
+        aptos_std::smart_vector::reverse(&mut self);
         aptos_std::smart_vector::reverse(&mut v2);
-        aptos_std::smart_vector::zip_reverse(v1, v2, |e1, e2| f(e1, e2));
+        aptos_std::smart_vector::zip_reverse(self, v2, |e1, e2| f(e1, e2));
     }
 
     /// Apply the function to each pair of elements in the two given vectors in the reverse order, consuming them.
     /// This errors out if the vectors are not of the same length.
     public inline fun zip_reverse<T1, T2>(
-        v1: SmartVector<T1>,
+        self: SmartVector<T1>,
         v2: SmartVector<T2>,
         f: |T1, T2|,
     ) {
-        let len = aptos_std::smart_vector::length(&v1);
+        let len = aptos_std::smart_vector::length(&self);
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
         assert!(len == aptos_std::smart_vector::length(&v2), 0x20005);
         while (len > 0) {
-            f(aptos_std::smart_vector::pop_back(&mut v1), aptos_std::smart_vector::pop_back(&mut v2));
+            f(aptos_std::smart_vector::pop_back(&mut self), aptos_std::smart_vector::pop_back(&mut v2));
             len = len - 1;
         };
-        aptos_std::smart_vector::destroy_empty(v1);
+        aptos_std::smart_vector::destroy_empty(self);
         aptos_std::smart_vector::destroy_empty(v2);
     }
 
     /// Apply the function to the references of each pair of elements in the two given vectors.
     /// This errors out if the vectors are not of the same length.
     public inline fun zip_ref<T1, T2>(
-        v1: &SmartVector<T1>,
+        self: &SmartVector<T1>,
         v2: &SmartVector<T2>,
         f: |&T1, &T2|,
     ) {
-        let len = aptos_std::smart_vector::length(v1);
+        let len = aptos_std::smart_vector::length(self);
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
         assert!(len == aptos_std::smart_vector::length(v2), 0x20005);
         let i = 0;
         while (i < len) {
-            f(aptos_std::smart_vector::borrow(v1, i), aptos_std::smart_vector::borrow(v2, i));
+            f(aptos_std::smart_vector::borrow(self, i), aptos_std::smart_vector::borrow(v2, i));
             i = i + 1
         }
     }
@@ -504,49 +504,49 @@ module aptos_std::smart_vector {
     /// Apply the function to mutable references to each pair of elements in the two given vectors.
     /// This errors out if the vectors are not of the same length.
     public inline fun zip_mut<T1, T2>(
-        v1: &mut SmartVector<T1>,
+        self: &mut SmartVector<T1>,
         v2: &mut SmartVector<T2>,
         f: |&mut T1, &mut T2|,
     ) {
         let i = 0;
-        let len = aptos_std::smart_vector::length(v1);
+        let len = aptos_std::smart_vector::length(self);
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
         assert!(len == aptos_std::smart_vector::length(v2), 0x20005);
         while (i < len) {
-            f(aptos_std::smart_vector::borrow_mut(v1, i), aptos_std::smart_vector::borrow_mut(v2, i));
+            f(aptos_std::smart_vector::borrow_mut(self, i), aptos_std::smart_vector::borrow_mut(v2, i));
             i = i + 1
         }
     }
 
     /// Map the function over the element pairs of the two vectors, producing a new vector.
     public inline fun zip_map<T1: store, T2: store, NewT: store>(
-        v1: SmartVector<T1>,
+        self: SmartVector<T1>,
         v2: SmartVector<T2>,
         f: |T1, T2|NewT
     ): SmartVector<NewT> {
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
-        assert!(aptos_std::smart_vector::length(&v1) == aptos_std::smart_vector::length(&v2), 0x20005);
+        assert!(aptos_std::smart_vector::length(&self) == aptos_std::smart_vector::length(&v2), 0x20005);
 
         let result = aptos_std::smart_vector::new<NewT>();
-        aptos_std::smart_vector::zip(v1, v2, |e1, e2| push_back(&mut result, f(e1, e2)));
+        aptos_std::smart_vector::zip(self, v2, |e1, e2| push_back(&mut result, f(e1, e2)));
         result
     }
 
     /// Map the function over the references of the element pairs of two vectors, producing a new vector from the return
     /// values without modifying the original vectors.
     public inline fun zip_map_ref<T1, T2, NewT: store>(
-        v1: &SmartVector<T1>,
+        self: &SmartVector<T1>,
         v2: &SmartVector<T2>,
         f: |&T1, &T2|NewT
     ): SmartVector<NewT> {
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
-        assert!(aptos_std::smart_vector::length(v1) == aptos_std::smart_vector::length(v2), 0x20005);
+        assert!(aptos_std::smart_vector::length(self) == aptos_std::smart_vector::length(v2), 0x20005);
 
         let result = aptos_std::smart_vector::new<NewT>();
-        aptos_std::smart_vector::zip_ref(v1, v2, |e1, e2| push_back(&mut result, f(e1, e2)));
+        aptos_std::smart_vector::zip_ref(self, v2, |e1, e2| push_back(&mut result, f(e1, e2)));
         result
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
@@ -13,7 +13,8 @@ spec aptos_std::smart_vector {
     }
 
     spec length {
-        aborts_if option::is_some(v.big_vec) && len(v.inline_vec) + big_vector::length(option::spec_borrow(v.big_vec)) > MAX_U64;
+        aborts_if option::is_some(self.big_vec) && len(self.inline_vec) + big_vector::length(option::spec_borrow(
+            self.big_vec)) > MAX_U64;
     }
 
     spec empty {
@@ -25,19 +26,19 @@ spec aptos_std::smart_vector {
     }
 
     spec destroy_empty {
-        aborts_if !(is_empty(v));
-        aborts_if len(v.inline_vec) != 0
-            || option::is_some(v.big_vec);
+        aborts_if !(is_empty(self));
+        aborts_if len(self.inline_vec) != 0
+            || option::is_some(self.big_vec);
     }
 
     spec borrow {
-        aborts_if i >= length(v);
-        aborts_if option::is_some(v.big_vec) && (
-            (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
+        aborts_if i >= length(self);
+        aborts_if option::is_some(self.big_vec) && (
+            (len(self.inline_vec) + big_vector::length<T>(option::borrow(self.big_vec))) > MAX_U64
         );
     }
 
-    spec push_back<T: store>(v: &mut SmartVector<T>, val: T) {
+    spec push_back<T: store>(self: &mut SmartVector<T>, val: T) {
         // use aptos_std::big_vector;
         // use aptos_std::type_info;
         pragma verify = false; // TODO: set to false because of timeout
@@ -65,24 +66,24 @@ spec aptos_std::smart_vector {
 
         pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved)
 
-        aborts_if  option::is_some(v.big_vec)
+        aborts_if  option::is_some(self.big_vec)
             &&
-            (table_with_length::spec_len(option::borrow(v.big_vec).buckets) == 0);
-        aborts_if is_empty(v);
-        aborts_if option::is_some(v.big_vec) && (
-            (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
+            (table_with_length::spec_len(option::borrow(self.big_vec).buckets) == 0);
+        aborts_if is_empty(self);
+        aborts_if option::is_some(self.big_vec) && (
+            (len(self.inline_vec) + big_vector::length<T>(option::borrow(self.big_vec))) > MAX_U64
         );
 
-        ensures length(v) == length(old(v)) - 1;
+        ensures length(self) == length(old(self)) - 1;
     }
 
     spec swap_remove {
         pragma verify = false; // TODO: set because of timeout
-        aborts_if i >= length(v);
-        aborts_if option::is_some(v.big_vec) && (
-            (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
+        aborts_if i >= length(self);
+        aborts_if option::is_some(self.big_vec) && (
+            (len(self.inline_vec) + big_vector::length<T>(option::borrow(self.big_vec))) > MAX_U64
         );
-        ensures length(v) == length(old(v)) - 1;
+        ensures length(self) == length(old(self)) - 1;
     }
 
     spec swap {

--- a/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
@@ -29,22 +29,22 @@ module aptos_std::fixed_point64 {
     /// Abort code on calculation result is negative.
     const ENEGATIVE_RESULT: u64 = 0x10006;
 
-    /// Returns x - y. x must be not less than y.
-    public fun sub(x: FixedPoint64, y: FixedPoint64): FixedPoint64 {
-        let x_raw = get_raw_value(x);
+    /// Returns self - y. self must be not less than y.
+    public fun sub(self: FixedPoint64, y: FixedPoint64): FixedPoint64 {
+        let x_raw = get_raw_value(self);
         let y_raw = get_raw_value(y);
         assert!(x_raw >= y_raw, ENEGATIVE_RESULT);
         create_from_raw_value(x_raw - y_raw)
     }
     spec sub {
         pragma opaque;
-        aborts_if x.value < y.value with ENEGATIVE_RESULT;
-        ensures result.value == x.value - y.value;
+        aborts_if self.value < y.value with ENEGATIVE_RESULT;
+        ensures result.value == self.value - y.value;
     }
 
-    /// Returns x + y. The result cannot be greater than MAX_U128.
-    public fun add(x: FixedPoint64, y: FixedPoint64): FixedPoint64 {
-        let x_raw = get_raw_value(x);
+    /// Returns self + y. The result cannot be greater than MAX_U128.
+    public fun add(self: FixedPoint64, y: FixedPoint64): FixedPoint64 {
+        let x_raw = get_raw_value(self);
         let y_raw = get_raw_value(y);
         let result = (x_raw as u256) + (y_raw as u256);
         assert!(result <= MAX_U128, ERATIO_OUT_OF_RANGE);
@@ -52,8 +52,8 @@ module aptos_std::fixed_point64 {
     }
     spec add {
         pragma opaque;
-        aborts_if (x.value as u256) + (y.value as u256) > MAX_U128 with ERATIO_OUT_OF_RANGE;
-        ensures result.value == x.value + y.value;
+        aborts_if (self.value as u256) + (y.value as u256) > MAX_U128 with ERATIO_OUT_OF_RANGE;
+        ensures result.value == self.value + y.value;
     }
 
     /// Multiply a u128 integer by a fixed-point number, truncating any
@@ -94,7 +94,7 @@ module aptos_std::fixed_point64 {
         assert!(unscaled_product <= MAX_U128, EMULTIPLICATION);
         create_from_raw_value((unscaled_product as u128))
     }
-
+    
 
     /// Divide a u128 integer by a fixed-point number, truncating any
     /// fractional part of the quotient. This will abort if the divisor
@@ -183,13 +183,13 @@ module aptos_std::fixed_point64 {
     /// Accessor for the raw u128 value. Other less common operations, such as
     /// adding or subtracting FixedPoint64 values, can be done using the raw
     /// values directly.
-    public fun get_raw_value(num: FixedPoint64): u128 {
-        num.value
+    public fun get_raw_value(self: FixedPoint64): u128 {
+        self.value
     }
 
     /// Returns true if the ratio is zero.
-    public fun is_zero(num: FixedPoint64): bool {
-        num.value == 0
+    public fun is_zero(self: FixedPoint64): bool {
+        self.value == 0
     }
 
     /// Returns the smaller of the two FixedPoint64 numbers.
@@ -234,89 +234,89 @@ module aptos_std::fixed_point64 {
         }
     }
 
-    /// Returns true if num1 <= num2
-    public fun less_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value <= num2.value
+    /// Returns true if self <= num2
+    public fun less_or_equal(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value <= num2.value
     }
     spec less_or_equal {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_less_or_equal(num1, num2);
+        ensures result == spec_less_or_equal(self, num2);
     }
-    spec fun spec_less_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value <= num2.value
+    spec fun spec_less_or_equal(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value <= num2.value
     }
 
-    /// Returns true if num1 < num2
-    public fun less(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value < num2.value
+    /// Returns true if self < num2
+    public fun less(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value < num2.value
     }
     spec less {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_less(num1, num2);
+        ensures result == spec_less(self, num2);
     }
-    spec fun spec_less(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value < num2.value
+    spec fun spec_less(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value < num2.value
     }
 
-    /// Returns true if num1 >= num2
-    public fun greater_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value >= num2.value
+    /// Returns true if self >= num2
+    public fun greater_or_equal(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value >= num2.value
     }
     spec greater_or_equal {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_greater_or_equal(num1, num2);
+        ensures result == spec_greater_or_equal(self, num2);
     }
-    spec fun spec_greater_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value >= num2.value
+    spec fun spec_greater_or_equal(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value >= num2.value
     }
 
-    /// Returns true if num1 > num2
-    public fun greater(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value > num2.value
+    /// Returns true if self > num2
+    public fun greater(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value > num2.value
     }
     spec greater {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_greater(num1, num2);
+        ensures result == spec_greater(self, num2);
     }
-    spec fun spec_greater(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value > num2.value
+    spec fun spec_greater(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value > num2.value
     }
 
-    /// Returns true if num1 = num2
-    public fun equal(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value == num2.value
+    /// Returns true if self = num2
+    public fun equal(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value == num2.value
     }
     spec equal {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_equal(num1, num2);
+        ensures result == spec_equal(self, num2);
     }
-    spec fun spec_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
-        num1.value == num2.value
+    spec fun spec_equal(self: FixedPoint64, num2: FixedPoint64): bool {
+        self.value == num2.value
     }
 
-    /// Returns true if num1 almost equals to num2, which means abs(num1-num2) <= precision
-    public fun almost_equal(num1: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64): bool {
-        if (num1.value > num2.value) {
-            (num1.value - num2.value <= precision.value)
+    /// Returns true if self almost equals to num2, which means abs(num1-num2) <= precision
+    public fun almost_equal(self: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64): bool {
+        if (self.value > num2.value) {
+            (self.value - num2.value <= precision.value)
         } else {
-            (num2.value - num1.value <= precision.value)
+            (num2.value - self.value <= precision.value)
         }
     }
     spec almost_equal {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_almost_equal(num1, num2, precision);
+        ensures result == spec_almost_equal(self, num2, precision);
     }
-    spec fun spec_almost_equal(num1: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64): bool {
-        if (num1.value > num2.value) {
-            (num1.value - num2.value <= precision.value)
+    spec fun spec_almost_equal(self: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64): bool {
+        if (self.value > num2.value) {
+            (self.value - num2.value <= precision.value)
         } else {
-            (num2.value - num1.value <= precision.value)
+            (num2.value - self.value <= precision.value)
         }
     }
     /// Create a fixedpoint value from a u128 value.
@@ -340,27 +340,27 @@ module aptos_std::fixed_point64 {
     }
 
     /// Returns the largest integer less than or equal to a given number.
-    public fun floor(num: FixedPoint64): u128 {
-        num.value >> 64
+    public fun floor(self: FixedPoint64): u128 {
+        self.value >> 64
     }
     spec floor {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_floor(num);
+        ensures result == spec_floor(self);
     }
-    spec fun spec_floor(val: FixedPoint64): u128 {
-        let fractional = val.value % (1 << 64);
+    spec fun spec_floor(self: FixedPoint64): u128 {
+        let fractional = self.value % (1 << 64);
         if (fractional == 0) {
-            val.value >> 64
+            self.value >> 64
         } else {
-            (val.value - fractional) >> 64
+            (self.value - fractional) >> 64
         }
     }
 
     /// Rounds up the given FixedPoint64 to the next largest integer.
-    public fun ceil(num: FixedPoint64): u128 {
-        let floored_num = floor(num) << 64;
-        if (num.value == floored_num) {
+    public fun ceil(self: FixedPoint64): u128 {
+        let floored_num = floor(self) << 64;
+        if (self.value == floored_num) {
             return floored_num >> 64
         };
         let val = ((floored_num as u256) + (1 << 64));
@@ -371,41 +371,41 @@ module aptos_std::fixed_point64 {
         pragma verify_duration_estimate = 1000;
         pragma opaque;
         aborts_if false;
-        ensures result == spec_ceil(num);
+        ensures result == spec_ceil(self);
     }
-    spec fun spec_ceil(val: FixedPoint64): u128 {
-        let fractional = val.value % (1 << 64);
+    spec fun spec_ceil(self: FixedPoint64): u128 {
+        let fractional = self.value % (1 << 64);
         let one = 1 << 64;
         if (fractional == 0) {
-            val.value >> 64
+            self.value >> 64
         } else {
-            (val.value - fractional + one) >> 64
+            (self.value - fractional + one) >> 64
         }
     }
 
     /// Returns the value of a FixedPoint64 to the nearest integer.
-    public fun round(num: FixedPoint64): u128 {
-        let floored_num = floor(num) << 64;
+    public fun round(self: FixedPoint64): u128 {
+        let floored_num = floor(self) << 64;
         let boundary = floored_num + ((1 << 64) / 2);
-        if (num.value < boundary) {
+        if (self.value < boundary) {
             floored_num >> 64
         } else {
-            ceil(num)
+            ceil(self)
         }
     }
     spec round {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_round(num);
+        ensures result == spec_round(self);
     }
-    spec fun spec_round(val: FixedPoint64): u128 {
-        let fractional = val.value % (1 << 64);
+    spec fun spec_round(self: FixedPoint64): u128 {
+        let fractional = self.value % (1 << 64);
         let boundary = (1 << 64) / 2;
         let one = 1 << 64;
         if (fractional < boundary) {
-            (val.value - fractional) >> 64
+            (self.value - fractional) >> 64
         } else {
-            (val.value - fractional + one) >> 64
+            (self.value - fractional + one) >> 64
         }
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
@@ -1,6 +1,6 @@
 /// This module provides a number of functions to convert _primitive_ types from their representation in `std::bcs`
 /// to values. This is the opposite of `bcs::to_bytes`. Note that it is not safe to define a generic public `from_bytes`
-/// function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
+/// function because this can violate implicit struct invariants, therefore only primitive types are offered. If
 /// a general conversion back-and-force is needed, consider the `aptos_std::Any` type which preserves invariants.
 ///
 /// Example:

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -39,6 +39,15 @@ module aptos_std::math128 {
         large
     }
 
+    /// Return least common multiple of `a` & `b`
+    public inline fun lcm(a: u128, b: u128): u128 {
+        if (a == 0 || b == 0) {
+            0
+        } else {
+            a / gcd(a, b) * b
+        }
+    }
+
     /// Returns a * b / c going through u256 to prevent intermediate overflow
     public inline fun mul_div(a: u128, b: u128, c: u128): u128 {
         // Inline functions cannot take constants, as then every module using it needs the constant
@@ -191,6 +200,28 @@ module aptos_std::math128 {
         assert!(gcd(10, 10) == 10, 0);
         assert!(gcd(1071, 462) == 21, 0);
         assert!(gcd(462, 1071) == 21, 0);
+    }
+
+    #[test]
+    fun test_lcm() {
+        assert!(lcm(0, 0) == 0, 0);
+        assert!(lcm(0, 1) == 0, 0);
+        assert!(lcm(1, 0) == 0, 0);
+        assert!(lcm(1, 1) == 1, 0);
+        assert!(lcm(1024, 144) == 9216, 0);
+        assert!(lcm(2, 17) == 34, 0);
+        assert!(lcm(17, 2) == 34, 0);
+        assert!(lcm(24, 54) == 216, 0);
+        assert!(lcm(115, 9) == 1035, 0);
+        assert!(lcm(101, 14) == 1414, 0);
+        assert!(lcm(110, 5) == 110, 0);
+        assert!(lcm(100, 8) == 200, 0);
+        assert!(lcm(32, 6) == 96, 0);
+        assert!(lcm(110, 13) == 1430, 0);
+        assert!(lcm(117, 13) == 117, 0);
+        assert!(lcm(100, 125) == 500, 0);
+        assert!(lcm(101, 3) == 303, 0);
+        assert!(lcm(115, 16) == 1840, 0);
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -37,6 +37,15 @@ module aptos_std::math64 {
         large
     }
 
+    /// Returns least common multiple of `a` & `b`.
+    public inline fun lcm(a: u64, b: u64): u64 {
+        if (a == 0 || b == 0) {
+            0
+        } else {
+            a / gcd(a, b) * b
+        }
+    }
+
     /// Returns a * b / c going through u128 to prevent intermediate overflow
     public inline fun mul_div(a: u64, b: u64, c: u64): u64 {
         // Inline functions cannot take constants, as then every module using it needs the constant
@@ -165,6 +174,28 @@ module aptos_std::math64 {
         assert!(gcd(10, 10) == 10, 0);
         assert!(gcd(1071, 462) == 21, 0);
         assert!(gcd(462, 1071) == 21, 0);
+    }
+
+   #[test]
+    fun test_lcm() {
+        assert!(lcm(0, 0) == 0, 0);
+        assert!(lcm(0, 1) == 0, 0);
+        assert!(lcm(1, 0) == 0, 0);
+        assert!(lcm(1, 1) == 1, 0);
+        assert!(lcm(1024, 144) == 9216, 0);
+        assert!(lcm(2, 17) == 34, 0);
+        assert!(lcm(17, 2) == 34, 0);
+        assert!(lcm(24, 54) == 216, 0);
+        assert!(lcm(115, 9) == 1035, 0);
+        assert!(lcm(101, 14) == 1414, 0);
+        assert!(lcm(110, 5) == 110, 0);
+        assert!(lcm(100, 8) == 200, 0);
+        assert!(lcm(32, 6) == 96, 0);
+        assert!(lcm(110, 13) == 1430, 0);
+        assert!(lcm(117, 13) == 117, 0);
+        assert!(lcm(100, 125) == 500, 0);
+        assert!(lcm(101, 3) == 303, 0);
+        assert!(lcm(115, 16) == 1840, 0);
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
@@ -72,8 +72,8 @@ module aptos_std::pool_u64 {
     }
 
     /// Destroy an empty pool. This will fail if the pool has any balance of coins.
-    public fun destroy_empty(pool: Pool) {
-        assert!(pool.total_coins == 0, error::invalid_state(EPOOL_IS_NOT_EMPTY));
+    public fun destroy_empty(self: Pool) {
+        assert!(self.total_coins == 0, error::invalid_state(EPOOL_IS_NOT_EMPTY));
         let Pool {
             shareholders_limit: _,
             total_coins: _,
@@ -81,73 +81,73 @@ module aptos_std::pool_u64 {
             shares: _,
             shareholders: _,
             scaling_factor: _,
-        } = pool;
+        } = self;
     }
 
-    /// Return `pool`'s total balance of coins.
-    public fun total_coins(pool: &Pool): u64 {
-        pool.total_coins
+    /// Return `self`'s total balance of coins.
+    public fun total_coins(self: &Pool): u64 {
+        self.total_coins
     }
 
-    /// Return the total number of shares across all shareholders in `pool`.
-    public fun total_shares(pool: &Pool): u64 {
-        pool.total_shares
+    /// Return the total number of shares across all shareholders in `self`.
+    public fun total_shares(self: &Pool): u64 {
+        self.total_shares
     }
 
-    /// Return true if `shareholder` is in `pool`.
-    public fun contains(pool: &Pool, shareholder: address): bool {
-        simple_map::contains_key(&pool.shares, &shareholder)
+    /// Return true if `shareholder` is in `self`.
+    public fun contains(self: &Pool, shareholder: address): bool {
+        simple_map::contains_key(&self.shares, &shareholder)
     }
 
-    /// Return the number of shares of `stakeholder` in `pool`.
-    public fun shares(pool: &Pool, shareholder: address): u64 {
-        if (contains(pool, shareholder)) {
-            *simple_map::borrow(&pool.shares, &shareholder)
+    /// Return the number of shares of `stakeholder` in `self`.
+    public fun shares(self: &Pool, shareholder: address): u64 {
+        if (contains(self, shareholder)) {
+            *simple_map::borrow(&self.shares, &shareholder)
         } else {
             0
         }
     }
 
-    /// Return the balance in coins of `shareholder` in `pool.`
-    public fun balance(pool: &Pool, shareholder: address): u64 {
-        let num_shares = shares(pool, shareholder);
-        shares_to_amount(pool, num_shares)
+    /// Return the balance in coins of `shareholder` in `self`.
+    public fun balance(self: &Pool, shareholder: address): u64 {
+        let num_shares = shares(self, shareholder);
+        shares_to_amount(self, num_shares)
     }
 
-    /// Return the list of shareholders in `pool`.
-    public fun shareholders(pool: &Pool): vector<address> {
-        pool.shareholders
+    /// Return the list of shareholders in `self`.
+    public fun shareholders(self: &Pool): vector<address> {
+        self.shareholders
     }
 
-    /// Return the number of shareholders in `pool`.
-    public fun shareholders_count(pool: &Pool): u64 {
-        vector::length(&pool.shareholders)
+    /// Return the number of shareholders in `self`.
+    public fun shareholders_count(self: &Pool): u64 {
+        vector::length(&self.shareholders)
     }
 
-    /// Update `pool`'s total balance of coins.
-    public fun update_total_coins(pool: &mut Pool, new_total_coins: u64) {
-        pool.total_coins = new_total_coins;
+    /// Update `self`'s total balance of coins.
+    public fun update_total_coins(self: &mut Pool, new_total_coins: u64) {
+        self.total_coins = new_total_coins;
     }
 
     /// Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
-    public fun buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u64 {
+    public fun buy_in(self: &mut Pool, shareholder: address, coins_amount: u64): u64 {
         if (coins_amount == 0) return 0;
 
-        let new_shares = amount_to_shares(pool, coins_amount);
-        assert!(MAX_U64 - pool.total_coins >= coins_amount, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
-        assert!(MAX_U64 - pool.total_shares >= new_shares, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
+        let new_shares = amount_to_shares(self, coins_amount);
+        assert!(MAX_U64 - self.total_coins >= coins_amount, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
+        assert!(MAX_U64 - self.total_shares >= new_shares, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
 
-        pool.total_coins = pool.total_coins + coins_amount;
-        pool.total_shares = pool.total_shares + new_shares;
-        add_shares(pool, shareholder, new_shares);
+        self.total_coins = self.total_coins + coins_amount;
+        self.total_shares = self.total_shares + new_shares;
+        add_shares(self, shareholder, new_shares);
         new_shares
     }
 
-    /// Add the number of shares directly for `shareholder` in `pool`.
+    /// Add the number of shares directly for `shareholder` in `self`.
     /// This would dilute other shareholders if the pool's balance of coins didn't change.
-    fun add_shares(pool: &mut Pool, shareholder: address, new_shares: u64): u64 {
-        if (contains(pool, shareholder)) {
-            let existing_shares = simple_map::borrow_mut(&mut pool.shares, &shareholder);
+    fun add_shares(self: &mut Pool, shareholder: address, new_shares: u64): u64 {
+        if (contains(self, shareholder)) {
+            let existing_shares = simple_map::borrow_mut(&mut self.shares, &shareholder);
             let current_shares = *existing_shares;
             assert!(MAX_U64 - current_shares >= new_shares, error::invalid_argument(ESHAREHOLDER_SHARES_OVERFLOW));
 
@@ -155,110 +155,110 @@ module aptos_std::pool_u64 {
             *existing_shares
         } else if (new_shares > 0) {
             assert!(
-                vector::length(&pool.shareholders) < pool.shareholders_limit,
+                vector::length(&self.shareholders) < self.shareholders_limit,
                 error::invalid_state(ETOO_MANY_SHAREHOLDERS),
             );
 
-            vector::push_back(&mut pool.shareholders, shareholder);
-            simple_map::add(&mut pool.shares, shareholder, new_shares);
+            vector::push_back(&mut self.shareholders, shareholder);
+            simple_map::add(&mut self.shares, shareholder, new_shares);
             new_shares
         } else {
             new_shares
         }
     }
 
-    /// Allow `shareholder` to redeem their shares in `pool` for coins.
-    public fun redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u64): u64 {
-        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder) >= shares_to_redeem, error::invalid_argument(EINSUFFICIENT_SHARES));
+    /// Allow `shareholder` to redeem their shares in `self` for coins.
+    public fun redeem_shares(self: &mut Pool, shareholder: address, shares_to_redeem: u64): u64 {
+        assert!(contains(self, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
+        assert!(shares(self, shareholder) >= shares_to_redeem, error::invalid_argument(EINSUFFICIENT_SHARES));
 
         if (shares_to_redeem == 0) return 0;
 
-        let redeemed_coins = shares_to_amount(pool, shares_to_redeem);
-        pool.total_coins = pool.total_coins - redeemed_coins;
-        pool.total_shares = pool.total_shares - shares_to_redeem;
-        deduct_shares(pool, shareholder, shares_to_redeem);
+        let redeemed_coins = shares_to_amount(self, shares_to_redeem);
+        self.total_coins = self.total_coins - redeemed_coins;
+        self.total_shares = self.total_shares - shares_to_redeem;
+        deduct_shares(self, shareholder, shares_to_redeem);
 
         redeemed_coins
     }
 
     /// Transfer shares from `shareholder_1` to `shareholder_2`.
     public fun transfer_shares(
-        pool: &mut Pool,
+        self: &mut Pool,
         shareholder_1: address,
         shareholder_2: address,
         shares_to_transfer: u64,
     ) {
-        assert!(contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder_1) >= shares_to_transfer, error::invalid_argument(EINSUFFICIENT_SHARES));
+        assert!(contains(self, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
+        assert!(shares(self, shareholder_1) >= shares_to_transfer, error::invalid_argument(EINSUFFICIENT_SHARES));
         if (shares_to_transfer == 0) return;
 
-        deduct_shares(pool, shareholder_1, shares_to_transfer);
-        add_shares(pool, shareholder_2, shares_to_transfer);
+        deduct_shares(self, shareholder_1, shares_to_transfer);
+        add_shares(self, shareholder_2, shares_to_transfer);
     }
 
-    /// Directly deduct `shareholder`'s number of shares in `pool` and return the number of remaining shares.
-    fun deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u64): u64 {
-        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
+    /// Directly deduct `shareholder`'s number of shares in `self` and return the number of remaining shares.
+    fun deduct_shares(self: &mut Pool, shareholder: address, num_shares: u64): u64 {
+        assert!(contains(self, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
+        assert!(shares(self, shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
 
-        let existing_shares = simple_map::borrow_mut(&mut pool.shares, &shareholder);
+        let existing_shares = simple_map::borrow_mut(&mut self.shares, &shareholder);
         *existing_shares = *existing_shares - num_shares;
 
         // Remove the shareholder completely if they have no shares left.
         let remaining_shares = *existing_shares;
         if (remaining_shares == 0) {
-            let (_, shareholder_index) = vector::index_of(&pool.shareholders, &shareholder);
-            vector::remove(&mut pool.shareholders, shareholder_index);
-            simple_map::remove(&mut pool.shares, &shareholder);
+            let (_, shareholder_index) = vector::index_of(&self.shareholders, &shareholder);
+            vector::remove(&mut self.shareholders, shareholder_index);
+            simple_map::remove(&mut self.shares, &shareholder);
         };
 
         remaining_shares
     }
 
-    /// Return the number of new shares `coins_amount` can buy in `pool`.
+    /// Return the number of new shares `coins_amount` can buy in `self`.
     /// `amount` needs to big enough to avoid rounding number.
-    public fun amount_to_shares(pool: &Pool, coins_amount: u64): u64 {
-        amount_to_shares_with_total_coins(pool, coins_amount, pool.total_coins)
+    public fun amount_to_shares(self: &Pool, coins_amount: u64): u64 {
+        amount_to_shares_with_total_coins(self, coins_amount, self.total_coins)
     }
 
-    /// Return the number of new shares `coins_amount` can buy in `pool` with a custom total coins number.
+    /// Return the number of new shares `coins_amount` can buy in `self` with a custom total coins number.
     /// `amount` needs to big enough to avoid rounding number.
-    public fun amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u64 {
+    public fun amount_to_shares_with_total_coins(self: &Pool, coins_amount: u64, total_coins: u64): u64 {
         // No shares yet so amount is worth the same number of shares.
-        if (pool.total_coins == 0 || pool.total_shares == 0) {
+        if (self.total_coins == 0 || self.total_shares == 0) {
             // Multiply by scaling factor to minimize rounding errors during internal calculations for buy ins/redeems.
             // This can overflow but scaling factor is expected to be chosen carefully so this would not overflow.
-            coins_amount * pool.scaling_factor
+            coins_amount * self.scaling_factor
         } else {
             // Shares price = total_coins / total existing shares.
             // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
             // We rearrange the calc and do multiplication first to avoid rounding errors.
-            multiply_then_divide(pool, coins_amount, pool.total_shares, total_coins)
+            multiply_then_divide(self, coins_amount, self.total_shares, total_coins)
         }
     }
 
-    /// Return the number of coins `shares` are worth in `pool`.
+    /// Return the number of coins `shares` are worth in `self`.
     /// `shares` needs to big enough to avoid rounding number.
-    public fun shares_to_amount(pool: &Pool, shares: u64): u64 {
-        shares_to_amount_with_total_coins(pool, shares, pool.total_coins)
+    public fun shares_to_amount(self: &Pool, shares: u64): u64 {
+        shares_to_amount_with_total_coins(self, shares, self.total_coins)
     }
 
-    /// Return the number of coins `shares` are worth in `pool` with a custom total coins number.
+    /// Return the number of coins `shares` are worth in `self` with a custom total coins number.
     /// `shares` needs to big enough to avoid rounding number.
-    public fun shares_to_amount_with_total_coins(pool: &Pool, shares: u64, total_coins: u64): u64 {
+    public fun shares_to_amount_with_total_coins(self: &Pool, shares: u64, total_coins: u64): u64 {
         // No shares or coins yet so shares are worthless.
-        if (pool.total_coins == 0 || pool.total_shares == 0) {
+        if (self.total_coins == 0 || self.total_shares == 0) {
             0
         } else {
             // Shares price = total_coins / total existing shares.
             // Shares worth = shares * shares price = shares * total_coins / total existing shares.
             // We rearrange the calc and do multiplication first to avoid rounding errors.
-            multiply_then_divide(pool, shares, total_coins, pool.total_shares)
+            multiply_then_divide(self, shares, total_coins, self.total_shares)
         }
     }
 
-    public fun multiply_then_divide(_pool: &Pool, x: u64, y: u64, z: u64): u64 {
+    public fun multiply_then_divide(self: &Pool, x: u64, y: u64, z: u64): u64 {
         let result = (to_u128(x) * to_u128(y)) / to_u128(z);
         (result as u64)
     }
@@ -268,7 +268,7 @@ module aptos_std::pool_u64 {
     }
 
     #[test_only]
-    public fun destroy_pool(pool: Pool) {
+    public fun destroy_pool(self: Pool) {
         let Pool {
             shareholders_limit: _,
             total_coins: _,
@@ -276,7 +276,7 @@ module aptos_std::pool_u64 {
             shares: _,
             shareholders: _,
             scaling_factor: _,
-        } = pool;
+        } = self;
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.spec.move
@@ -30,9 +30,9 @@ spec aptos_std::pool_u64 {
         simple_map::spec_contains_key(pool.shares, shareholder)
     }
 
-    spec contains(pool: &Pool, shareholder: address): bool {
+    spec contains(self: &Pool, shareholder: address): bool {
         aborts_if false;
-        ensures result == spec_contains(pool, shareholder);
+        ensures result == spec_contains(self, shareholder);
     }
 
     spec fun spec_shares(pool: Pool, shareholder: address): u64 {
@@ -44,62 +44,62 @@ spec aptos_std::pool_u64 {
         }
     }
 
-    spec shares(pool: &Pool, shareholder: address): u64 {
+    spec shares(self: &Pool, shareholder: address): u64 {
         aborts_if false;
-        ensures result == spec_shares(pool, shareholder);
+        ensures result == spec_shares(self, shareholder);
     }
 
-    spec balance(pool: &Pool, shareholder: address): u64 {
-        let shares = spec_shares(pool, shareholder);
-        let total_coins = pool.total_coins;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+    spec balance(self: &Pool, shareholder: address): u64 {
+        let shares = spec_shares(self, shareholder);
+        let total_coins = self.total_coins;
+        aborts_if self.total_coins > 0 && self.total_shares > 0 && (shares * total_coins) / self.total_shares > MAX_U64;
+        ensures result == spec_shares_to_amount_with_total_coins(self, shares, total_coins);
     }
 
-    spec buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u64 {
-        let new_shares = spec_amount_to_shares_with_total_coins(pool, coins_amount, pool.total_coins);
-        aborts_if pool.total_coins + coins_amount > MAX_U64;
-        aborts_if pool.total_shares + new_shares > MAX_U64;
+    spec buy_in(self: &mut Pool, shareholder: address, coins_amount: u64): u64 {
+        let new_shares = spec_amount_to_shares_with_total_coins(self, coins_amount, self.total_coins);
+        aborts_if self.total_coins + coins_amount > MAX_U64;
+        aborts_if self.total_shares + new_shares > MAX_U64;
         include coins_amount > 0 ==> AddSharesAbortsIf { new_shares: new_shares };
         include coins_amount > 0 ==> AddSharesEnsures { new_shares: new_shares };
-        ensures pool.total_coins == old(pool.total_coins) + coins_amount;
-        ensures pool.total_shares == old(pool.total_shares) + new_shares;
+        ensures self.total_coins == old(self.total_coins) + coins_amount;
+        ensures self.total_shares == old(self.total_shares) + new_shares;
         ensures result == new_shares;
     }
 
-    spec add_shares(pool: &mut Pool, shareholder: address, new_shares: u64): u64 {
+    spec add_shares(self: &mut Pool, shareholder: address, new_shares: u64): u64 {
         include AddSharesAbortsIf;
         include AddSharesEnsures;
 
-        let key_exists = simple_map::spec_contains_key(pool.shares, shareholder);
-        ensures result == if (key_exists) { simple_map::spec_get(pool.shares, shareholder) }
+        let key_exists = simple_map::spec_contains_key(self.shares, shareholder);
+        ensures result == if (key_exists) { simple_map::spec_get(self.shares, shareholder) }
         else { new_shares };
     }
     spec schema AddSharesAbortsIf {
-        pool: Pool;
+        self: Pool;
         shareholder: address;
         new_shares: u64;
 
-        let key_exists = simple_map::spec_contains_key(pool.shares, shareholder);
-        let current_shares = simple_map::spec_get(pool.shares, shareholder);
+        let key_exists = simple_map::spec_contains_key(self.shares, shareholder);
+        let current_shares = simple_map::spec_get(self.shares, shareholder);
 
         aborts_if key_exists && current_shares + new_shares > MAX_U64;
-        aborts_if !key_exists && new_shares > 0 && len(pool.shareholders) >= pool.shareholders_limit;
+        aborts_if !key_exists && new_shares > 0 && len(self.shareholders) >= self.shareholders_limit;
     }
     spec schema AddSharesEnsures {
-        pool: Pool;
+        self: Pool;
         shareholder: address;
         new_shares: u64;
 
-        let key_exists = simple_map::spec_contains_key(pool.shares, shareholder);
-        let current_shares = simple_map::spec_get(pool.shares, shareholder);
+        let key_exists = simple_map::spec_contains_key(self.shares, shareholder);
+        let current_shares = simple_map::spec_get(self.shares, shareholder);
 
         ensures key_exists ==>
-            pool.shares == simple_map::spec_set(old(pool.shares), shareholder, current_shares + new_shares);
+            self.shares == simple_map::spec_set(old(self.shares), shareholder, current_shares + new_shares);
         ensures (!key_exists && new_shares > 0) ==>
-            pool.shares == simple_map::spec_set(old(pool.shares), shareholder, new_shares);
+            self.shares == simple_map::spec_set(old(self.shares), shareholder, new_shares);
         ensures (!key_exists && new_shares > 0) ==>
-            vector::eq_push_back(pool.shareholders, old(pool.shareholders), shareholder);
+            vector::eq_push_back(self.shareholders, old(self.shareholders), shareholder);
     }
 
     spec fun spec_amount_to_shares_with_total_coins(pool: Pool, coins_amount: u64, total_coins: u64): u64 {
@@ -111,19 +111,19 @@ spec aptos_std::pool_u64 {
         }
     }
 
-    spec amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u64 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
-            && (coins_amount * pool.total_shares) / total_coins > MAX_U64;
-        aborts_if (pool.total_coins == 0 || pool.total_shares == 0)
-            && coins_amount * pool.scaling_factor > MAX_U64;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && total_coins == 0;
-        ensures result == spec_amount_to_shares_with_total_coins(pool, coins_amount, total_coins);
+    spec amount_to_shares_with_total_coins(self: &Pool, coins_amount: u64, total_coins: u64): u64 {
+        aborts_if self.total_coins > 0 && self.total_shares > 0
+            && (coins_amount * self.total_shares) / total_coins > MAX_U64;
+        aborts_if (self.total_coins == 0 || self.total_shares == 0)
+            && coins_amount * self.scaling_factor > MAX_U64;
+        aborts_if self.total_coins > 0 && self.total_shares > 0 && total_coins == 0;
+        ensures result == spec_amount_to_shares_with_total_coins(self, coins_amount, total_coins);
     }
 
-    spec shares_to_amount_with_total_coins(pool: &Pool, shares: u64, total_coins: u64): u64 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
-            && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+    spec shares_to_amount_with_total_coins(self: &Pool, shares: u64, total_coins: u64): u64 {
+        aborts_if self.total_coins > 0 && self.total_shares > 0
+            && (shares * total_coins) / self.total_shares > MAX_U64;
+        ensures result == spec_shares_to_amount_with_total_coins(self, shares, total_coins);
     }
 
     spec fun spec_shares_to_amount_with_total_coins(pool: Pool, shares: u64, total_coins: u64): u64 {
@@ -135,52 +135,54 @@ spec aptos_std::pool_u64 {
         }
     }
 
-    spec multiply_then_divide(_pool: &Pool, x: u64, y: u64, z: u64): u64 {
+    spec multiply_then_divide(self: &Pool, x: u64, y: u64, z: u64): u64 {
         aborts_if z == 0;
         aborts_if (x * y) / z > MAX_U64;
         ensures result == (x * y) / z;
     }
 
-    spec redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u64): u64 {
-        let redeemed_coins = spec_shares_to_amount_with_total_coins(pool, shares_to_redeem, pool.total_coins);
-        aborts_if !spec_contains(pool, shareholder);
-        aborts_if spec_shares(pool, shareholder) < shares_to_redeem;
-        aborts_if pool.total_coins < redeemed_coins;
-        aborts_if pool.total_shares < shares_to_redeem;
-        ensures pool.total_coins == old(pool.total_coins) - redeemed_coins;
-        ensures pool.total_shares == old(pool.total_shares) - shares_to_redeem;
-        include shares_to_redeem > 0 ==> DeductSharesEnsures { num_shares: shares_to_redeem };
+    spec redeem_shares(self: &mut Pool, shareholder: address, shares_to_redeem: u64): u64 {
+        let redeemed_coins = spec_shares_to_amount_with_total_coins(self, shares_to_redeem, self.total_coins);
+        aborts_if !spec_contains(self, shareholder);
+        aborts_if spec_shares(self, shareholder) < shares_to_redeem;
+        aborts_if self.total_coins < redeemed_coins;
+        aborts_if self.total_shares < shares_to_redeem;
+        ensures self.total_coins == old(self.total_coins) - redeemed_coins;
+        ensures self.total_shares == old(self.total_shares) - shares_to_redeem;
+        include shares_to_redeem > 0 ==> DeductSharesEnsures {
+            num_shares: shares_to_redeem
+        };
         ensures result == redeemed_coins;
     }
 
     spec transfer_shares(
-        pool: &mut Pool,
+        self: &mut Pool,
         shareholder_1: address,
         shareholder_2: address,
         shares_to_transfer: u64
     ) {
         pragma aborts_if_is_partial;
-        aborts_if !spec_contains(pool, shareholder_1);
-        aborts_if spec_shares(pool, shareholder_1) < shares_to_transfer;
+        aborts_if !spec_contains(self, shareholder_1);
+        aborts_if spec_shares(self, shareholder_1) < shares_to_transfer;
         // TODO: difficult to specify due to the intermediate state problem.
     }
 
-    spec deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u64): u64 {
-        aborts_if !spec_contains(pool, shareholder);
-        aborts_if spec_shares(pool, shareholder) < num_shares;
+    spec deduct_shares(self: &mut Pool, shareholder: address, num_shares: u64): u64 {
+        aborts_if !spec_contains(self, shareholder);
+        aborts_if spec_shares(self, shareholder) < num_shares;
 
         include DeductSharesEnsures;
-        let remaining_shares = simple_map::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> result == simple_map::spec_get(pool.shares, shareholder);
+        let remaining_shares = simple_map::spec_get(self.shares, shareholder) - num_shares;
+        ensures remaining_shares > 0 ==> result == simple_map::spec_get(self.shares, shareholder);
         ensures remaining_shares == 0 ==> result == 0;
     }
     spec schema DeductSharesEnsures {
-        pool: Pool;
+        self: Pool;
         shareholder: address;
         num_shares: u64;
-        let remaining_shares = simple_map::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> simple_map::spec_get(pool.shares, shareholder) == remaining_shares;
-        ensures remaining_shares == 0 ==> !simple_map::spec_contains_key(pool.shares, shareholder);
-        ensures remaining_shares == 0 ==> !vector::spec_contains(pool.shareholders, shareholder);
+        let remaining_shares = simple_map::spec_get(self.shares, shareholder) - num_shares;
+        ensures remaining_shares > 0 ==> simple_map::spec_get(self.shares, shareholder) == remaining_shares;
+        ensures remaining_shares == 0 ==> !simple_map::spec_contains_key(self.shares, shareholder);
+        ensures remaining_shares == 0 ==> !vector::spec_contains(self.shareholders, shareholder);
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.spec.move
@@ -15,9 +15,9 @@ spec aptos_std::pool_u64_unbound {
         table::spec_contains(pool.shares, shareholder)
     }
 
-    spec contains(pool: &Pool, shareholder: address): bool {
+    spec contains(self: &Pool, shareholder: address): bool {
         aborts_if false;
-        ensures result == spec_contains(pool, shareholder);
+        ensures result == spec_contains(self, shareholder);
     }
 
     spec fun spec_shares(pool: Pool, shareholder: address): u64 {
@@ -29,59 +29,59 @@ spec aptos_std::pool_u64_unbound {
         }
     }
 
-    spec shares(pool: &Pool, shareholder: address): u128 {
+    spec shares(self: &Pool, shareholder: address): u128 {
         aborts_if false;
-        ensures result == spec_shares(pool, shareholder);
+        ensures result == spec_shares(self, shareholder);
     }
 
-    spec balance(pool: &Pool, shareholder: address): u64 {
-        let shares = spec_shares(pool, shareholder);
-        let total_coins = pool.total_coins;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+    spec balance(self: &Pool, shareholder: address): u64 {
+        let shares = spec_shares(self, shareholder);
+        let total_coins = self.total_coins;
+        aborts_if self.total_coins > 0 && self.total_shares > 0 && (shares * total_coins) / self.total_shares > MAX_U64;
+        ensures result == spec_shares_to_amount_with_total_coins(self, shares, total_coins);
     }
 
-    spec buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u128 {
-        let new_shares = spec_amount_to_shares_with_total_coins(pool, coins_amount, pool.total_coins);
-        aborts_if pool.total_coins + coins_amount > MAX_U64;
-        aborts_if pool.total_shares + new_shares > MAX_U128;
+    spec buy_in(self: &mut Pool, shareholder: address, coins_amount: u64): u128 {
+        let new_shares = spec_amount_to_shares_with_total_coins(self, coins_amount, self.total_coins);
+        aborts_if self.total_coins + coins_amount > MAX_U64;
+        aborts_if self.total_shares + new_shares > MAX_U128;
         include coins_amount > 0 ==> AddSharesAbortsIf { new_shares: new_shares };
         include coins_amount > 0 ==> AddSharesEnsures { new_shares: new_shares };
-        ensures pool.total_coins == old(pool.total_coins) + coins_amount;
-        ensures pool.total_shares == old(pool.total_shares) + new_shares;
+        ensures self.total_coins == old(self.total_coins) + coins_amount;
+        ensures self.total_shares == old(self.total_shares) + new_shares;
         ensures result == new_shares;
     }
 
-    spec add_shares(pool: &mut Pool, shareholder: address, new_shares: u128): u128 {
+    spec add_shares(self: &mut Pool, shareholder: address, new_shares: u128): u128 {
         include AddSharesAbortsIf;
         include AddSharesEnsures;
 
-        let key_exists = table::spec_contains(pool.shares, shareholder);
-        ensures result == if (key_exists) { table::spec_get(pool.shares, shareholder) }
+        let key_exists = table::spec_contains(self.shares, shareholder);
+        ensures result == if (key_exists) { table::spec_get(self.shares, shareholder) }
         else { new_shares };
     }
     spec schema AddSharesAbortsIf {
-        pool: Pool;
+        self: Pool;
         shareholder: address;
         new_shares: u64;
 
-        let key_exists = table::spec_contains(pool.shares, shareholder);
-        let current_shares = table::spec_get(pool.shares, shareholder);
+        let key_exists = table::spec_contains(self.shares, shareholder);
+        let current_shares = table::spec_get(self.shares, shareholder);
 
         aborts_if key_exists && current_shares + new_shares > MAX_U128;
     }
     spec schema AddSharesEnsures {
-        pool: Pool;
+        self: Pool;
         shareholder: address;
         new_shares: u64;
 
-        let key_exists = table::spec_contains(pool.shares, shareholder);
-        let current_shares = table::spec_get(pool.shares, shareholder);
+        let key_exists = table::spec_contains(self.shares, shareholder);
+        let current_shares = table::spec_get(self.shares, shareholder);
 
         ensures key_exists ==>
-            pool.shares == table::spec_set(old(pool.shares), shareholder, current_shares + new_shares);
+            self.shares == table::spec_set(old(self.shares), shareholder, current_shares + new_shares);
         ensures (!key_exists && new_shares > 0) ==>
-            pool.shares == table::spec_set(old(pool.shares), shareholder, new_shares);
+            self.shares == table::spec_set(old(self.shares), shareholder, new_shares);
     }
 
     spec fun spec_amount_to_shares_with_total_coins(pool: Pool, coins_amount: u64, total_coins: u64): u128 {
@@ -93,19 +93,19 @@ spec aptos_std::pool_u64_unbound {
         }
     }
 
-    spec amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u128 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
-            && (coins_amount * pool.total_shares) / total_coins > MAX_U128;
-        aborts_if (pool.total_coins == 0 || pool.total_shares == 0)
-            && coins_amount * pool.scaling_factor > MAX_U128;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && total_coins == 0;
-        ensures result == spec_amount_to_shares_with_total_coins(pool, coins_amount, total_coins);
+    spec amount_to_shares_with_total_coins(self: &Pool, coins_amount: u64, total_coins: u64): u128 {
+        aborts_if self.total_coins > 0 && self.total_shares > 0
+            && (coins_amount * self.total_shares) / total_coins > MAX_U128;
+        aborts_if (self.total_coins == 0 || self.total_shares == 0)
+            && coins_amount * self.scaling_factor > MAX_U128;
+        aborts_if self.total_coins > 0 && self.total_shares > 0 && total_coins == 0;
+        ensures result == spec_amount_to_shares_with_total_coins(self, coins_amount, total_coins);
     }
 
-    spec shares_to_amount_with_total_coins(pool: &Pool, shares: u128, total_coins: u64): u64 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
-            && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+    spec shares_to_amount_with_total_coins(self: &Pool, shares: u128, total_coins: u64): u64 {
+        aborts_if self.total_coins > 0 && self.total_shares > 0
+            && (shares * total_coins) / self.total_shares > MAX_U64;
+        ensures result == spec_shares_to_amount_with_total_coins(self, shares, total_coins);
     }
 
     spec fun spec_shares_to_amount_with_total_coins(pool: Pool, shares: u128, total_coins: u64): u64 {
@@ -117,63 +117,66 @@ spec aptos_std::pool_u64_unbound {
         }
     }
 
-    spec multiply_then_divide(_pool: &Pool, x: u128, y: u128, z: u128): u128 {
+    spec multiply_then_divide(self: &Pool, x: u128, y: u128, z: u128): u128 {
         aborts_if z == 0;
         aborts_if (x * y) / z > MAX_U128;
         ensures result == (x * y) / z;
     }
 
-    spec redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u128): u64 {
-        let redeemed_coins = spec_shares_to_amount_with_total_coins(pool, shares_to_redeem, pool.total_coins);
-        aborts_if !spec_contains(pool, shareholder);
-        aborts_if spec_shares(pool, shareholder) < shares_to_redeem;
-        aborts_if pool.total_coins < redeemed_coins;
-        aborts_if pool.total_shares < shares_to_redeem;
-        ensures pool.total_coins == old(pool.total_coins) - redeemed_coins;
-        ensures pool.total_shares == old(pool.total_shares) - shares_to_redeem;
-        include shares_to_redeem > 0 ==> DeductSharesEnsures { num_shares: shares_to_redeem };
+    spec redeem_shares(self: &mut Pool, shareholder: address, shares_to_redeem: u128): u64 {
+        let redeemed_coins = spec_shares_to_amount_with_total_coins(self, shares_to_redeem, self.total_coins);
+        aborts_if !spec_contains(self, shareholder);
+        aborts_if spec_shares(self, shareholder) < shares_to_redeem;
+        aborts_if self.total_coins < redeemed_coins;
+        aborts_if self.total_shares < shares_to_redeem;
+        ensures self.total_coins == old(self.total_coins) - redeemed_coins;
+        ensures self.total_shares == old(self.total_shares) - shares_to_redeem;
+        include shares_to_redeem > 0 ==> DeductSharesEnsures {
+            num_shares: shares_to_redeem
+        };
         ensures result == redeemed_coins;
     }
 
     spec transfer_shares(
-    pool: &mut Pool,
+    self: &mut Pool,
     shareholder_1: address,
     shareholder_2: address,
     shares_to_transfer: u128
     ) {
-        aborts_if (shareholder_1 != shareholder_2) && shares_to_transfer > 0 && spec_contains(pool, shareholder_2) &&
-            (spec_shares(pool, shareholder_2) + shares_to_transfer > MAX_U128);
-        aborts_if !spec_contains(pool, shareholder_1);
-        aborts_if spec_shares(pool, shareholder_1) < shares_to_transfer;
-        ensures shareholder_1 == shareholder_2 ==> spec_shares(old(pool), shareholder_1) == spec_shares(pool, shareholder_1);
-        ensures ((shareholder_1 != shareholder_2) && (spec_shares(old(pool), shareholder_1) == shares_to_transfer)) ==>
-            !spec_contains(pool, shareholder_1);
+        aborts_if (shareholder_1 != shareholder_2) && shares_to_transfer > 0 && spec_contains(self, shareholder_2) &&
+            (spec_shares(self, shareholder_2) + shares_to_transfer > MAX_U128);
+        aborts_if !spec_contains(self, shareholder_1);
+        aborts_if spec_shares(self, shareholder_1) < shares_to_transfer;
+        ensures shareholder_1 == shareholder_2 ==> spec_shares(old(self), shareholder_1) == spec_shares(
+            self, shareholder_1);
+        ensures ((shareholder_1 != shareholder_2) && (spec_shares(old(self), shareholder_1) == shares_to_transfer)) ==>
+            !spec_contains(self, shareholder_1);
         ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0) ==>
-            (spec_contains(pool, shareholder_2));
-        ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0 && !spec_contains(old(pool), shareholder_2)) ==>
-            (spec_contains(pool, shareholder_2) && spec_shares(pool, shareholder_2) == shares_to_transfer);
-        ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0 && spec_contains(old(pool), shareholder_2)) ==>
-            (spec_contains(pool, shareholder_2) && spec_shares(pool, shareholder_2) == spec_shares(old(pool), shareholder_2) + shares_to_transfer);
-        ensures ((shareholder_1 != shareholder_2) && (spec_shares(old(pool), shareholder_1) > shares_to_transfer)) ==>
-            (spec_contains(pool, shareholder_1) && (spec_shares(pool, shareholder_1) == spec_shares(old(pool), shareholder_1) - shares_to_transfer));
+            (spec_contains(self, shareholder_2));
+        ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0 && !spec_contains(old(self), shareholder_2)) ==>
+            (spec_contains(self, shareholder_2) && spec_shares(self, shareholder_2) == shares_to_transfer);
+        ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0 && spec_contains(old(self), shareholder_2)) ==>
+            (spec_contains(self, shareholder_2) && spec_shares(self, shareholder_2) == spec_shares(old(self), shareholder_2) + shares_to_transfer);
+        ensures ((shareholder_1 != shareholder_2) && (spec_shares(old(self), shareholder_1) > shares_to_transfer)) ==>
+            (spec_contains(self, shareholder_1) && (spec_shares(self, shareholder_1) == spec_shares(old(self), shareholder_1) - shares_to_transfer));
     }
 
-    spec deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u128): u128 {
-        aborts_if !spec_contains(pool, shareholder);
-        aborts_if spec_shares(pool, shareholder) < num_shares;
+    spec deduct_shares(self: &mut Pool, shareholder: address, num_shares: u128): u128 {
+        aborts_if !spec_contains(self, shareholder);
+        aborts_if spec_shares(self, shareholder) < num_shares;
 
         include DeductSharesEnsures;
-        let remaining_shares = table::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> result == table::spec_get(pool.shares, shareholder);
+        let remaining_shares = table::spec_get(self.shares, shareholder) - num_shares;
+        ensures remaining_shares > 0 ==> result == table::spec_get(self.shares, shareholder);
         ensures remaining_shares == 0 ==> result == 0;
     }
     spec schema DeductSharesEnsures {
-        pool: Pool;
+        self: Pool;
         shareholder: address;
         num_shares: u64;
-        let remaining_shares = table::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> table::spec_get(pool.shares, shareholder) == remaining_shares;
-        ensures remaining_shares == 0 ==> !table::spec_contains(pool.shares, shareholder);
+        let remaining_shares = table::spec_get(self.shares, shareholder) - num_shares;
+        ensures remaining_shares > 0 ==> table::spec_get(self.shares, shareholder) == remaining_shares;
+        ensures remaining_shares == 0 ==> !table::spec_contains(self.shares, shareholder);
     }
 
     spec to_u128(num: u64): u128 {

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
@@ -89,30 +89,32 @@ spec aptos_std::simple_map {
             spec_get(result, vector::borrow(keys, i)) == vector::borrow(values, i);
     }
 
-    spec to_vec_pair<Key: store, Value: store>(map: SimpleMap<Key, Value>): (vector<Key>, vector<Value>) {
+    spec to_vec_pair<Key: store, Value: store>(self: SimpleMap<Key, Value>): (vector<Key>, vector<Value>) {
         pragma intrinsic;
         pragma opaque;
         ensures [abstract]
             forall k: Key: vector::spec_contains(result_1, k) <==>
-                spec_contains_key(map, k);
+                spec_contains_key(self, k);
         ensures [abstract] forall i in 0..len(result_1):
-            spec_get(map, vector::borrow(result_1, i)) == vector::borrow(result_2, i);
+            spec_get(self, vector::borrow(result_1, i)) == vector::borrow(result_2, i);
     }
 
     spec upsert<Key: store, Value: store>(
-        map: &mut SimpleMap<Key, Value>,
+        self: &mut SimpleMap<Key, Value>,
         key: Key,
         value: Value
         ): (std::option::Option<Key>, std::option::Option<Value>) {
         pragma intrinsic;
         pragma opaque;
         aborts_if [abstract] false;
-        ensures [abstract] !spec_contains_key(old(map), key) ==> option::is_none(result_1);
-        ensures [abstract] !spec_contains_key(old(map), key) ==> option::is_none(result_2);
-        ensures [abstract] spec_contains_key(map, key);
-        ensures [abstract] spec_get(map, key) == value;
-        ensures [abstract] spec_contains_key(old(map), key) ==> ((option::is_some(result_1)) && (option::spec_borrow(result_1) == key));
-        ensures [abstract] spec_contains_key(old(map), key) ==> ((option::is_some(result_2)) && (option::spec_borrow(result_2) == spec_get(old(map), key)));
+        ensures [abstract] !spec_contains_key(old(self), key) ==> option::is_none(result_1);
+        ensures [abstract] !spec_contains_key(old(self), key) ==> option::is_none(result_2);
+        ensures [abstract] spec_contains_key(self, key);
+        ensures [abstract] spec_get(self, key) == value;
+        ensures [abstract] spec_contains_key(old(self), key) ==> ((option::is_some(result_1)) && (option::spec_borrow(result_1) == key));
+        ensures [abstract] spec_contains_key(old(self), key) ==> ((option::is_some(result_2)) && (option::spec_borrow(result_2) == spec_get(old(
+            self
+        ), key)));
     }
 
     // Specification functions for tables

--- a/aptos-move/framework/aptos-stdlib/sources/table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table.move
@@ -23,73 +23,73 @@ module aptos_std::table {
     /// Add a new entry to the table. Aborts if an entry for this
     /// key already exists. The entry itself is not stored in the
     /// table, and cannot be discovered from it.
-    public fun add<K: copy + drop, V>(table: &mut Table<K, V>, key: K, val: V) {
-        add_box<K, V, Box<V>>(table, key, Box { val })
+    public fun add<K: copy + drop, V>(self: &mut Table<K, V>, key: K, val: V) {
+        add_box<K, V, Box<V>>(self, key, Box { val })
     }
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow<K: copy + drop, V>(table: &Table<K, V>, key: K): &V {
-        &borrow_box<K, V, Box<V>>(table, key).val
+    public fun borrow<K: copy + drop, V>(self: &Table<K, V>, key: K): &V {
+        &borrow_box<K, V, Box<V>>(self, key).val
     }
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Returns specified default value if there is no entry for `key`.
-    public fun borrow_with_default<K: copy + drop, V>(table: &Table<K, V>, key: K, default: &V): &V {
-        if (!contains(table, copy key)) {
+    public fun borrow_with_default<K: copy + drop, V>(self: &Table<K, V>, key: K, default: &V): &V {
+        if (!contains(self, copy key)) {
             default
         } else {
-            borrow(table, copy key)
+            borrow(self, copy key)
         }
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow_mut<K: copy + drop, V>(table: &mut Table<K, V>, key: K): &mut V {
-        &mut borrow_box_mut<K, V, Box<V>>(table, key).val
+    public fun borrow_mut<K: copy + drop, V>(self: &mut Table<K, V>, key: K): &mut V {
+        &mut borrow_box_mut<K, V, Box<V>>(self, key).val
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
-    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut Table<K, V>, key: K, default: V): &mut V {
-        if (!contains(table, copy key)) {
-            add(table, copy key, default)
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(self: &mut Table<K, V>, key: K, default: V): &mut V {
+        if (!contains(self, copy key)) {
+            add(self, copy key, default)
         };
-        borrow_mut(table, key)
+        borrow_mut(self, key)
     }
 
     /// Insert the pair (`key`, `value`) if there is no entry for `key`.
     /// update the value of the entry for `key` to `value` otherwise
-    public fun upsert<K: copy + drop, V: drop>(table: &mut Table<K, V>, key: K, value: V) {
-        if (!contains(table, copy key)) {
-            add(table, copy key, value)
+    public fun upsert<K: copy + drop, V: drop>(self: &mut Table<K, V>, key: K, value: V) {
+        if (!contains(self, copy key)) {
+            add(self, copy key, value)
         } else {
-            let ref = borrow_mut(table, key);
+            let ref = borrow_mut(self, key);
             *ref = value;
         };
     }
 
-    /// Remove from `table` and return the value which `key` maps to.
+    /// Remove from `self` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun remove<K: copy + drop, V>(table: &mut Table<K, V>, key: K): V {
-        let Box { val } = remove_box<K, V, Box<V>>(table, key);
+    public fun remove<K: copy + drop, V>(self: &mut Table<K, V>, key: K): V {
+        let Box { val } = remove_box<K, V, Box<V>>(self, key);
         val
     }
 
-    /// Returns true iff `table` contains an entry for `key`.
-    public fun contains<K: copy + drop, V>(table: &Table<K, V>, key: K): bool {
-        contains_box<K, V, Box<V>>(table, key)
+    /// Returns true iff `self` contains an entry for `key`.
+    public fun contains<K: copy + drop, V>(self: &Table<K, V>, key: K): bool {
+        contains_box<K, V, Box<V>>(self, key)
     }
 
     #[test_only]
     /// Testing only: allows to drop a table even if it is not empty.
-    public fun drop_unchecked<K: copy + drop, V>(table: Table<K, V>) {
-        drop_unchecked_box<K, V, Box<V>>(table)
+    public fun drop_unchecked<K: copy + drop, V>(self: Table<K, V>) {
+        drop_unchecked_box<K, V, Box<V>>(self)
     }
 
-    public(friend) fun destroy<K: copy + drop, V>(table: Table<K, V>) {
-        destroy_empty_box<K, V, Box<V>>(&table);
-        drop_unchecked_box<K, V, Box<V>>(table)
+    public(friend) fun destroy<K: copy + drop, V>(self: Table<K, V>) {
+        destroy_empty_box<K, V, Box<V>>(&self);
+        drop_unchecked_box<K, V, Box<V>>(self)
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/table_with_length.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table_with_length.move
@@ -25,84 +25,84 @@ module aptos_std::table_with_length {
     }
 
     /// Destroy a table. The table must be empty to succeed.
-    public fun destroy_empty<K: copy + drop, V>(table: TableWithLength<K, V>) {
-        assert!(table.length == 0, error::invalid_state(ENOT_EMPTY));
-        let TableWithLength { inner, length: _ } = table;
+    public fun destroy_empty<K: copy + drop, V>(self: TableWithLength<K, V>) {
+        assert!(self.length == 0, error::invalid_state(ENOT_EMPTY));
+        let TableWithLength { inner, length: _ } = self;
         table::destroy(inner)
     }
 
     /// Add a new entry to the table. Aborts if an entry for this
     /// key already exists. The entry itself is not stored in the
     /// table, and cannot be discovered from it.
-    public fun add<K: copy + drop, V>(table: &mut TableWithLength<K, V>, key: K, val: V) {
-        table::add(&mut table.inner, key, val);
-        table.length = table.length + 1;
+    public fun add<K: copy + drop, V>(self: &mut TableWithLength<K, V>, key: K, val: V) {
+        table::add(&mut self.inner, key, val);
+        self.length = self.length + 1;
     }
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow<K: copy + drop, V>(table: &TableWithLength<K, V>, key: K): &V {
-        table::borrow(&table.inner, key)
+    public fun borrow<K: copy + drop, V>(self: &TableWithLength<K, V>, key: K): &V {
+        table::borrow(&self.inner, key)
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow_mut<K: copy + drop, V>(table: &mut TableWithLength<K, V>, key: K): &mut V {
-        table::borrow_mut(&mut table.inner, key)
+    public fun borrow_mut<K: copy + drop, V>(self: &mut TableWithLength<K, V>, key: K): &mut V {
+        table::borrow_mut(&mut self.inner, key)
     }
 
     /// Returns the length of the table, i.e. the number of entries.
-    public fun length<K: copy + drop, V>(table: &TableWithLength<K, V>): u64 {
-        table.length
+    public fun length<K: copy + drop, V>(self: &TableWithLength<K, V>): u64 {
+        self.length
     }
 
     /// Returns true if this table is empty.
-    public fun empty<K: copy + drop, V>(table: &TableWithLength<K, V>): bool {
-        table.length == 0
+    public fun empty<K: copy + drop, V>(self: &TableWithLength<K, V>): bool {
+        self.length == 0
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
-    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut TableWithLength<K, V>, key: K, default: V): &mut V {
-        if (table::contains(&table.inner, key)) {
-            table::borrow_mut(&mut table.inner, key)
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(self: &mut TableWithLength<K, V>, key: K, default: V): &mut V {
+        if (table::contains(&self.inner, key)) {
+            table::borrow_mut(&mut self.inner, key)
         } else {
-            table::add(&mut table.inner, key, default);
-            table.length = table.length + 1;
-            table::borrow_mut(&mut table.inner, key)
+            table::add(&mut self.inner, key, default);
+            self.length = self.length + 1;
+            table::borrow_mut(&mut self.inner, key)
         }
     }
 
     /// Insert the pair (`key`, `value`) if there is no entry for `key`.
     /// update the value of the entry for `key` to `value` otherwise
-    public fun upsert<K: copy + drop, V: drop>(table: &mut TableWithLength<K, V>, key: K, value: V) {
-        if (!table::contains(&table.inner, key)) {
-            add(table, copy key, value)
+    public fun upsert<K: copy + drop, V: drop>(self: &mut TableWithLength<K, V>, key: K, value: V) {
+        if (!table::contains(&self.inner, key)) {
+            add(self, copy key, value)
         } else {
-            let ref = table::borrow_mut(&mut table.inner, key);
+            let ref = table::borrow_mut(&mut self.inner, key);
             *ref = value;
         };
     }
 
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun remove<K: copy + drop, V>(table: &mut TableWithLength<K, V>, key: K): V {
-        let val = table::remove(&mut table.inner, key);
-        table.length = table.length - 1;
+    public fun remove<K: copy + drop, V>(self: &mut TableWithLength<K, V>, key: K): V {
+        let val = table::remove(&mut self.inner, key);
+        self.length = self.length - 1;
         val
     }
 
     /// Returns true iff `table` contains an entry for `key`.
-    public fun contains<K: copy + drop, V>(table: &TableWithLength<K, V>, key: K): bool {
-        table::contains(&table.inner, key)
+    public fun contains<K: copy + drop, V>(self: &TableWithLength<K, V>, key: K): bool {
+        table::contains(&self.inner, key)
     }
 
     #[test_only]
     /// Drop table even if not empty, only when testing.
-    public fun drop_unchecked<K: copy + drop, V>(table: TableWithLength<K, V>) {
+    public fun drop_unchecked<K: copy + drop, V>(self: TableWithLength<K, V>) {
         // Unpack table with length, dropping length count but not
         // inner table.
-        let TableWithLength{inner, length: _} = table;
+        let TableWithLength{inner, length: _} = self;
         table::drop_unchecked(inner); // Drop inner table.
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -3,7 +3,6 @@ module aptos_std::type_info {
     use std::features;
     use std::string::{Self, String};
     use std::vector;
-
     //
     // Error codes
     //
@@ -24,16 +23,16 @@ module aptos_std::type_info {
     // Public functions
     //
 
-    public fun account_address(type_info: &TypeInfo): address {
-        type_info.account_address
+    public fun account_address(self: &TypeInfo): address {
+        self.account_address
     }
 
-    public fun module_name(type_info: &TypeInfo): vector<u8> {
-        type_info.module_name
+    public fun module_name(self: &TypeInfo): vector<u8> {
+        self.module_name
     }
 
-    public fun struct_name(type_info: &TypeInfo): vector<u8> {
-        type_info.struct_name
+    public fun struct_name(self: &TypeInfo): vector<u8> {
+        self.struct_name
     }
 
     /// Returns the current chain ID, mirroring what `aptos_framework::chain_id::get()` would return, except in `#[test]`
@@ -65,12 +64,14 @@ module aptos_std::type_info {
     /// nesting patterns, as well as `test_size_of_val_vectors()` for an
     /// analysis of vector size dynamism.
     public fun size_of_val<T>(val_ref: &T): u64 {
-        // Return vector length of vectorized BCS representation.
         vector::length(&bcs::to_bytes(val_ref))
     }
 
     #[test_only]
     use aptos_std::table::Table;
+
+    #[test_only]
+    use std::vector;
 
     #[test]
     fun test_type_of() {

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
@@ -30,7 +30,6 @@ spec aptos_std::type_info {
     }
 
     spec size_of_val<T>(val_ref: &T): u64 {
-        aborts_if false;
         ensures result == spec_size_of_val<T>(val_ref);
     }
 }

--- a/aptos-move/framework/move-stdlib/doc/option.md
+++ b/aptos-move/framework/move-stdlib/doc/option.md
@@ -208,10 +208,10 @@ Return an <code><a href="option.md#0x1_option_Option">Option</a></code> containi
 
 ## Function `is_none`
 
-Return true if <code>t</code> does not hold a value
+Return true if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
 </code></pre>
 
 
@@ -220,8 +220,8 @@ Return true if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
-    <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&t.vec)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
+    <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&self.vec)
 }
 </code></pre>
 
@@ -233,10 +233,10 @@ Return true if <code>t</code> does not hold a value
 
 ## Function `is_some`
 
-Return true if <code>t</code> holds a value
+Return true if <code>self</code> holds a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
 </code></pre>
 
 
@@ -245,8 +245,8 @@ Return true if <code>t</code> holds a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
-    !<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&t.vec)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
+    !<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&self.vec)
 }
 </code></pre>
 
@@ -258,11 +258,11 @@ Return true if <code>t</code> holds a value
 
 ## Function `contains`
 
-Return true if the value in <code>t</code> is equal to <code>e_ref</code>
-Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
+Return true if the value in <code>self</code> is equal to <code>e_ref</code>
+Always returns <code><b>false</b></code> if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
 </code></pre>
 
 
@@ -271,8 +271,8 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e_ref: &Element): bool {
-    <a href="vector.md#0x1_vector_contains">vector::contains</a>(&t.vec, e_ref)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e_ref: &Element): bool {
+    <a href="vector.md#0x1_vector_contains">vector::contains</a>(&self.vec, e_ref)
 }
 </code></pre>
 
@@ -284,11 +284,11 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 ## Function `borrow`
 
-Return an immutable reference to the value inside <code>t</code>
-Aborts if <code>t</code> does not hold a value
+Return an immutable reference to the value inside <code>self</code>
+Aborts if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
 </code></pre>
 
 
@@ -297,9 +297,9 @@ Aborts if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &Element {
-    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
-    <a href="vector.md#0x1_vector_borrow">vector::borrow</a>(&t.vec, 0)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &Element {
+    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(self), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <a href="vector.md#0x1_vector_borrow">vector::borrow</a>(&self.vec, 0)
 }
 </code></pre>
 
@@ -311,11 +311,11 @@ Aborts if <code>t</code> does not hold a value
 
 ## Function `borrow_with_default`
 
-Return a reference to the value inside <code>t</code> if it holds one
-Return <code>default_ref</code> if <code>t</code> does not hold a value
+Return a reference to the value inside <code>self</code> if it holds one
+Return <code>default_ref</code> if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
 </code></pre>
 
 
@@ -324,8 +324,8 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, default_ref: &Element): &Element {
-    <b>let</b> vec_ref = &t.vec;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, default_ref: &Element): &Element {
+    <b>let</b> vec_ref = &self.vec;
     <b>if</b> (<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(vec_ref)) default_ref
     <b>else</b> <a href="vector.md#0x1_vector_borrow">vector::borrow</a>(vec_ref, 0)
 }
@@ -339,11 +339,11 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 ## Function `get_with_default`
 
-Return the value inside <code>t</code> if it holds one
-Return <code>default</code> if <code>t</code> does not hold a value
+Return the value inside <code>self</code> if it holds one
+Return <code>default</code> if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
 
@@ -353,10 +353,10 @@ Return <code>default</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b> + drop&gt;(
-    t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;,
+    self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;,
     default: Element,
 ): Element {
-    <b>let</b> vec_ref = &t.vec;
+    <b>let</b> vec_ref = &self.vec;
     <b>if</b> (<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(vec_ref)) default
     <b>else</b> *<a href="vector.md#0x1_vector_borrow">vector::borrow</a>(vec_ref, 0)
 }
@@ -370,11 +370,11 @@ Return <code>default</code> if <code>t</code> does not hold a value
 
 ## Function `fill`
 
-Convert the none option <code>t</code> to a some option by adding <code>e</code>.
-Aborts if <code>t</code> already holds a value
+Convert the none option <code>self</code> to a some option by adding <code>e</code>.
+Aborts if <code>self</code> already holds a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
 </code></pre>
 
 
@@ -383,8 +383,8 @@ Aborts if <code>t</code> already holds a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element) {
-    <b>let</b> vec_ref = &<b>mut</b> t.vec;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element) {
+    <b>let</b> vec_ref = &<b>mut</b> self.vec;
     <b>if</b> (<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(vec_ref)) <a href="vector.md#0x1_vector_push_back">vector::push_back</a>(vec_ref, e)
     <b>else</b> <b>abort</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>
 }
@@ -398,11 +398,11 @@ Aborts if <code>t</code> already holds a value
 
 ## Function `extract`
 
-Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>t</code>
-Aborts if <code>t</code> does not hold a value
+Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>self</code>
+Aborts if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
 </code></pre>
 
 
@@ -411,9 +411,9 @@ Aborts if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
-    <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> t.vec)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
+    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(self), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> self.vec)
 }
 </code></pre>
 
@@ -425,11 +425,11 @@ Aborts if <code>t</code> does not hold a value
 
 ## Function `borrow_mut`
 
-Return a mutable reference to the value inside <code>t</code>
-Aborts if <code>t</code> does not hold a value
+Return a mutable reference to the value inside <code>self</code>
+Aborts if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
 </code></pre>
 
 
@@ -438,9 +438,9 @@ Aborts if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &<b>mut</b> Element {
-    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
-    <a href="vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> t.vec, 0)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &<b>mut</b> Element {
+    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(self), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <a href="vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.vec, 0)
 }
 </code></pre>
 
@@ -452,11 +452,11 @@ Aborts if <code>t</code> does not hold a value
 
 ## Function `swap`
 
-Swap the old value inside <code>t</code> with <code>e</code> and return the old value
-Aborts if <code>t</code> does not hold a value
+Swap the old value inside <code>self</code> with <code>e</code> and return the old value
+Aborts if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
 </code></pre>
 
 
@@ -465,9 +465,9 @@ Aborts if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): Element {
-    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
-    <b>let</b> vec_ref = &<b>mut</b> t.vec;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): Element {
+    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(self), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>let</b> vec_ref = &<b>mut</b> self.vec;
     <b>let</b> old_value = <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(vec_ref);
     <a href="vector.md#0x1_vector_push_back">vector::push_back</a>(vec_ref, e);
     old_value
@@ -482,12 +482,12 @@ Aborts if <code>t</code> does not hold a value
 
 ## Function `swap_or_fill`
 
-Swap the old value inside <code>t</code> with <code>e</code> and return the old value;
+Swap the old value inside <code>self</code> with <code>e</code> and return the old value;
 or if there is no old value, fill it with <code>e</code>.
-Different from swap(), swap_or_fill() allows for <code>t</code> not holding a value.
+Different from swap(), swap_or_fill() allows for <code>self</code> not holding a value.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
 </code></pre>
 
 
@@ -496,8 +496,8 @@ Different from swap(), swap_or_fill() allows for <code>t</code> not holding a va
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
-    <b>let</b> vec_ref = &<b>mut</b> t.vec;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
+    <b>let</b> vec_ref = &<b>mut</b> self.vec;
     <b>let</b> old_value = <b>if</b> (<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(vec_ref)) <a href="option.md#0x1_option_none">none</a>()
         <b>else</b> <a href="option.md#0x1_option_some">some</a>(<a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(vec_ref));
     <a href="vector.md#0x1_vector_push_back">vector::push_back</a>(vec_ref, e);
@@ -513,10 +513,10 @@ Different from swap(), swap_or_fill() allows for <code>t</code> not holding a va
 
 ## Function `destroy_with_default`
 
-Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
+Destroys <code>self.</code> If <code>self</code> holds a value, return it. Returns <code>default</code> otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
 
@@ -525,8 +525,8 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, default: Element): Element {
-    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = t;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, default: Element): Element {
+    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = self;
     <b>if</b> (<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<b>mut</b> vec)) default
     <b>else</b> <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> vec)
 }
@@ -540,11 +540,11 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 
 ## Function `destroy_some`
 
-Unpack <code>t</code> and return its contents
-Aborts if <code>t</code> does not hold a value
+Unpack <code>self</code> and return its contents
+Aborts if <code>self</code> does not hold a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
 </code></pre>
 
 
@@ -553,9 +553,9 @@ Aborts if <code>t</code> does not hold a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(&t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
-    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = t;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
+    <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(&self), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
+    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = self;
     <b>let</b> elem = <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> vec);
     <a href="vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(vec);
     elem
@@ -570,11 +570,11 @@ Aborts if <code>t</code> does not hold a value
 
 ## Function `destroy_none`
 
-Unpack <code>t</code>
-Aborts if <code>t</code> holds a value
+Unpack <code>self</code>
+Aborts if <code>self</code> holds a value
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
 </code></pre>
 
 
@@ -583,9 +583,9 @@ Aborts if <code>t</code> holds a value
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;) {
-    <b>assert</b>!(<a href="option.md#0x1_option_is_none">is_none</a>(&t), <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>);
-    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = t;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;) {
+    <b>assert</b>!(<a href="option.md#0x1_option_is_none">is_none</a>(&self), <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>);
+    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = self;
     <a href="vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(vec)
 }
 </code></pre>
@@ -598,11 +598,11 @@ Aborts if <code>t</code> holds a value
 
 ## Function `to_vec`
 
-Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
+Convert <code>self</code> into a vector of length 1 if it is <code>Some</code>,
 and an empty vector otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
 </code></pre>
 
 
@@ -611,8 +611,8 @@ and an empty vector otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
-    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = t;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
+    <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = self;
     vec
 }
 </code></pre>
@@ -628,7 +628,7 @@ and an empty vector otherwise
 Apply the function to the optional element, consuming it. Does nothing if no value present.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|)
 </code></pre>
 
 
@@ -637,11 +637,11 @@ Apply the function to the optional element, consuming it. Does nothing if no val
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |Element|) {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&o)) {
-        f(<a href="option.md#0x1_option_destroy_some">destroy_some</a>(o))
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |Element|) {
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&self)) {
+        f(<a href="option.md#0x1_option_destroy_some">destroy_some</a>(self))
     } <b>else</b> {
-        <a href="option.md#0x1_option_destroy_none">destroy_none</a>(o)
+        <a href="option.md#0x1_option_destroy_none">destroy_none</a>(self)
     }
 }
 </code></pre>
@@ -657,7 +657,7 @@ Apply the function to the optional element, consuming it. Does nothing if no val
 Apply the function to the optional element reference. Does nothing if no value present.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|)
 </code></pre>
 
 
@@ -666,9 +666,9 @@ Apply the function to the optional element reference. Does nothing if no value p
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&Element|) {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(o)) {
-        f(<a href="option.md#0x1_option_borrow">borrow</a>(o))
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&Element|) {
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(self)) {
+        f(<a href="option.md#0x1_option_borrow">borrow</a>(self))
     }
 }
 </code></pre>
@@ -684,7 +684,7 @@ Apply the function to the optional element reference. Does nothing if no value p
 Apply the function to the optional element reference. Does nothing if no value present.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(o: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|)
 </code></pre>
 
 
@@ -693,9 +693,9 @@ Apply the function to the optional element reference. Does nothing if no value p
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(o: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|) {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(o)) {
-        f(<a href="option.md#0x1_option_borrow_mut">borrow_mut</a>(o))
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|) {
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(self)) {
+        f(<a href="option.md#0x1_option_borrow_mut">borrow_mut</a>(self))
     }
 }
 </code></pre>
@@ -711,7 +711,7 @@ Apply the function to the optional element reference. Does nothing if no value p
 Folds the function over the optional element.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fold">fold</a>&lt;Accumulator, Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, init: Accumulator, f: |(Accumulator, Element)|Accumulator): Accumulator
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fold">fold</a>&lt;Accumulator, Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, init: Accumulator, f: |(Accumulator, Element)|Accumulator): Accumulator
 </code></pre>
 
 
@@ -721,14 +721,14 @@ Folds the function over the optional element.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_fold">fold</a>&lt;Accumulator, Element&gt;(
-    o: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;,
+    self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;,
     init: Accumulator,
     f: |Accumulator,Element|Accumulator
 ): Accumulator {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&o)) {
-        f(init, <a href="option.md#0x1_option_destroy_some">destroy_some</a>(o))
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&self)) {
+        f(init, <a href="option.md#0x1_option_destroy_some">destroy_some</a>(self))
     } <b>else</b> {
-        <a href="option.md#0x1_option_destroy_none">destroy_none</a>(o);
+        <a href="option.md#0x1_option_destroy_none">destroy_none</a>(self);
         init
     }
 }
@@ -745,7 +745,7 @@ Folds the function over the optional element.
 Maps the content of an option.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_map">map</a>&lt;Element, OtherElement&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|OtherElement): <a href="option.md#0x1_option_Option">option::Option</a>&lt;OtherElement&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_map">map</a>&lt;Element, OtherElement&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|OtherElement): <a href="option.md#0x1_option_Option">option::Option</a>&lt;OtherElement&gt;
 </code></pre>
 
 
@@ -754,11 +754,11 @@ Maps the content of an option.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_map">map</a>&lt;Element, OtherElement&gt;(o: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |Element|OtherElement): <a href="option.md#0x1_option_Option">Option</a>&lt;OtherElement&gt; {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&o)) {
-        <a href="option.md#0x1_option_some">some</a>(f(<a href="option.md#0x1_option_destroy_some">destroy_some</a>(o)))
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_map">map</a>&lt;Element, OtherElement&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |Element|OtherElement): <a href="option.md#0x1_option_Option">Option</a>&lt;OtherElement&gt; {
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&self)) {
+        <a href="option.md#0x1_option_some">some</a>(f(<a href="option.md#0x1_option_destroy_some">destroy_some</a>(self)))
     } <b>else</b> {
-        <a href="option.md#0x1_option_destroy_none">destroy_none</a>(o);
+        <a href="option.md#0x1_option_destroy_none">destroy_none</a>(self);
         <a href="option.md#0x1_option_none">none</a>()
     }
 }
@@ -775,7 +775,7 @@ Maps the content of an option.
 Maps the content of an option without destroying the original option.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_map_ref">map_ref</a>&lt;Element, OtherElement&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|OtherElement): <a href="option.md#0x1_option_Option">option::Option</a>&lt;OtherElement&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_map_ref">map_ref</a>&lt;Element, OtherElement&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|OtherElement): <a href="option.md#0x1_option_Option">option::Option</a>&lt;OtherElement&gt;
 </code></pre>
 
 
@@ -785,9 +785,9 @@ Maps the content of an option without destroying the original option.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_map_ref">map_ref</a>&lt;Element, OtherElement&gt;(
-    o: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&Element|OtherElement): <a href="option.md#0x1_option_Option">Option</a>&lt;OtherElement&gt; {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(o)) {
-        <a href="option.md#0x1_option_some">some</a>(f(<a href="option.md#0x1_option_borrow">borrow</a>(o)))
+    self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&Element|OtherElement): <a href="option.md#0x1_option_Option">Option</a>&lt;OtherElement&gt; {
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(self)) {
+        <a href="option.md#0x1_option_some">some</a>(f(<a href="option.md#0x1_option_borrow">borrow</a>(self)))
     } <b>else</b> {
         <a href="option.md#0x1_option_none">none</a>()
     }
@@ -805,7 +805,7 @@ Maps the content of an option without destroying the original option.
 Filters the content of an option
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_filter">filter</a>&lt;Element: drop&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|bool): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_filter">filter</a>&lt;Element: drop&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|bool): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
 </code></pre>
 
 
@@ -814,9 +814,9 @@ Filters the content of an option
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_filter">filter</a>&lt;Element:drop&gt;(o: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&Element|bool): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
-    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&o) && f(<a href="option.md#0x1_option_borrow">borrow</a>(&o))) {
-        o
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_filter">filter</a>&lt;Element:drop&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, f: |&Element|bool): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
+    <b>if</b> (<a href="option.md#0x1_option_is_some">is_some</a>(&self) && f(<a href="option.md#0x1_option_borrow">borrow</a>(&self))) {
+        self
     } <b>else</b> {
         <a href="option.md#0x1_option_none">none</a>()
     }
@@ -834,7 +834,7 @@ Filters the content of an option
 Returns true if the option contains an element which satisfies predicate.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_any">any</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, p: |&Element|bool): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_any">any</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, p: |&Element|bool): bool
 </code></pre>
 
 
@@ -843,8 +843,8 @@ Returns true if the option contains an element which satisfies predicate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_any">any</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, p: |&Element|bool): bool {
-    <a href="option.md#0x1_option_is_some">is_some</a>(o) && p(<a href="option.md#0x1_option_borrow">borrow</a>(o))
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_any">any</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, p: |&Element|bool): bool {
+    <a href="option.md#0x1_option_is_some">is_some</a>(self) && p(<a href="option.md#0x1_option_borrow">borrow</a>(self))
 }
 </code></pre>
 
@@ -859,7 +859,7 @@ Returns true if the option contains an element which satisfies predicate.
 Utility function to destroy an option that is not droppable.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy">destroy</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, d: |Element|)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy">destroy</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, d: |Element|)
 </code></pre>
 
 
@@ -868,8 +868,8 @@ Utility function to destroy an option that is not droppable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_destroy">destroy</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, d: |Element|) {
-    <b>let</b> vec = <a href="option.md#0x1_option_to_vec">to_vec</a>(o);
+<pre><code><b>public</b> inline <b>fun</b> <a href="option.md#0x1_option_destroy">destroy</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, d: |Element|) {
+    <b>let</b> vec = <a href="option.md#0x1_option_to_vec">to_vec</a>(self);
     <a href="vector.md#0x1_vector_destroy">vector::destroy</a>(vec, |e| d(e));
 }
 </code></pre>
@@ -900,8 +900,8 @@ Utility function to destroy an option that is not droppable.
 
 
 <pre><code><b>schema</b> <a href="option.md#0x1_option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt; {
-    t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;;
-    <b>aborts_if</b> <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>(t) <b>with</b> <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>;
+    self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;;
+    <b>aborts_if</b> <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>(self) <b>with</b> <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>;
 }
 </code></pre>
 
@@ -1015,7 +1015,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `is_none`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
 </code></pre>
 
 
@@ -1023,7 +1023,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>(t);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>(self);
 </code></pre>
 
 
@@ -1032,8 +1032,8 @@ because it's 0 for "none" or 1 for "some".
 <a id="0x1_option_spec_is_none"></a>
 
 
-<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
-   <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(t.vec)
+<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
+   <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(self.vec)
 }
 </code></pre>
 
@@ -1044,7 +1044,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `is_some`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
 </code></pre>
 
 
@@ -1052,7 +1052,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self);
 </code></pre>
 
 
@@ -1061,8 +1061,8 @@ because it's 0 for "none" or 1 for "some".
 <a id="0x1_option_spec_is_some"></a>
 
 
-<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
-   !<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(t.vec)
+<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
+   !<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(self.vec)
 }
 </code></pre>
 
@@ -1073,7 +1073,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `contains`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
 </code></pre>
 
 
@@ -1081,7 +1081,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_contains">spec_contains</a>(t, e_ref);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_contains">spec_contains</a>(self, e_ref);
 </code></pre>
 
 
@@ -1090,8 +1090,8 @@ because it's 0 for "none" or 1 for "some".
 <a id="0x1_option_spec_contains"></a>
 
 
-<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_contains">spec_contains</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): bool {
-   <a href="option.md#0x1_option_is_some">is_some</a>(t) && <a href="option.md#0x1_option_borrow">borrow</a>(t) == e
+<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_contains">spec_contains</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): bool {
+   <a href="option.md#0x1_option_is_some">is_some</a>(self) && <a href="option.md#0x1_option_borrow">borrow</a>(self) == e
 }
 </code></pre>
 
@@ -1102,7 +1102,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `borrow`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
 </code></pre>
 
 
@@ -1110,7 +1110,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="option.md#0x1_option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self);
 </code></pre>
 
 
@@ -1119,8 +1119,8 @@ because it's 0 for "none" or 1 for "some".
 <a id="0x1_option_spec_borrow"></a>
 
 
-<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
-   t.vec[0]
+<pre><code><b>fun</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
+   self.vec[0]
 }
 </code></pre>
 
@@ -1131,7 +1131,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `borrow_with_default`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
 </code></pre>
 
 
@@ -1139,7 +1139,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == (<b>if</b> (<a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t)) <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t) <b>else</b> default_ref);
+<b>ensures</b> result == (<b>if</b> (<a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self)) <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self) <b>else</b> default_ref);
 </code></pre>
 
 
@@ -1149,7 +1149,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `get_with_default`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(self: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
 
@@ -1157,7 +1157,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == (<b>if</b> (<a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t)) <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t) <b>else</b> default);
+<b>ensures</b> result == (<b>if</b> (<a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self)) <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self) <b>else</b> default);
 </code></pre>
 
 
@@ -1167,16 +1167,16 @@ because it's 0 for "none" or 1 for "some".
 ### Function `fill`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t) <b>with</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>;
-<b>ensures</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t);
-<b>ensures</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t) == e;
+<b>aborts_if</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self) <b>with</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>;
+<b>ensures</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self);
+<b>ensures</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self) == e;
 </code></pre>
 
 
@@ -1186,7 +1186,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `extract`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
 </code></pre>
 
 
@@ -1194,8 +1194,8 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="option.md#0x1_option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(<b>old</b>(t));
-<b>ensures</b> <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>(t);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(<b>old</b>(self));
+<b>ensures</b> <a href="option.md#0x1_option_spec_is_none">spec_is_none</a>(self);
 </code></pre>
 
 
@@ -1205,15 +1205,15 @@ because it's 0 for "none" or 1 for "some".
 ### Function `borrow_mut`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
 </code></pre>
 
 
 
 
 <pre><code><b>include</b> <a href="option.md#0x1_option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t);
-<b>ensures</b> t == <b>old</b>(t);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self);
+<b>ensures</b> self == <b>old</b>(self);
 </code></pre>
 
 
@@ -1223,7 +1223,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `swap`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
 </code></pre>
 
 
@@ -1231,9 +1231,9 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="option.md#0x1_option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(<b>old</b>(t));
-<b>ensures</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t);
-<b>ensures</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t) == e;
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(<b>old</b>(self));
+<b>ensures</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self);
+<b>ensures</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self) == e;
 </code></pre>
 
 
@@ -1243,7 +1243,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `swap_or_fill`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(self: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
 </code></pre>
 
 
@@ -1251,8 +1251,8 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <b>old</b>(t);
-<b>ensures</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t) == e;
+<b>ensures</b> result == <b>old</b>(self);
+<b>ensures</b> <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self) == e;
 </code></pre>
 
 
@@ -1262,7 +1262,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `destroy_with_default`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
 
@@ -1270,7 +1270,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == (<b>if</b> (<a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t)) <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t) <b>else</b> default);
+<b>ensures</b> result == (<b>if</b> (<a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self)) <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self) <b>else</b> default);
 </code></pre>
 
 
@@ -1280,7 +1280,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `destroy_some`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
 </code></pre>
 
 
@@ -1288,7 +1288,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>include</b> <a href="option.md#0x1_option_AbortsIfNone">AbortsIfNone</a>&lt;Element&gt;;
-<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(t);
+<b>ensures</b> result == <a href="option.md#0x1_option_spec_borrow">spec_borrow</a>(self);
 </code></pre>
 
 
@@ -1298,14 +1298,14 @@ because it's 0 for "none" or 1 for "some".
 ### Function `destroy_none`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
 </code></pre>
 
 
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(t) <b>with</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>;
+<b>aborts_if</b> <a href="option.md#0x1_option_spec_is_some">spec_is_some</a>(self) <b>with</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>;
 </code></pre>
 
 
@@ -1315,7 +1315,7 @@ because it's 0 for "none" or 1 for "some".
 ### Function `to_vec`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(self: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
 </code></pre>
 
 
@@ -1323,7 +1323,7 @@ because it's 0 for "none" or 1 for "some".
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == t.vec;
+<b>ensures</b> result == self.vec;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/string.md
+++ b/aptos-move/framework/move-stdlib/doc/string.md
@@ -150,7 +150,7 @@ Tries to create a new string from a sequence of bytes.
 Returns a reference to the underlying byte vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_bytes">bytes</a>(s: &<a href="string.md#0x1_string_String">string::String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_bytes">bytes</a>(self: &<a href="string.md#0x1_string_String">string::String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -159,8 +159,8 @@ Returns a reference to the underlying byte vector.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_bytes">bytes</a>(s: &<a href="string.md#0x1_string_String">String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    &s.bytes
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_bytes">bytes</a>(self: &<a href="string.md#0x1_string_String">String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    &self.bytes
 }
 </code></pre>
 
@@ -175,7 +175,7 @@ Returns a reference to the underlying byte vector.
 Checks whether this string is empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="string.md#0x1_string_String">string::String</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_is_empty">is_empty</a>(self: &<a href="string.md#0x1_string_String">string::String</a>): bool
 </code></pre>
 
 
@@ -184,8 +184,8 @@ Checks whether this string is empty.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="string.md#0x1_string_String">String</a>): bool {
-    <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&s.bytes)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_is_empty">is_empty</a>(self: &<a href="string.md#0x1_string_String">String</a>): bool {
+    <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&self.bytes)
 }
 </code></pre>
 
@@ -200,7 +200,7 @@ Checks whether this string is empty.
 Returns the length of this string, in bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_length">length</a>(s: &<a href="string.md#0x1_string_String">string::String</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_length">length</a>(self: &<a href="string.md#0x1_string_String">string::String</a>): u64
 </code></pre>
 
 
@@ -209,8 +209,8 @@ Returns the length of this string, in bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_length">length</a>(s: &<a href="string.md#0x1_string_String">String</a>): u64 {
-    <a href="vector.md#0x1_vector_length">vector::length</a>(&s.bytes)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_length">length</a>(self: &<a href="string.md#0x1_string_String">String</a>): u64 {
+    <a href="vector.md#0x1_vector_length">vector::length</a>(&self.bytes)
 }
 </code></pre>
 
@@ -225,7 +225,7 @@ Returns the length of this string, in bytes.
 Appends a string.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, r: <a href="string.md#0x1_string_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append">append</a>(self: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, r: <a href="string.md#0x1_string_String">string::String</a>)
 </code></pre>
 
 
@@ -234,8 +234,8 @@ Appends a string.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, r: <a href="string.md#0x1_string_String">String</a>) {
-    <a href="vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> s.bytes, r.bytes)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append">append</a>(self: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, r: <a href="string.md#0x1_string_String">String</a>) {
+    <a href="vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> self.bytes, r.bytes)
 }
 </code></pre>
 
@@ -250,7 +250,7 @@ Appends a string.
 Appends bytes which must be in valid utf8 format.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append_utf8">append_utf8</a>(self: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -259,8 +259,8 @@ Appends bytes which must be in valid utf8 format.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
-    <a href="string.md#0x1_string_append">append</a>(s, <a href="string.md#0x1_string_utf8">utf8</a>(bytes))
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append_utf8">append_utf8</a>(self: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+    <a href="string.md#0x1_string_append">append</a>(self, <a href="string.md#0x1_string_utf8">utf8</a>(bytes))
 }
 </code></pre>
 
@@ -276,7 +276,7 @@ Insert the other string at the byte index in given string. The index must be at 
 boundary.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="string.md#0x1_string_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_insert">insert</a>(self: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="string.md#0x1_string_String">string::String</a>)
 </code></pre>
 
 
@@ -285,15 +285,15 @@ boundary.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, at: u64, o: <a href="string.md#0x1_string_String">String</a>) {
-    <b>let</b> bytes = &s.bytes;
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_insert">insert</a>(self: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, at: u64, o: <a href="string.md#0x1_string_String">String</a>) {
+    <b>let</b> bytes = &self.bytes;
     <b>assert</b>!(at &lt;= <a href="vector.md#0x1_vector_length">vector::length</a>(bytes) && <a href="string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, at), <a href="string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>);
-    <b>let</b> l = <a href="string.md#0x1_string_length">length</a>(s);
-    <b>let</b> front = <a href="string.md#0x1_string_sub_string">sub_string</a>(s, 0, at);
-    <b>let</b> end = <a href="string.md#0x1_string_sub_string">sub_string</a>(s, at, l);
+    <b>let</b> l = <a href="string.md#0x1_string_length">length</a>(self);
+    <b>let</b> front = <a href="string.md#0x1_string_sub_string">sub_string</a>(self, 0, at);
+    <b>let</b> end = <a href="string.md#0x1_string_sub_string">sub_string</a>(self, at, l);
     <a href="string.md#0x1_string_append">append</a>(&<b>mut</b> front, o);
     <a href="string.md#0x1_string_append">append</a>(&<b>mut</b> front, end);
-    *s = front;
+    *self = front;
 }
 </code></pre>
 
@@ -310,7 +310,7 @@ of the first byte not included (or the length of the string). The indices must b
 guaranteeing that the result is valid utf8.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="string.md#0x1_string_String">string::String</a>
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_sub_string">sub_string</a>(self: &<a href="string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="string.md#0x1_string_String">string::String</a>
 </code></pre>
 
 
@@ -319,8 +319,8 @@ guaranteeing that the result is valid utf8.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="string.md#0x1_string_String">String</a> {
-    <b>let</b> bytes = &s.bytes;
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_sub_string">sub_string</a>(self: &<a href="string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="string.md#0x1_string_String">String</a> {
+    <b>let</b> bytes = &self.bytes;
     <b>let</b> l = <a href="vector.md#0x1_vector_length">vector::length</a>(bytes);
     <b>assert</b>!(
         j &lt;= l && i &lt;= j && <a href="string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, i) && <a href="string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(bytes, j),
@@ -341,7 +341,7 @@ guaranteeing that the result is valid utf8.
 Computes the index of the first occurrence of a string. Returns <code><a href="string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_index_of">index_of</a>(s: &<a href="string.md#0x1_string_String">string::String</a>, r: &<a href="string.md#0x1_string_String">string::String</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_index_of">index_of</a>(self: &<a href="string.md#0x1_string_String">string::String</a>, r: &<a href="string.md#0x1_string_String">string::String</a>): u64
 </code></pre>
 
 
@@ -350,8 +350,8 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_index_of">index_of</a>(s: &<a href="string.md#0x1_string_String">String</a>, r: &<a href="string.md#0x1_string_String">String</a>): u64 {
-    <a href="string.md#0x1_string_internal_index_of">internal_index_of</a>(&s.bytes, &r.bytes)
+<pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_index_of">index_of</a>(self: &<a href="string.md#0x1_string_String">String</a>, r: &<a href="string.md#0x1_string_String">String</a>): u64 {
+    <a href="string.md#0x1_string_internal_index_of">internal_index_of</a>(&self.bytes, &r.bytes)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/option.move
+++ b/aptos-move/framework/move-stdlib/sources/option.move
@@ -57,134 +57,134 @@ module std::option {
         aborts_if vector::length(vec) > 1;
     }
 
-    /// Return true if `t` does not hold a value
-    public fun is_none<Element>(t: &Option<Element>): bool {
-        vector::is_empty(&t.vec)
+    /// Return true if `self` does not hold a value
+    public fun is_none<Element>(self: &Option<Element>): bool {
+        vector::is_empty(&self.vec)
     }
     spec is_none {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_is_none(t);
+        ensures result == spec_is_none(self);
     }
-    spec fun spec_is_none<Element>(t: Option<Element>): bool {
-        vector::is_empty(t.vec)
+    spec fun spec_is_none<Element>(self: Option<Element>): bool {
+        vector::is_empty(self.vec)
     }
 
-    /// Return true if `t` holds a value
-    public fun is_some<Element>(t: &Option<Element>): bool {
-        !vector::is_empty(&t.vec)
+    /// Return true if `self` holds a value
+    public fun is_some<Element>(self: &Option<Element>): bool {
+        !vector::is_empty(&self.vec)
     }
     spec is_some {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_is_some(t);
+        ensures result == spec_is_some(self);
     }
-    spec fun spec_is_some<Element>(t: Option<Element>): bool {
-        !vector::is_empty(t.vec)
+    spec fun spec_is_some<Element>(self: Option<Element>): bool {
+        !vector::is_empty(self.vec)
     }
 
-    /// Return true if the value in `t` is equal to `e_ref`
-    /// Always returns `false` if `t` does not hold a value
-    public fun contains<Element>(t: &Option<Element>, e_ref: &Element): bool {
-        vector::contains(&t.vec, e_ref)
+    /// Return true if the value in `self` is equal to `e_ref`
+    /// Always returns `false` if `self` does not hold a value
+    public fun contains<Element>(self: &Option<Element>, e_ref: &Element): bool {
+        vector::contains(&self.vec, e_ref)
     }
     spec contains {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_contains(t, e_ref);
+        ensures result == spec_contains(self, e_ref);
     }
-    spec fun spec_contains<Element>(t: Option<Element>, e: Element): bool {
-        is_some(t) && borrow(t) == e
+    spec fun spec_contains<Element>(self: Option<Element>, e: Element): bool {
+        is_some(self) && borrow(self) == e
     }
 
-    /// Return an immutable reference to the value inside `t`
-    /// Aborts if `t` does not hold a value
-    public fun borrow<Element>(t: &Option<Element>): &Element {
-        assert!(is_some(t), EOPTION_NOT_SET);
-        vector::borrow(&t.vec, 0)
+    /// Return an immutable reference to the value inside `self`
+    /// Aborts if `self` does not hold a value
+    public fun borrow<Element>(self: &Option<Element>): &Element {
+        assert!(is_some(self), EOPTION_NOT_SET);
+        vector::borrow(&self.vec, 0)
     }
     spec borrow {
         pragma opaque;
         include AbortsIfNone<Element>;
-        ensures result == spec_borrow(t);
+        ensures result == spec_borrow(self);
     }
-    spec fun spec_borrow<Element>(t: Option<Element>): Element {
-        t.vec[0]
+    spec fun spec_borrow<Element>(self: Option<Element>): Element {
+        self.vec[0]
     }
 
-    /// Return a reference to the value inside `t` if it holds one
-    /// Return `default_ref` if `t` does not hold a value
-    public fun borrow_with_default<Element>(t: &Option<Element>, default_ref: &Element): &Element {
-        let vec_ref = &t.vec;
+    /// Return a reference to the value inside `self` if it holds one
+    /// Return `default_ref` if `self` does not hold a value
+    public fun borrow_with_default<Element>(self: &Option<Element>, default_ref: &Element): &Element {
+        let vec_ref = &self.vec;
         if (vector::is_empty(vec_ref)) default_ref
         else vector::borrow(vec_ref, 0)
     }
     spec borrow_with_default {
         pragma opaque;
         aborts_if false;
-        ensures result == (if (spec_is_some(t)) spec_borrow(t) else default_ref);
+        ensures result == (if (spec_is_some(self)) spec_borrow(self) else default_ref);
     }
 
-    /// Return the value inside `t` if it holds one
-    /// Return `default` if `t` does not hold a value
+    /// Return the value inside `self` if it holds one
+    /// Return `default` if `self` does not hold a value
     public fun get_with_default<Element: copy + drop>(
-        t: &Option<Element>,
+        self: &Option<Element>,
         default: Element,
     ): Element {
-        let vec_ref = &t.vec;
+        let vec_ref = &self.vec;
         if (vector::is_empty(vec_ref)) default
         else *vector::borrow(vec_ref, 0)
     }
     spec get_with_default {
         pragma opaque;
         aborts_if false;
-        ensures result == (if (spec_is_some(t)) spec_borrow(t) else default);
+        ensures result == (if (spec_is_some(self)) spec_borrow(self) else default);
     }
 
-    /// Convert the none option `t` to a some option by adding `e`.
-    /// Aborts if `t` already holds a value
-    public fun fill<Element>(t: &mut Option<Element>, e: Element) {
-        let vec_ref = &mut t.vec;
+    /// Convert the none option `self` to a some option by adding `e`.
+    /// Aborts if `self` already holds a value
+    public fun fill<Element>(self: &mut Option<Element>, e: Element) {
+        let vec_ref = &mut self.vec;
         if (vector::is_empty(vec_ref)) vector::push_back(vec_ref, e)
         else abort EOPTION_IS_SET
     }
     spec fill {
         pragma opaque;
-        aborts_if spec_is_some(t) with EOPTION_IS_SET;
-        ensures spec_is_some(t);
-        ensures spec_borrow(t) == e;
+        aborts_if spec_is_some(self) with EOPTION_IS_SET;
+        ensures spec_is_some(self);
+        ensures spec_borrow(self) == e;
     }
 
-    /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
-    /// Aborts if `t` does not hold a value
-    public fun extract<Element>(t: &mut Option<Element>): Element {
-        assert!(is_some(t), EOPTION_NOT_SET);
-        vector::pop_back(&mut t.vec)
+    /// Convert a `some` option to a `none` by removing and returning the value stored inside `self`
+    /// Aborts if `self` does not hold a value
+    public fun extract<Element>(self: &mut Option<Element>): Element {
+        assert!(is_some(self), EOPTION_NOT_SET);
+        vector::pop_back(&mut self.vec)
     }
     spec extract {
         pragma opaque;
         include AbortsIfNone<Element>;
-        ensures result == spec_borrow(old(t));
-        ensures spec_is_none(t);
+        ensures result == spec_borrow(old(self));
+        ensures spec_is_none(self);
     }
 
-    /// Return a mutable reference to the value inside `t`
-    /// Aborts if `t` does not hold a value
-    public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
-        assert!(is_some(t), EOPTION_NOT_SET);
-        vector::borrow_mut(&mut t.vec, 0)
+    /// Return a mutable reference to the value inside `self`
+    /// Aborts if `self` does not hold a value
+    public fun borrow_mut<Element>(self: &mut Option<Element>): &mut Element {
+        assert!(is_some(self), EOPTION_NOT_SET);
+        vector::borrow_mut(&mut self.vec, 0)
     }
     spec borrow_mut {
         include AbortsIfNone<Element>;
-        ensures result == spec_borrow(t);
-        ensures t == old(t);
+        ensures result == spec_borrow(self);
+        ensures self == old(self);
     }
 
-    /// Swap the old value inside `t` with `e` and return the old value
-    /// Aborts if `t` does not hold a value
-    public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
-        assert!(is_some(t), EOPTION_NOT_SET);
-        let vec_ref = &mut t.vec;
+    /// Swap the old value inside `self` with `e` and return the old value
+    /// Aborts if `self` does not hold a value
+    public fun swap<Element>(self: &mut Option<Element>, e: Element): Element {
+        assert!(is_some(self), EOPTION_NOT_SET);
+        let vec_ref = &mut self.vec;
         let old_value = vector::pop_back(vec_ref);
         vector::push_back(vec_ref, e);
         old_value
@@ -192,16 +192,16 @@ module std::option {
     spec swap {
         pragma opaque;
         include AbortsIfNone<Element>;
-        ensures result == spec_borrow(old(t));
-        ensures spec_is_some(t);
-        ensures spec_borrow(t) == e;
+        ensures result == spec_borrow(old(self));
+        ensures spec_is_some(self);
+        ensures spec_borrow(self) == e;
     }
 
-    /// Swap the old value inside `t` with `e` and return the old value;
+    /// Swap the old value inside `self` with `e` and return the old value;
     /// or if there is no old value, fill it with `e`.
-    /// Different from swap(), swap_or_fill() allows for `t` not holding a value.
-    public fun swap_or_fill<Element>(t: &mut Option<Element>, e: Element): Option<Element> {
-        let vec_ref = &mut t.vec;
+    /// Different from swap(), swap_or_fill() allows for `self` not holding a value.
+    public fun swap_or_fill<Element>(self: &mut Option<Element>, e: Element): Option<Element> {
+        let vec_ref = &mut self.vec;
         let old_value = if (vector::is_empty(vec_ref)) none()
             else some(vector::pop_back(vec_ref));
         vector::push_back(vec_ref, e);
@@ -210,27 +210,27 @@ module std::option {
     spec swap_or_fill {
         pragma opaque;
         aborts_if false;
-        ensures result == old(t);
-        ensures spec_borrow(t) == e;
+        ensures result == old(self);
+        ensures spec_borrow(self) == e;
     }
 
-    /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
-    public fun destroy_with_default<Element: drop>(t: Option<Element>, default: Element): Element {
-        let Option { vec } = t;
+    /// Destroys `self.` If `self` holds a value, return it. Returns `default` otherwise
+    public fun destroy_with_default<Element: drop>(self: Option<Element>, default: Element): Element {
+        let Option { vec } = self;
         if (vector::is_empty(&mut vec)) default
         else vector::pop_back(&mut vec)
     }
     spec destroy_with_default {
         pragma opaque;
         aborts_if false;
-        ensures result == (if (spec_is_some(t)) spec_borrow(t) else default);
+        ensures result == (if (spec_is_some(self)) spec_borrow(self) else default);
     }
 
-    /// Unpack `t` and return its contents
-    /// Aborts if `t` does not hold a value
-    public fun destroy_some<Element>(t: Option<Element>): Element {
-        assert!(is_some(&t), EOPTION_NOT_SET);
-        let Option { vec } = t;
+    /// Unpack `self` and return its contents
+    /// Aborts if `self` does not hold a value
+    public fun destroy_some<Element>(self: Option<Element>): Element {
+        assert!(is_some(&self), EOPTION_NOT_SET);
+        let Option { vec } = self;
         let elem = vector::pop_back(&mut vec);
         vector::destroy_empty(vec);
         elem
@@ -238,106 +238,106 @@ module std::option {
     spec destroy_some {
         pragma opaque;
         include AbortsIfNone<Element>;
-        ensures result == spec_borrow(t);
+        ensures result == spec_borrow(self);
     }
 
-    /// Unpack `t`
-    /// Aborts if `t` holds a value
-    public fun destroy_none<Element>(t: Option<Element>) {
-        assert!(is_none(&t), EOPTION_IS_SET);
-        let Option { vec } = t;
+    /// Unpack `self`
+    /// Aborts if `self` holds a value
+    public fun destroy_none<Element>(self: Option<Element>) {
+        assert!(is_none(&self), EOPTION_IS_SET);
+        let Option { vec } = self;
         vector::destroy_empty(vec)
     }
     spec destroy_none {
         pragma opaque;
-        aborts_if spec_is_some(t) with EOPTION_IS_SET;
+        aborts_if spec_is_some(self) with EOPTION_IS_SET;
     }
 
-    /// Convert `t` into a vector of length 1 if it is `Some`,
+    /// Convert `self` into a vector of length 1 if it is `Some`,
     /// and an empty vector otherwise
-    public fun to_vec<Element>(t: Option<Element>): vector<Element> {
-        let Option { vec } = t;
+    public fun to_vec<Element>(self: Option<Element>): vector<Element> {
+        let Option { vec } = self;
         vec
     }
     spec to_vec {
         pragma opaque;
         aborts_if false;
-        ensures result == t.vec;
+        ensures result == self.vec;
     }
     /// Apply the function to the optional element, consuming it. Does nothing if no value present.
-    public inline fun for_each<Element>(o: Option<Element>, f: |Element|) {
-        if (is_some(&o)) {
-            f(destroy_some(o))
+    public inline fun for_each<Element>(self: Option<Element>, f: |Element|) {
+        if (is_some(&self)) {
+            f(destroy_some(self))
         } else {
-            destroy_none(o)
+            destroy_none(self)
         }
     }
 
     /// Apply the function to the optional element reference. Does nothing if no value present.
-    public inline fun for_each_ref<Element>(o: &Option<Element>, f: |&Element|) {
-        if (is_some(o)) {
-            f(borrow(o))
+    public inline fun for_each_ref<Element>(self: &Option<Element>, f: |&Element|) {
+        if (is_some(self)) {
+            f(borrow(self))
         }
     }
 
     /// Apply the function to the optional element reference. Does nothing if no value present.
-    public inline fun for_each_mut<Element>(o: &mut Option<Element>, f: |&mut Element|) {
-        if (is_some(o)) {
-            f(borrow_mut(o))
+    public inline fun for_each_mut<Element>(self: &mut Option<Element>, f: |&mut Element|) {
+        if (is_some(self)) {
+            f(borrow_mut(self))
         }
     }
 
     /// Folds the function over the optional element.
     public inline fun fold<Accumulator, Element>(
-        o: Option<Element>,
+        self: Option<Element>,
         init: Accumulator,
         f: |Accumulator,Element|Accumulator
     ): Accumulator {
-        if (is_some(&o)) {
-            f(init, destroy_some(o))
+        if (is_some(&self)) {
+            f(init, destroy_some(self))
         } else {
-            destroy_none(o);
+            destroy_none(self);
             init
         }
     }
 
     /// Maps the content of an option.
-    public inline fun map<Element, OtherElement>(o: Option<Element>, f: |Element|OtherElement): Option<OtherElement> {
-        if (is_some(&o)) {
-            some(f(destroy_some(o)))
+    public inline fun map<Element, OtherElement>(self: Option<Element>, f: |Element|OtherElement): Option<OtherElement> {
+        if (is_some(&self)) {
+            some(f(destroy_some(self)))
         } else {
-            destroy_none(o);
+            destroy_none(self);
             none()
         }
     }
 
     /// Maps the content of an option without destroying the original option.
     public inline fun map_ref<Element, OtherElement>(
-        o: &Option<Element>, f: |&Element|OtherElement): Option<OtherElement> {
-        if (is_some(o)) {
-            some(f(borrow(o)))
+        self: &Option<Element>, f: |&Element|OtherElement): Option<OtherElement> {
+        if (is_some(self)) {
+            some(f(borrow(self)))
         } else {
             none()
         }
     }
 
     /// Filters the content of an option
-    public inline fun filter<Element:drop>(o: Option<Element>, f: |&Element|bool): Option<Element> {
-        if (is_some(&o) && f(borrow(&o))) {
-            o
+    public inline fun filter<Element:drop>(self: Option<Element>, f: |&Element|bool): Option<Element> {
+        if (is_some(&self) && f(borrow(&self))) {
+            self
         } else {
             none()
         }
     }
 
     /// Returns true if the option contains an element which satisfies predicate.
-    public inline fun any<Element>(o: &Option<Element>, p: |&Element|bool): bool {
-        is_some(o) && p(borrow(o))
+    public inline fun any<Element>(self: &Option<Element>, p: |&Element|bool): bool {
+        is_some(self) && p(borrow(self))
     }
 
     /// Utility function to destroy an option that is not droppable.
-    public inline fun destroy<Element>(o: Option<Element>, d: |Element|) {
-        let vec = to_vec(o);
+    public inline fun destroy<Element>(self: Option<Element>, d: |Element|) {
+        let vec = to_vec(self);
         vector::destroy(vec, |e| d(e));
     }
 
@@ -350,7 +350,7 @@ module std::option {
     /// # Helper Schema
 
     spec schema AbortsIfNone<Element> {
-        t: Option<Element>;
-        aborts_if spec_is_none(t) with EOPTION_NOT_SET;
+        self: Option<Element>;
+        aborts_if spec_is_none(self) with EOPTION_NOT_SET;
     }
 }

--- a/aptos-move/framework/move-stdlib/sources/string.move
+++ b/aptos-move/framework/move-stdlib/sources/string.move
@@ -30,48 +30,48 @@ module std::string {
     }
 
     /// Returns a reference to the underlying byte vector.
-    public fun bytes(s: &String): &vector<u8> {
-        &s.bytes
+    public fun bytes(self: &String): &vector<u8> {
+        &self.bytes
     }
 
     /// Checks whether this string is empty.
-    public fun is_empty(s: &String): bool {
-        vector::is_empty(&s.bytes)
+    public fun is_empty(self: &String): bool {
+        vector::is_empty(&self.bytes)
     }
 
     /// Returns the length of this string, in bytes.
-    public fun length(s: &String): u64 {
-        vector::length(&s.bytes)
+    public fun length(self: &String): u64 {
+        vector::length(&self.bytes)
     }
 
     /// Appends a string.
-    public fun append(s: &mut String, r: String) {
-        vector::append(&mut s.bytes, r.bytes)
+    public fun append(self: &mut String, r: String) {
+        vector::append(&mut self.bytes, r.bytes)
     }
 
     /// Appends bytes which must be in valid utf8 format.
-    public fun append_utf8(s: &mut String, bytes: vector<u8>) {
-        append(s, utf8(bytes))
+    public fun append_utf8(self: &mut String, bytes: vector<u8>) {
+        append(self, utf8(bytes))
     }
 
     /// Insert the other string at the byte index in given string. The index must be at a valid utf8 char
     /// boundary.
-    public fun insert(s: &mut String, at: u64, o: String) {
-        let bytes = &s.bytes;
+    public fun insert(self: &mut String, at: u64, o: String) {
+        let bytes = &self.bytes;
         assert!(at <= vector::length(bytes) && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
-        let l = length(s);
-        let front = sub_string(s, 0, at);
-        let end = sub_string(s, at, l);
+        let l = length(self);
+        let front = sub_string(self, 0, at);
+        let end = sub_string(self, at, l);
         append(&mut front, o);
         append(&mut front, end);
-        *s = front;
+        *self = front;
     }
 
     /// Returns a sub-string using the given byte indices, where `i` is the first byte position and `j` is the start
     /// of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
     /// guaranteeing that the result is valid utf8.
-    public fun sub_string(s: &String, i: u64, j: u64): String {
-        let bytes = &s.bytes;
+    public fun sub_string(self: &String, i: u64, j: u64): String {
+        let bytes = &self.bytes;
         let l = vector::length(bytes);
         assert!(
             j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
@@ -81,8 +81,8 @@ module std::string {
     }
 
     /// Computes the index of the first occurrence of a string. Returns `length(s)` if no occurrence found.
-    public fun index_of(s: &String, r: &String): u64 {
-        internal_index_of(&s.bytes, &r.bytes)
+    public fun index_of(self: &String, r: &String): u64 {
+        internal_index_of(&self.bytes, &r.bytes)
     }
 
     // Native API

--- a/aptos-move/framework/supra-framework/doc/config_buffer.md
+++ b/aptos-move/framework/supra-framework/doc/config_buffer.md
@@ -287,7 +287,7 @@ Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
     <b>let</b> key = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;();
     <b>aborts_if</b> !<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_contains_key">simple_map::spec_contains_key</a>(configs.configs, key);
     <b>include</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any_UnpackAbortsIf">any::UnpackAbortsIf</a>&lt;T&gt; {
-        x: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(configs.configs, key)
+        self: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(configs.configs, key)
     };
 }
 </code></pre>
@@ -318,7 +318,7 @@ Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
     <b>let</b> type_name = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;();
     <b>let</b> configs = <b>global</b>&lt;<a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a>&gt;(@supra_framework);
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_spec_fun_does_exist">spec_fun_does_exist</a>&lt;T&gt;(type_name) ==&gt; <a href="../../aptos-stdlib/doc/any.md#0x1_any_UnpackAbortsIf">any::UnpackAbortsIf</a>&lt;T&gt; {
-        x: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(configs.configs, type_name)
+        self: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(configs.configs, type_name)
     };
 }
 </code></pre>
@@ -333,7 +333,7 @@ Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
     <b>let</b> type_name = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;();
     <b>let</b> configs = <b>global</b>&lt;<a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a>&gt;(@supra_framework);
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_spec_fun_does_exist">spec_fun_does_exist</a>&lt;T&gt;(type_name) ==&gt; <a href="../../aptos-stdlib/doc/any.md#0x1_any_UnpackRequirement">any::UnpackRequirement</a>&lt;T&gt; {
-        x: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(configs.configs, type_name)
+        self: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(configs.configs, type_name)
     };
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/doc/reconfiguration_state.md
+++ b/aptos-move/framework/supra-framework/doc/reconfiguration_state.md
@@ -562,7 +562,7 @@ Abort if the current state is not "in progress".
     <b>include</b>  <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(<b>global</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@supra_framework).variant).bytes
         == b"<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">0x1::reconfiguration_state::StateActive</a>" ==&gt;
     <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_UnpackAbortsIf">copyable_any::UnpackAbortsIf</a>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">StateActive</a>&gt; {
-        x:  <b>global</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@supra_framework).variant
+        self:  <b>global</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@supra_framework).variant
     };
     <b>aborts_if</b> <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(<b>global</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@supra_framework).variant).bytes
         != b"<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">0x1::reconfiguration_state::StateActive</a>";

--- a/aptos-move/framework/supra-framework/sources/configs/config_buffer.spec.move
+++ b/aptos-move/framework/supra-framework/sources/configs/config_buffer.spec.move
@@ -32,7 +32,7 @@ spec supra_framework::config_buffer {
         let key = type_info::type_name<T>();
         aborts_if !simple_map::spec_contains_key(configs.configs, key);
         include any::UnpackAbortsIf<T> {
-            x: simple_map::spec_get(configs.configs, key)
+            self: simple_map::spec_get(configs.configs, key)
         };
     }
 
@@ -51,7 +51,7 @@ spec supra_framework::config_buffer {
         let configs = global<PendingConfigs>(@supra_framework);
         // TODO(#12015)
         include spec_fun_does_exist<T>(type_name) ==> any::UnpackAbortsIf<T> {
-            x: simple_map::spec_get(configs.configs, type_name)
+            self: simple_map::spec_get(configs.configs, type_name)
         };
     }
 
@@ -61,7 +61,7 @@ spec supra_framework::config_buffer {
         let configs = global<PendingConfigs>(@supra_framework);
         // TODO(#12015)
         include spec_fun_does_exist<T>(type_name) ==> any::UnpackRequirement<T> {
-            x: simple_map::spec_get(configs.configs, type_name)
+            self: simple_map::spec_get(configs.configs, type_name)
         };
     }
 

--- a/aptos-move/framework/supra-framework/sources/reconfiguration_state.spec.move
+++ b/aptos-move/framework/supra-framework/sources/reconfiguration_state.spec.move
@@ -100,7 +100,7 @@ spec supra_framework::reconfiguration_state {
         include  copyable_any::type_name(global<State>(@supra_framework).variant).bytes
             == b"0x1::reconfiguration_state::StateActive" ==>
         copyable_any::UnpackAbortsIf<StateActive> {
-            x:  global<State>(@supra_framework).variant
+            self:  global<State>(@supra_framework).variant
         };
         aborts_if copyable_any::type_name(global<State>(@supra_framework).variant).bytes
             != b"0x1::reconfiguration_state::StateActive";


### PR DESCRIPTION
This PR updates move-stdlib and aptos-stdlib to use Move 2 syntax for self parameters, ensuring compatibility with the Aptos Move 2 CLI.