### PR TITLE
Refactor - congestion fee increases polynomially based on exponent value as the degree

### DIFF
--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -1538,6 +1538,7 @@ Initialization of Automation Registry with configuration parameters is expected 
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
     <b>assert</b>!(congestion_threshold_percentage &lt; 100, <a href="automation_registry.md#0x1_automation_registry_MAX_CONGESTION_THRESHOLD">MAX_CONGESTION_THRESHOLD</a>);
+    <b>assert</b>!(congestion_exponent &gt; 0, <a href="automation_registry.md#0x1_automation_registry_CONGESTION_EXP_NON_ZERO">CONGESTION_EXP_NON_ZERO</a>);
 
     <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(
         supra_framework,
@@ -1962,11 +1963,21 @@ Calculate automation congestion fee for the epoch
     <b>if</b> (threshold_usage &lt; threshold_percentage) 0
     <b>else</b> {
         <b>let</b> threshold_surplus_normalized = (threshold_usage - threshold_percentage) / 100;
+
+        // Ensure threshold + threshold_surplus does not exceeds 1 (1 in scaled terms)
+        <b>let</b> threshold_percentage_scaled = threshold_percentage / 100;
+        <b>let</b> threshold_surplus_clip = <b>if</b> ((threshold_surplus_normalized + threshold_percentage_scaled) &gt; <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>) {
+            <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a> - threshold_percentage_scaled
+        } <b>else</b> {
+            threshold_surplus_normalized
+        };
         // Compute the automation congestion fee (acf) for the epoch
         <b>let</b> threshold_surplus_exponential = <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(
-            threshold_surplus_normalized,
+            threshold_surplus_clip,
             arc.congestion_exponent
         );
+
+        // Calculate acf by multiplying base fee <b>with</b> exponential result
         <b>let</b> acf = (arc.congestion_base_fee_in_quants_per_sec <b>as</b> u256) * threshold_surplus_exponential;
         <a href="automation_registry.md#0x1_automation_registry_downscale_to_u256">downscale_to_u256</a>(acf)
     }

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -1995,7 +1995,14 @@ Calculate automation congestion fee for the epoch
 Calculates (1 + base)^exponent, where <code>base</code> is represented with <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> decimal places.
 For example, if <code>base</code> is 0.5, it should be passed as 0.5 * DECIMAL (i.e., 50000000).
 The result is returned as an integer with <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> decimal places.
-- It will return the result of ((1 + base)^exponent-1), scaled by <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> (e.g., 103906250 for 1.0390625).
+It will return the result of (((1 + base)^exponent) - 1), scaled by <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> (e.g., 103906250 for 1.0390625).
+The reason for using <code>(1 + base)^exponent</code> is that <code>base</code> would be the fraction by which the congestion threshold is crossed,
+thus highly likely to be less than one. To ensure that as <code>exponent</code> increases, the function increases, <code>1</code> is added.
+In the final result, after <code>(1 + base)^exponent</code> is calculated, <code>1</code> is subtracted so as not to subsume the automation
+base fee in this component. This would allow the freedom to set a multiplier for the automation base fee separately
+from the congestion fee.
+<code>exponent</code> here acts as the degree of the polynomial, therefore an <code>exponent</code> of <code>2</code> or higher
+would allow the congestion fee to increase in a non-linear fashion.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u8): u256

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -49,6 +49,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `calculate_task_fee`](#0x1_automation_registry_calculate_task_fee)
 -  [Function `calculate_automation_fee_for_interval`](#0x1_automation_registry_calculate_automation_fee_for_interval)
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
+-  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
@@ -1941,9 +1942,56 @@ Calculate automation congestion fee for the epoch
     <b>else</b> {
         <b>let</b> threshold_surplus_normalized = (threshold_usage - threshold_percentage) / 100;
         // Compute the automation congestion fee (acf) for the epoch
-        <b>let</b> acf = (arc.congestion_base_fee_in_quants_per_sec <b>as</b> u256) * threshold_surplus_normalized;
+        <b>let</b> threshold_surplus_exponential = <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(
+            threshold_surplus_normalized,
+            arc.congestion_exponent
+        );
+        <b>let</b> acf = (arc.congestion_base_fee_in_quants_per_sec <b>as</b> u256) * threshold_surplus_exponential;
         <a href="automation_registry.md#0x1_automation_registry_downscale_to_u256">downscale_to_u256</a>(acf)
     }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_calculate_exponentiation"></a>
+
+## Function `calculate_exponentiation`
+
+Calculates (1 + base)^exponent, where <code>base</code> is represented with <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> decimal places.
+For example, if <code>base</code> is 0.5, it should be passed as 0.5 * DECIMAL (i.e., 50000000).
+The result is returned as an integer with <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> decimal places.
+- It will return the result of ((1 + base)^exponent-1), scaled by <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> (e.g., 103906250 for 1.0390625).
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u64): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u64): u256 {
+    // Add 1 (represented <b>as</b> <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>) <b>to</b> the base
+    <b>let</b> one_scaled = <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>; // 1.0 in <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a> representation
+    <b>let</b> adjusted_base = base + one_scaled; // (1 + base) in <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a> representation
+
+    // Initialize result <b>as</b> 1 (represented in <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>)
+    <b>let</b> result = one_scaled;
+
+    // Perform exponential calculation using integer arithmetic
+    <b>let</b> i: u64 = 0;
+    <b>while</b> (i &lt; exponent) {
+        result = result * adjusted_base / <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>; // Adjust for decimal places
+        i = i + 1;
+    };
+
+    // Subtract the initial added 1 (<a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>) <b>to</b> get the final result
+    result - one_scaled
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -1401,7 +1401,9 @@ occupancy for the next epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee">estimate_automation_fee</a>(task_occupancy: u64) : u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee">estimate_automation_fee</a>(
+    task_occupancy: u64
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>let</b> registry = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(task_occupancy, registry.gas_committed_for_next_epoch)
 }
@@ -1430,7 +1432,10 @@ maximum allowed occupancy for the next epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(task_occupancy: u64, committed_occupancy: u64) : u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(
+    task_occupancy: u64,
+    committed_occupancy: u64
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>let</b> epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
     <b>let</b> config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <b>let</b> total_committed_max_gas = committed_occupancy + task_occupancy;
@@ -1914,7 +1919,11 @@ Calculate automation congestion fee for the epoch
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>, tcmg: u256, registry_max_gas_cap: u64): u256 {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    tcmg: u256,
+    registry_max_gas_cap: u64
+): u256 {
     <b>let</b> max_gas_cap = (registry_max_gas_cap <b>as</b> u256);
     <b>let</b> threshold_percentage = <a href="automation_registry.md#0x1_automation_registry_upscale_from_u8">upscale_from_u8</a>(arc.congestion_threshold_percentage);
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -177,6 +177,12 @@ Automation registry configuration parameters
 <dd>
  Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
 </dd>
+<dt>
+<code>congestion_exponent: u64</code>
+</dt>
+<dd>
+ The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
+</dd>
 </dl>
 
 
@@ -1489,7 +1495,7 @@ Asserts that SUPRA_NATIVE_AUTOMATION feature flag is enabled.
 Initialization of Automation Registry with configuration parameters is expected metrics.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u64)
 </code></pre>
 
 
@@ -1507,6 +1513,7 @@ Initialization of Automation Registry with configuration parameters is expected 
     flat_registration_fee_in_quants: u64,
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u64,
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
@@ -1533,6 +1540,7 @@ Initialization of Automation Registry with configuration parameters is expected 
             flat_registration_fee_in_quants,
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
         },
         next_epoch_registry_max_gas_cap: registry_max_gas_cap
     });
@@ -2053,6 +2061,7 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
         automation_registry_config.flat_registration_fee_in_quants = buffer.flat_registration_fee_in_quants;
         automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
         automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
+        automation_registry_config.congestion_exponent = buffer.congestion_exponent;
     };
 }
 </code></pre>
@@ -2134,7 +2143,7 @@ Transfers the specified fee amount from the resource account to the target accou
 Update Automation Registry Config
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u64)
 </code></pre>
 
 
@@ -2151,6 +2160,7 @@ Update Automation Registry Config
     flat_registration_fee_in_quants: u64,
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u64,
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
@@ -2174,6 +2184,7 @@ Update Automation Registry Config
         flat_registration_fee_in_quants,
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
+        congestion_exponent,
     };
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_automation_registry_config);
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -755,6 +755,16 @@ Insufficient balance in the resource wallet for withdrawal
 
 
 
+<a id="0x1_automation_registry_CONGESTION_EXP_NON_ZERO"></a>
+
+Congestion exponent must be non-zero
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CONGESTION_EXP_NON_ZERO">CONGESTION_EXP_NON_ZERO</a>: u64 = 20;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_DECIMAL"></a>
 
 Decimal place to make
@@ -2237,6 +2247,7 @@ Update Automation Registry Config
     );
 
     <b>assert</b>!(congestion_threshold_percentage &lt; 100, <a href="automation_registry.md#0x1_automation_registry_MAX_CONGESTION_THRESHOLD">MAX_CONGESTION_THRESHOLD</a>);
+    <b>assert</b>!(congestion_exponent &gt; 0, <a href="automation_registry.md#0x1_automation_registry_CONGESTION_EXP_NON_ZERO">CONGESTION_EXP_NON_ZERO</a>);
 
     <b>let</b> new_automation_registry_config = <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
         task_duration_cap_in_secs,

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -935,6 +935,16 @@ Unauthorized access: the caller is not the owner of the task
 
 
 
+<a id="0x1_automation_registry_MAX_CONGESTION_THRESHOLD"></a>
+
+Congestion threshold should not exceed 100
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_MAX_CONGESTION_THRESHOLD">MAX_CONGESTION_THRESHOLD</a>: u64 = 19;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_MICROSECS_CONVERSION_FACTOR"></a>
 
 Conversion factor between microseconds and second
@@ -2224,6 +2234,8 @@ Update Automation Registry Config
         automation_epoch_info.epoch_interval &lt; task_duration_cap_in_secs,
         <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>
     );
+
+    <b>assert</b>!(congestion_threshold_percentage &lt; 100, <a href="automation_registry.md#0x1_automation_registry_MAX_CONGESTION_THRESHOLD">MAX_CONGESTION_THRESHOLD</a>);
 
     <b>let</b> new_automation_registry_config = <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
         task_duration_cap_in_secs,

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -179,7 +179,7 @@ Automation registry configuration parameters
  Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
 </dd>
 <dt>
-<code>congestion_exponent: u64</code>
+<code>congestion_exponent: u8</code>
 </dt>
 <dd>
  The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
@@ -1506,7 +1506,7 @@ Asserts that SUPRA_NATIVE_AUTOMATION feature flag is enabled.
 Initialization of Automation Registry with configuration parameters is expected metrics.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8)
 </code></pre>
 
 
@@ -1524,9 +1524,10 @@ Initialization of Automation Registry with configuration parameters is expected 
     flat_registration_fee_in_quants: u64,
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u64,
+    congestion_exponent: u8,
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>assert</b>!(congestion_threshold_percentage &lt; 100, <a href="automation_registry.md#0x1_automation_registry_MAX_CONGESTION_THRESHOLD">MAX_CONGESTION_THRESHOLD</a>);
 
     <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(
         supra_framework,
@@ -1976,7 +1977,7 @@ The result is returned as an integer with <code><a href="automation_registry.md#
 - It will return the result of ((1 + base)^exponent-1), scaled by <code><a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a></code> (e.g., 103906250 for 1.0390625).
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u64): u256
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u8): u256
 </code></pre>
 
 
@@ -1985,7 +1986,7 @@ The result is returned as an integer with <code><a href="automation_registry.md#
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u64): u256 {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_exponentiation">calculate_exponentiation</a>(base: u256, exponent: u8): u256 {
     // Add 1 (represented <b>as</b> <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>) <b>to</b> the base
     <b>let</b> one_scaled = <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>; // 1.0 in <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a> representation
     <b>let</b> adjusted_base = base + one_scaled; // (1 + base) in <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a> representation
@@ -1994,7 +1995,7 @@ The result is returned as an integer with <code><a href="automation_registry.md#
     <b>let</b> result = one_scaled;
 
     // Perform exponential calculation using integer arithmetic
-    <b>let</b> i: u64 = 0;
+    <b>let</b> i = 0;
     <b>while</b> (i &lt; exponent) {
         result = result * adjusted_base / <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>; // Adjust for decimal places
         i = i + 1;
@@ -2201,7 +2202,7 @@ Transfers the specified fee amount from the resource account to the target accou
 Update Automation Registry Config
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8)
 </code></pre>
 
 
@@ -2218,7 +2219,7 @@ Update Automation Registry Config
     flat_registration_fee_in_quants: u64,
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u64,
+    congestion_exponent: u8,
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -681,7 +681,7 @@ Genesis step 2: Initialize Supra coin.
 Genesis step 3: Initialize Supra Native Automation.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8)
 </code></pre>
 
 
@@ -698,7 +698,7 @@ Genesis step 3: Initialize Supra Native Automation.
     flat_registration_fee_in_quants: u64,
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u64,
+    congestion_exponent: u8,
 ) {
     <b>let</b> epoch_interval_secs = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -681,7 +681,7 @@ Genesis step 2: Initialize Supra coin.
 Genesis step 3: Initialize Supra Native Automation.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u64)
 </code></pre>
 
 
@@ -698,6 +698,7 @@ Genesis step 3: Initialize Supra Native Automation.
     flat_registration_fee_in_quants: u64,
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u64,
 ) {
     <b>let</b> epoch_interval_secs = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
@@ -709,6 +710,7 @@ Genesis step 3: Initialize Supra Native Automation.
         flat_registration_fee_in_quants,
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
+        congestion_exponent,
     )
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -690,13 +690,14 @@ Genesis step 3: Initialize Supra Native Automation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-                                       task_duration_cap_in_secs: u64,
-                                       registry_max_gas_cap: u64,
-                                       automation_base_fee_in_quants_per_sec: u64,
-                                       flat_registration_fee_in_quants: u64,
-                                       congestion_threshold_percentage: u8,
-                                       congestion_base_fee_in_quants_per_sec: u64,
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
 ) {
     <b>let</b> epoch_interval_secs = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
@@ -1338,7 +1339,7 @@ encoded in a single BCS byte array.
         <b>let</b> schedule_length = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&pool_config.vesting_numerators);
         <b>assert</b>!(schedule_length != 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EVESTING_SCHEDULE_IS_ZERO">EVESTING_SCHEDULE_IS_ZERO</a>));
         <b>assert</b>!(pool_config.vesting_denominator != 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EDENOMINATOR_IS_ZERO">EDENOMINATOR_IS_ZERO</a>));
-        <b>assert</b>!(pool_config.vpool_locking_percentage != 0 && pool_config.vpool_locking_percentage &lt;=100 ,
+        <b>assert</b>!(pool_config.vpool_locking_percentage != 0 && pool_config.vpool_locking_percentage &lt;= 100,
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_EPERCENTAGE_INVALID">EPERCENTAGE_INVALID</a>));
         //check the sum of numerator are &lt;= denominator.
         <b>let</b> sum = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_fold">vector::fold</a>(pool_config.vesting_numerators, 0, |acc, x| acc + x);
@@ -1356,11 +1357,10 @@ encoded in a single BCS byte array.
         //Create the <a href="vesting.md#0x1_vesting">vesting</a> schedule
         <b>let</b> j = 0;
         <b>while</b> (j &lt; schedule_length) {
-
-            <b>let</b> numerator = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&pool_config.vesting_numerators,j);
+            <b>let</b> numerator = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&pool_config.vesting_numerators, j);
             <b>assert</b>!(numerator != 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="genesis.md#0x1_genesis_ENUMERATOR_IS_ZERO">ENUMERATOR_IS_ZERO</a>));
-            <b>let</b> <a href="event.md#0x1_event">event</a> = <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_create_from_rational">fixed_point32::create_from_rational</a>(numerator,pool_config.vesting_denominator);
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> schedule,<a href="event.md#0x1_event">event</a>);
+            <b>let</b> <a href="event.md#0x1_event">event</a> = <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_create_from_rational">fixed_point32::create_from_rational</a>(numerator, pool_config.vesting_denominator);
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> schedule, <a href="event.md#0x1_event">event</a>);
             j = j + 1;
         };
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -677,11 +677,21 @@ module supra_framework::automation_registry {
         if (threshold_usage < threshold_percentage) 0
         else {
             let threshold_surplus_normalized = (threshold_usage - threshold_percentage) / 100;
+
+            // Ensure threshold + threshold_surplus does not exceeds 1 (1 in scaled terms)
+            let threshold_percentage_scaled = threshold_percentage / 100;
+            let threshold_surplus_clip = if ((threshold_surplus_normalized + threshold_percentage_scaled) > DECIMAL) {
+                DECIMAL - threshold_percentage_scaled
+            } else {
+                threshold_surplus_normalized
+            };
             // Compute the automation congestion fee (acf) for the epoch
             let threshold_surplus_exponential = calculate_exponentiation(
-                threshold_surplus_normalized,
+                threshold_surplus_clip,
                 arc.congestion_exponent
             );
+
+            // Calculate acf by multiplying base fee with exponential result
             let acf = (arc.congestion_base_fee_in_quants_per_sec as u256) * threshold_surplus_exponential;
             downscale_to_u256(acf)
         }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -108,6 +108,8 @@ module supra_framework::automation_registry {
         congestion_threshold_percentage: u8,
         /// Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
         congestion_base_fee_in_quants_per_sec: u64,
+        /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
+        congestion_exponent: u64,
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -402,6 +404,7 @@ module supra_framework::automation_registry {
         flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u64,
     ) {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -428,6 +431,7 @@ module supra_framework::automation_registry {
                 flat_registration_fee_in_quants,
                 congestion_threshold_percentage,
                 congestion_base_fee_in_quants_per_sec,
+                congestion_exponent,
             },
             next_epoch_registry_max_gas_cap: registry_max_gas_cap
         });
@@ -749,6 +753,7 @@ module supra_framework::automation_registry {
             automation_registry_config.flat_registration_fee_in_quants = buffer.flat_registration_fee_in_quants;
             automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
             automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
+            automation_registry_config.congestion_exponent = buffer.congestion_exponent;
         };
     }
 
@@ -787,6 +792,7 @@ module supra_framework::automation_registry {
         flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u64,
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -810,6 +816,7 @@ module supra_framework::automation_registry {
             flat_registration_fee_in_quants,
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
         };
         config_buffer::upsert(copy new_automation_registry_config);
 
@@ -986,6 +993,8 @@ module supra_framework::automation_registry {
     #[test_only]
     const CONGESTION_BASE_FEE_TEST: u64 = 100;
     #[test_only]
+    const CONGESTION_EXPONENT_TEST: u64 = 6;
+    #[test_only]
     /// Value defined in microsecond
     const EPOCH_INTERVAL_FOR_TEST_IN_SECS: u64 = 7200;
     #[test_only]
@@ -1019,6 +1028,7 @@ module supra_framework::automation_registry {
             FLAT_REGISTRATION_FEE_TEST,
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
         );
         let ar = borrow_global<AutomationRegistry>(address_of(supra_framework));
         let resource_signer = account::create_signer_with_capability(
@@ -1161,7 +1171,7 @@ module supra_framework::automation_registry {
         config_buffer::initialize(framework);
         // Next epoch gas committed gas is less than the new limit value.
         // Configuration parameter will update after on new epoch
-        update_config(framework, 1_626_560, 75, 1005, 700000000, 70, 2000);
+        update_config(framework, 1_626_560, 75, 1005, 700000000, 70, 2000, 5);
 
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         assert!(state.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 1);
@@ -1176,6 +1186,7 @@ module supra_framework::automation_registry {
         assert!(state.flat_registration_fee_in_quants == 700000000, 5);
         assert!(state.congestion_threshold_percentage == 70, 6);
         assert!(state.congestion_base_fee_in_quants_per_sec == 2000, 7);
+        assert!(state.congestion_exponent == 5, 8);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
@@ -1203,6 +1214,7 @@ module supra_framework::automation_registry {
             FLAT_REGISTRATION_FEE_TEST,
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
         );
     }
 
@@ -1221,6 +1233,7 @@ module supra_framework::automation_registry {
             FLAT_REGISTRATION_FEE_TEST,
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
         );
     }
 
@@ -1806,6 +1819,7 @@ module supra_framework::automation_registry {
             FLAT_REGISTRATION_FEE_TEST,
             CONGESTION_THRESHOLD_TEST / 2,
             CONGESTION_BASE_FEE_TEST / 2,
+            CONGESTION_EXPONENT_TEST,
         );
         // Disable feature in order to avoid charges and check only refunds.
         toggle_feature_flag(framework, false);

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -700,7 +700,14 @@ module supra_framework::automation_registry {
     /// Calculates (1 + base)^exponent, where `base` is represented with `DECIMAL` decimal places.
     /// For example, if `base` is 0.5, it should be passed as 0.5 * DECIMAL (i.e., 50000000).
     /// The result is returned as an integer with `DECIMAL` decimal places.
-    /// - It will return the result of ((1 + base)^exponent-1), scaled by `DECIMAL` (e.g., 103906250 for 1.0390625).
+    /// It will return the result of (((1 + base)^exponent) - 1), scaled by `DECIMAL` (e.g., 103906250 for 1.0390625).
+    /// The reason for using `(1 + base)^exponent` is that `base` would be the fraction by which the congestion threshold is crossed,
+    ///     thus highly likely to be less than one. To ensure that as `exponent` increases, the function increases, `1` is added.
+    ///     In the final result, after `(1 + base)^exponent` is calculated, `1` is subtracted so as not to subsume the automation
+    ///     base fee in this component. This would allow the freedom to set a multiplier for the automation base fee separately
+    ///     from the congestion fee.
+    /// `exponent` here acts as the degree of the polynomial, therefore an `exponent` of `2` or higher
+    ///     would allow the congestion fee to increase in a non-linear fashion.
     fun calculate_exponentiation(base: u256, exponent: u8): u256 {
         // Add 1 (represented as DECIMAL) to the base
         let one_scaled = DECIMAL; // 1.0 in DECIMAL representation

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -63,7 +63,8 @@ module supra_framework::automation_registry {
     const EREQUEST_EXCEEDS_LOCKED_BALANCE: u64 = 17;
     /// Current epoch interval is greater than specified task duration cap.
     const EUNACCEPTABLE_TASK_DURATION_CAP: u64 = 18;
-
+    /// Congestion threshold should not exceed 100
+    const MAX_CONGESTION_THRESHOLD: u64 = 19;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -407,6 +408,7 @@ module supra_framework::automation_registry {
         congestion_exponent: u64,
     ) {
         system_addresses::assert_supra_framework(supra_framework);
+        assert!(congestion_threshold_percentage < 100, MAX_CONGESTION_THRESHOLD);
 
         let (registry_fee_resource_signer, registry_fee_address_signer_cap) = account::create_resource_account(
             supra_framework,
@@ -836,6 +838,8 @@ module supra_framework::automation_registry {
             EUNACCEPTABLE_TASK_DURATION_CAP
         );
 
+        assert!(congestion_threshold_percentage < 100, MAX_CONGESTION_THRESHOLD);
+
         let new_automation_registry_config = AutomationRegistryConfig {
             task_duration_cap_in_secs,
             registry_max_gas_cap,
@@ -1259,6 +1263,25 @@ module supra_framework::automation_registry {
             AUTOMATION_BASE_FEE_TEST,
             FLAT_REGISTRATION_FEE_TEST,
             CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+        );
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = MAX_CONGESTION_THRESHOLD, location = Self)]
+    fun check_config_udpate_with_max_congestion_threshold(
+        framework: &signer, user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        // Specified task duration cap is less than epoch length
+        update_config(
+            framework,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            150,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
         );

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -65,6 +65,8 @@ module supra_framework::automation_registry {
     const EUNACCEPTABLE_TASK_DURATION_CAP: u64 = 18;
     /// Congestion threshold should not exceed 100
     const MAX_CONGESTION_THRESHOLD: u64 = 19;
+    /// Congestion exponent must be non-zero
+    const CONGESTION_EXP_NON_ZERO: u64 = 20;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -409,6 +411,7 @@ module supra_framework::automation_registry {
     ) {
         system_addresses::assert_supra_framework(supra_framework);
         assert!(congestion_threshold_percentage < 100, MAX_CONGESTION_THRESHOLD);
+        assert!(congestion_exponent > 0, CONGESTION_EXP_NON_ZERO);
 
         let (registry_fee_resource_signer, registry_fee_address_signer_cap) = account::create_resource_account(
             supra_framework,
@@ -839,6 +842,7 @@ module supra_framework::automation_registry {
         );
 
         assert!(congestion_threshold_percentage < 100, MAX_CONGESTION_THRESHOLD);
+        assert!(congestion_exponent > 0, CONGESTION_EXP_NON_ZERO);
 
         let new_automation_registry_config = AutomationRegistryConfig {
             task_duration_cap_in_secs,
@@ -1284,6 +1288,25 @@ module supra_framework::automation_registry {
             150,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+        );
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = CONGESTION_EXP_NON_ZERO, location = Self)]
+    fun check_config_udpate_with_invalid_congestion_exponent(
+        framework: &signer, user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        // Specified task duration cap is less than epoch length
+        update_config(
+            framework,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            0,
         );
     }
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -20,6 +20,9 @@ module supra_framework::automation_registry {
     use supra_framework::system_addresses;
     use supra_framework::timestamp;
 
+    #[test_only]
+    use std::signer::address_of;
+
     friend supra_framework::block;
     friend supra_framework::reconfiguration;
     friend supra_framework::genesis;
@@ -351,7 +354,9 @@ module supra_framework::automation_registry {
     /// Estimates automation fee for the next epoch for specified task occupancy for the configured epoch-interval
     /// referencing the current automation registry fee parameters, current total occupancy and registry maximum allowed
     /// occupancy for the next epoch.
-    public fun estimate_automation_fee(task_occupancy: u64) : u64 acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    public fun estimate_automation_fee(
+        task_occupancy: u64
+    ): u64 acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
         let registry = borrow_global<AutomationRegistry>(@supra_framework);
         estimate_automation_fee_with_committed_occupancy(task_occupancy, registry.gas_committed_for_next_epoch)
     }
@@ -360,7 +365,10 @@ module supra_framework::automation_registry {
     /// Estimates automation fee the next epoch for specified task occupancy for the configured epoch-interval
     /// referencing the current automation registry fee parameters, specified total/committed occupancy and registry
     /// maximum allowed occupancy for the next epoch.
-    public fun estimate_automation_fee_with_committed_occupancy(task_occupancy: u64, committed_occupancy: u64) : u64 acquires AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    public fun estimate_automation_fee_with_committed_occupancy(
+        task_occupancy: u64,
+        committed_occupancy: u64
+    ): u64 acquires AutomationEpochInfo, ActiveAutomationRegistryConfig {
         let epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
         let config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         let total_committed_max_gas = committed_occupancy + task_occupancy;
@@ -647,7 +655,11 @@ module supra_framework::automation_registry {
     }
 
     /// Calculate automation congestion fee for the epoch
-    fun calculate_automation_congestion_fee(arc: &AutomationRegistryConfig, tcmg: u256, registry_max_gas_cap: u64): u256 {
+    fun calculate_automation_congestion_fee(
+        arc: &AutomationRegistryConfig,
+        tcmg: u256,
+        registry_max_gas_cap: u64
+    ): u256 {
         let max_gas_cap = (registry_max_gas_cap as u256);
         let threshold_percentage = upscale_from_u8(arc.congestion_threshold_percentage);
 
@@ -960,9 +972,6 @@ module supra_framework::automation_registry {
     fun downscale_to_u64(value: u256): u64 { ((value / DECIMAL) as u64) }
 
     fun downscale_to_u256(value: u256): u256 { value / DECIMAL }
-
-    #[test_only]
-    use std::signer::address_of;
 
     #[test_only]
     const AUTOMATION_MAX_GAS_TEST: u64 = 100_000_000;
@@ -1613,7 +1622,7 @@ module supra_framework::automation_registry {
         // 10 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
         // check user balance after on new epoch fee applied
-        check_account_balance(user_account,  expected_current_balance - expected_automation_fee);
+        check_account_balance(user_account, expected_current_balance - expected_automation_fee);
         check_account_balance(
             registry_fee_address,
             REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_automation_fee);
@@ -1652,7 +1661,7 @@ module supra_framework::automation_registry {
         let expected_congestion_fee = 5 * 85 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         let expected_epoch_fee = expected_automation_fee + expected_congestion_fee;
         // check user balance after on new epoch fee applied
-        check_account_balance( user_address, expected_current_balance - expected_epoch_fee);
+        check_account_balance(user_address, expected_current_balance - expected_epoch_fee);
         check_account_balance(
             registry_fee_address,
             REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_epoch_fee);
@@ -1723,7 +1732,7 @@ module supra_framework::automation_registry {
             check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
 
-            adjust_tasks_epoch_fee_refund(ar, arc, aei, task_exipry_time +  EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+            adjust_tasks_epoch_fee_refund(ar, arc, aei, task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS);
             check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
 
@@ -2016,7 +2025,10 @@ module supra_framework::automation_registry {
         assert!(!has_task_with_id(t3), 2);
         assert!(has_sender_active_task_with_id(user_address, t2), 3);
         // only one task is charged as the other 2 are cancelled/removed.
-        check_account_balance(get_registry_fee_address(), expected_registry_current_balance + expected_epoch_fee_for_t1_2);
+        check_account_balance(
+            get_registry_fee_address(),
+            expected_registry_current_balance + expected_epoch_fee_for_t1_2
+        );
         check_account_balance(address_of(user), 0);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -2028,7 +2040,7 @@ module supra_framework::automation_registry {
     fun check_estimate_api(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry,  AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         let fwk_address = address_of(framework);
         let task_max_gas = 10_000_000;
@@ -2089,7 +2101,7 @@ module supra_framework::automation_registry {
     fun check_registry_fee_failed_withdrawal_locked_balance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry  {
+    ) acquires AutomationRegistry {
         initialize_registry_test(framework, user);
         set_locked_fee(framework, 100_000_000);
         let withdraw_amount = REGISTRY_DEFAULT_BALANCE - 80_000_000;
@@ -2101,7 +2113,7 @@ module supra_framework::automation_registry {
     fun check_registry_fee_failed_withdrawal_insufficient_balance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry  {
+    ) acquires AutomationRegistry {
         initialize_registry_test(framework, user);
         let withdraw_amount = REGISTRY_DEFAULT_BALANCE + 1;
         withdraw_automation_task_fees(framework, address_of(user), withdraw_amount);
@@ -2143,5 +2155,4 @@ module supra_framework::automation_registry {
             i = i + 1;
         };
     }
-
 }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -673,9 +673,36 @@ module supra_framework::automation_registry {
         else {
             let threshold_surplus_normalized = (threshold_usage - threshold_percentage) / 100;
             // Compute the automation congestion fee (acf) for the epoch
-            let acf = (arc.congestion_base_fee_in_quants_per_sec as u256) * threshold_surplus_normalized;
+            let threshold_surplus_exponential = calculate_exponentiation(
+                threshold_surplus_normalized,
+                arc.congestion_exponent
+            );
+            let acf = (arc.congestion_base_fee_in_quants_per_sec as u256) * threshold_surplus_exponential;
             downscale_to_u256(acf)
         }
+    }
+
+    /// Calculates (1 + base)^exponent, where `base` is represented with `DECIMAL` decimal places.
+    /// For example, if `base` is 0.5, it should be passed as 0.5 * DECIMAL (i.e., 50000000).
+    /// The result is returned as an integer with `DECIMAL` decimal places.
+    /// - It will return the result of ((1 + base)^exponent-1), scaled by `DECIMAL` (e.g., 103906250 for 1.0390625).
+    fun calculate_exponentiation(base: u256, exponent: u64): u256 {
+        // Add 1 (represented as DECIMAL) to the base
+        let one_scaled = DECIMAL; // 1.0 in DECIMAL representation
+        let adjusted_base = base + one_scaled; // (1 + base) in DECIMAL representation
+
+        // Initialize result as 1 (represented in DECIMAL)
+        let result = one_scaled;
+
+        // Perform exponential calculation using integer arithmetic
+        let i: u64 = 0;
+        while (i < exponent) {
+            result = result * adjusted_base / DECIMAL; // Adjust for decimal places
+            i = i + 1;
+        };
+
+        // Subtract the initial added 1 (DECIMAL) to get the final result
+        result - one_scaled
     }
 
     /// Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
@@ -1670,8 +1697,8 @@ module supra_framework::automation_registry {
 
         // 85/100 * 1000 = 850 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 850;
-        // 5% surpasses the threshold, 5/100 * 100 = 5 congestion base fee, occupancy 85/100, 7200 epoch duration
-        let expected_congestion_fee = 5 * 85 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 5% surpasses the threshold, ((1+(5/100))^exponent-1) * 100 = 34 congestion base fee, occupancy 85/100, 7200 epoch duration
+        let expected_congestion_fee = 34 * 85 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         let expected_epoch_fee = expected_automation_fee + expected_congestion_fee;
         // check user balance after on new epoch fee applied
         check_account_balance(user_address, expected_current_balance - expected_epoch_fee);
@@ -1715,8 +1742,8 @@ module supra_framework::automation_registry {
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 8% surpasses the threshold, 8/100 * 100 = 8 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_per_task = 8 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         let fwk_address = address_of(framework);
         let user_address = address_of(user);
 
@@ -1831,8 +1858,8 @@ module supra_framework::automation_registry {
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 8% surpasses the threshold, 8/100 * 100 = 8 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_per_task = 8 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         // Epoch cut short 2 times
 
         // Refund is expected
@@ -1895,8 +1922,8 @@ module supra_framework::automation_registry {
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 8% surpasses the threshold, 8/100 * 100 = 8 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_per_task = 8 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         // Epoch cut short 2 times
         let fwk_address = address_of(framework);
 
@@ -2012,8 +2039,8 @@ module supra_framework::automation_registry {
         // TASK 1 and 2 expected epoch fee calculation
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_for_t1_2 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 18% surpasses the threshold, 18/100 * 100(cbf) = 18 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_for_t1_2 = 18 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 18% surpasses the threshold, ((1+(18/100))^exponent-1) * 100 = 169 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_for_t1_2 = 169 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         let expected_epoch_fee_for_t1_2 = expected_automation_fee_for_t1_2 + expected_congestion_fee_for_t1_2;
 
         // 3 tasks have been registered
@@ -2064,8 +2091,8 @@ module supra_framework::automation_registry {
         assert!(result == expected_automation_fee, 1);
 
         // expected congestion fee with 85 % congestion
-        // 5% surpass, 5/100 * 100(cbf) = 5 (acf), task occupancy 10% epoch interval 7200
-        let expected_congestion_fee = 5 * 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 5% surpass, ((1+(5/100))^exponent-1) * 100 = 34 (acf), task occupancy 10% epoch interval 7200
+        let expected_congestion_fee = 34 * 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         let result = estimate_automation_fee_with_committed_occupancy(task_max_gas, 75_000_000);
         assert!(result == expected_automation_fee + expected_congestion_fee, 2);
 
@@ -2089,8 +2116,8 @@ module supra_framework::automation_registry {
         assert!(result == expected_automation_fee, 2);
 
         // expected congestion fee with 86 % congestion
-        // 6% surpass, 6/100 * 100(cbf) = 6 (acf), task occupancy 5% epoch interval 7200
-        let expected_congestion_fee = 6 * 5 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // 6% surpass, ((1+(6/100))^exponent-1) * 100 = 41 (acf), task occupancy 5% epoch interval 7200
+        let expected_congestion_fee = 41 * 5 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
         let result = estimate_automation_fee_with_committed_occupancy(task_max_gas, 162_000_000);
         assert!(result == expected_automation_fee + expected_congestion_fee, 2);
     }
@@ -2168,5 +2195,20 @@ module supra_framework::automation_registry {
             assert!(i + 1 == item.task_index, i);
             i = i + 1;
         };
+    }
+
+    #[test]
+    fun check_calculate_exponentiation() {
+        // 5% threshould which means (5/100) * DECIMAL
+        let result = calculate_exponentiation(5 * DECIMAL / 100, CONGESTION_EXPONENT_TEST);
+        assert!(result == 34009563, 11); // ~0.34
+
+        // 28% threshould which means (28/100) * DECIMAL
+        let result = calculate_exponentiation(28 * DECIMAL / 100, CONGESTION_EXPONENT_TEST);
+        assert!(result == 339804650, 12); // ~3.39
+
+        // 50% threshould which means (50/100) * DECIMAL
+        let result = calculate_exponentiation(50 * DECIMAL / 100, CONGESTION_EXPONENT_TEST);
+        assert!(result == 1039062500, 13); // ~10.39
     }
 }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -110,7 +110,7 @@ module supra_framework::automation_registry {
         /// Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
         congestion_base_fee_in_quants_per_sec: u64,
         /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
-        congestion_exponent: u64,
+        congestion_exponent: u8,
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -405,7 +405,7 @@ module supra_framework::automation_registry {
         flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u64,
+        congestion_exponent: u8,
     ) {
         system_addresses::assert_supra_framework(supra_framework);
         assert!(congestion_threshold_percentage < 100, MAX_CONGESTION_THRESHOLD);
@@ -688,7 +688,7 @@ module supra_framework::automation_registry {
     /// For example, if `base` is 0.5, it should be passed as 0.5 * DECIMAL (i.e., 50000000).
     /// The result is returned as an integer with `DECIMAL` decimal places.
     /// - It will return the result of ((1 + base)^exponent-1), scaled by `DECIMAL` (e.g., 103906250 for 1.0390625).
-    fun calculate_exponentiation(base: u256, exponent: u64): u256 {
+    fun calculate_exponentiation(base: u256, exponent: u8): u256 {
         // Add 1 (represented as DECIMAL) to the base
         let one_scaled = DECIMAL; // 1.0 in DECIMAL representation
         let adjusted_base = base + one_scaled; // (1 + base) in DECIMAL representation
@@ -697,7 +697,7 @@ module supra_framework::automation_registry {
         let result = one_scaled;
 
         // Perform exponential calculation using integer arithmetic
-        let i: u64 = 0;
+        let i = 0;
         while (i < exponent) {
             result = result * adjusted_base / DECIMAL; // Adjust for decimal places
             i = i + 1;
@@ -821,7 +821,7 @@ module supra_framework::automation_registry {
         flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u64,
+        congestion_exponent: u8,
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -1024,7 +1024,7 @@ module supra_framework::automation_registry {
     #[test_only]
     const CONGESTION_BASE_FEE_TEST: u64 = 100;
     #[test_only]
-    const CONGESTION_EXPONENT_TEST: u64 = 6;
+    const CONGESTION_EXPONENT_TEST: u8 = 6;
     #[test_only]
     /// Value defined in microsecond
     const EPOCH_INTERVAL_FOR_TEST_IN_SECS: u64 = 7200;
@@ -1869,7 +1869,7 @@ module supra_framework::automation_registry {
             FLAT_REGISTRATION_FEE_TEST,
             CONGESTION_THRESHOLD_TEST / 2,
             CONGESTION_BASE_FEE_TEST / 2,
-            CONGESTION_EXPONENT_TEST,
+            CONGESTION_EXPONENT_TEST - 1,
         );
         // Disable feature in order to avoid charges and check only refunds.
         toggle_feature_flag(framework, false);
@@ -1902,6 +1902,7 @@ module supra_framework::automation_registry {
         assert!(arc.main_config.automation_base_fee_in_quants_per_sec == AUTOMATION_BASE_FEE_TEST / 2, 14);
         assert!(arc.main_config.congestion_threshold_percentage == CONGESTION_THRESHOLD_TEST / 2, 14);
         assert!(arc.main_config.congestion_base_fee_in_quants_per_sec == CONGESTION_BASE_FEE_TEST / 2, 14);
+        assert!(arc.main_config.congestion_exponent == CONGESTION_EXPONENT_TEST - 1, 14);
         // Check that if feature is disabled, cleanup happens and no task is available in the registry.
         assert!(!has_task_with_id(t1), 15);
         assert!(!has_task_with_id(t2), 15);

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -858,7 +858,7 @@ module supra_framework::automation_registry {
             EUNACCEPTABLE_TASK_DURATION_CAP
         );
 
-        assert!(congestion_threshold_percentage < 100, MAX_CONGESTION_THRESHOLD);
+        assert!(congestion_threshold_percentage <= 100, MAX_CONGESTION_THRESHOLD);
         assert!(congestion_exponent > 0, CONGESTION_EXP_NON_ZERO);
 
         let new_automation_registry_config = AutomationRegistryConfig {

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -220,7 +220,7 @@ module supra_framework::genesis {
         flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u64,
+        congestion_exponent: u8,
     ) {
         let epoch_interval_secs = block::get_epoch_interval_secs();
         automation_registry::initialize(

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -212,13 +212,14 @@ module supra_framework::genesis {
     }
 
     /// Genesis step 3: Initialize Supra Native Automation.
-    public fun initialize_supra_native_automation(supra_framework: &signer,
-                                           task_duration_cap_in_secs: u64,
-                                           registry_max_gas_cap: u64,
-                                           automation_base_fee_in_quants_per_sec: u64,
-                                           flat_registration_fee_in_quants: u64,
-                                           congestion_threshold_percentage: u8,
-                                           congestion_base_fee_in_quants_per_sec: u64,
+    public fun initialize_supra_native_automation(
+        supra_framework: &signer,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
     ) {
         let epoch_interval_secs = block::get_epoch_interval_secs();
         automation_registry::initialize(
@@ -602,7 +603,7 @@ module supra_framework::genesis {
             let schedule_length = vector::length(&pool_config.vesting_numerators);
             assert!(schedule_length != 0, error::invalid_argument(EVESTING_SCHEDULE_IS_ZERO));
             assert!(pool_config.vesting_denominator != 0, error::invalid_argument(EDENOMINATOR_IS_ZERO));
-            assert!(pool_config.vpool_locking_percentage != 0 && pool_config.vpool_locking_percentage <=100 ,
+            assert!(pool_config.vpool_locking_percentage != 0 && pool_config.vpool_locking_percentage <= 100,
                 error::invalid_argument(EPERCENTAGE_INVALID));
             //check the sum of numerator are <= denominator.
             let sum = vector::fold(pool_config.vesting_numerators, 0, |acc, x| acc + x);
@@ -620,11 +621,10 @@ module supra_framework::genesis {
             //Create the vesting schedule
             let j = 0;
             while (j < schedule_length) {
-
-                let numerator = *vector::borrow(&pool_config.vesting_numerators,j);
+                let numerator = *vector::borrow(&pool_config.vesting_numerators, j);
                 assert!(numerator != 0, error::invalid_argument(ENUMERATOR_IS_ZERO));
-                let event = fixed_point32::create_from_rational(numerator,pool_config.vesting_denominator);
-                vector::push_back(&mut schedule,event);
+                let event = fixed_point32::create_from_rational(numerator, pool_config.vesting_denominator);
+                vector::push_back(&mut schedule, event);
                 j = j + 1;
             };
 

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -220,6 +220,7 @@ module supra_framework::genesis {
         flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u64,
     ) {
         let epoch_interval_secs = block::get_epoch_interval_secs();
         automation_registry::initialize(
@@ -231,6 +232,7 @@ module supra_framework::genesis {
             flat_registration_fee_in_quants,
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
         )
     }
 

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -12,6 +12,7 @@ const DEFAULT_AUTOMATION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 1000;
 const ONE_SUPRA_IN_QUANTS: u64 = 100_000_000;
 const DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE: u8 = 80;
 const DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 100;
+const DEFAULT_CONGESTION_EXPONENT: u64 = 6;
 
 /// Initial version of configuration parameters for Supra native automation feature
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -32,6 +33,8 @@ pub struct AutomationRegistryConfigV1 {
     congestion_threshold_percentage: u8,
     /// Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
     congestion_base_fee_in_quants_per_sec: u64,
+    /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
+    congestion_exponent: u64,
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -43,6 +46,7 @@ impl Default for AutomationRegistryConfigV1 {
             flat_registration_fee_in_quants: ONE_SUPRA_IN_QUANTS,
             congestion_threshold_percentage: DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE,
             congestion_base_fee_in_quants_per_sec: DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC,
+            congestion_exponent: DEFAULT_CONGESTION_EXPONENT,
         }
     }
 }
@@ -68,6 +72,10 @@ impl AutomationRegistryConfigV1 {
     }
     pub fn congestion_base_fee_in_quants_per_sec(&self) -> u64 {
         self.congestion_base_fee_in_quants_per_sec
+    }
+
+    pub fn congestion_exponent(&self) -> u64 {
+        self.congestion_exponent
     }
 
     pub fn verify(&self) {
@@ -100,6 +108,7 @@ impl AutomationRegistryConfig {
             MoveValue::U64(config.flat_registration_fee_in_quants()),
             MoveValue::U8(config.congestion_threshold_percentage()),
             MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
+            MoveValue::U64(config.congestion_exponent()),
         ];
         serialize_values(&arguments)
     }

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -12,7 +12,7 @@ const DEFAULT_AUTOMATION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 1000;
 const ONE_SUPRA_IN_QUANTS: u64 = 100_000_000;
 const DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE: u8 = 80;
 const DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 100;
-const DEFAULT_CONGESTION_EXPONENT: u64 = 6;
+const DEFAULT_CONGESTION_EXPONENT: u8 = 6;
 
 /// Initial version of configuration parameters for Supra native automation feature
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -34,7 +34,7 @@ pub struct AutomationRegistryConfigV1 {
     /// Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
     congestion_base_fee_in_quants_per_sec: u64,
     /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
-    congestion_exponent: u64,
+    congestion_exponent: u8,
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -74,12 +74,8 @@ impl AutomationRegistryConfigV1 {
         self.congestion_base_fee_in_quants_per_sec
     }
 
-    pub fn congestion_exponent(&self) -> u64 {
+    pub fn congestion_exponent(&self) -> u8 {
         self.congestion_exponent
-    }
-
-    pub fn verify(&self) {
-
     }
 }
 
@@ -108,7 +104,7 @@ impl AutomationRegistryConfig {
             MoveValue::U64(config.flat_registration_fee_in_quants()),
             MoveValue::U8(config.congestion_threshold_percentage()),
             MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
-            MoveValue::U64(config.congestion_exponent()),
+            MoveValue::U8(config.congestion_exponent()),
         ];
         serialize_values(&arguments)
     }


### PR DESCRIPTION
- The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
- Create new `calculate_exponentiation` function which **return the result of `((1 + base)^exponent-1)`**