### PR TITLE
[AN-Issue-1628] Added new automation configuration parameter task_capacity

### DIFF
--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -189,7 +189,7 @@ Automation registry configuration parameters
 <code>task_capacity: u16</code>
 </dt>
 <dd>
- Mximum tasks that registry can hold.
+ Maximum number of tasks that registry can hold.
 </dd>
 </dl>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -185,6 +185,12 @@ Automation registry configuration parameters
 <dd>
  The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
 </dd>
+<dt>
+<code>task_capacity: u16</code>
+</dt>
+<dd>
+ Mximum tasks that registry can hold.
+</dd>
 </dl>
 
 
@@ -932,6 +938,16 @@ Auxiliary data during registration is not supported
 
 
 
+<a id="0x1_automation_registry_EREGISTRY_IS_FULL"></a>
+
+Registry task capacity has reached.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EREGISTRY_IS_FULL">EREGISTRY_IS_FULL</a>: u64 = 23;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EREGISTRY_MAX_GAS_CAP_NON_ZERO"></a>
 
 Automation registry max gas capacity cannot be zero.
@@ -1589,7 +1605,7 @@ maximum allowed occupancy for the next epoch.
 Initialization of Automation Registry with configuration parameters is expected metrics.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
 </code></pre>
 
 
@@ -1608,6 +1624,7 @@ Initialization of Automation Registry with configuration parameters is expected 
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
+    task_capacity: u16,
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
@@ -1642,6 +1659,7 @@ Initialization of Automation Registry with configuration parameters is expected 
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
+            task_capacity
         },
         next_epoch_registry_max_gas_cap: registry_max_gas_cap
     });
@@ -2232,6 +2250,7 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
         automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
         automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
         automation_registry_config.congestion_exponent = buffer.congestion_exponent;
+        automation_registry_config.task_capacity = buffer.task_capacity;
     };
 }
 </code></pre>
@@ -2313,7 +2332,7 @@ Transfers the specified fee amount from the resource account to the target accou
 Update Automation Registry Config
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
 </code></pre>
 
 
@@ -2331,6 +2350,7 @@ Update Automation Registry Config
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
+    task_capacity: u16,
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
@@ -2357,6 +2377,7 @@ Update Automation Registry Config
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
         congestion_exponent,
+        task_capacity
     };
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_automation_registry_config);
 
@@ -2402,9 +2423,12 @@ Registers a new automation task entry.
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&aux_data), <a href="automation_registry.md#0x1_automation_registry_ENO_AUX_DATA_SUPPORTED">ENO_AUX_DATA_SUPPORTED</a>);
 
+    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    // If registry is full, reject task registration
+    <b>assert</b>!((<a href="automation_registry.md#0x1_automation_registry_get_task_count">get_task_count</a>() <b>as</b> u16) &lt; automation_registry_config.main_config.task_capacity, <a href="automation_registry.md#0x1_automation_registry_EREGISTRY_IS_FULL">EREGISTRY_IS_FULL</a>);
+
     <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
 
     //Well-formedness check of payload_tx is done in <b>native</b> layer beforehand.

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -681,7 +681,7 @@ Genesis step 2: Initialize Supra coin.
 Genesis step 3: Initialize Supra Native Automation.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8)
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
 </code></pre>
 
 
@@ -699,6 +699,7 @@ Genesis step 3: Initialize Supra Native Automation.
     congestion_threshold_percentage: u8,
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
+    task_capacity: u16,
 ) {
     <b>let</b> epoch_interval_secs = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
@@ -711,6 +712,7 @@ Genesis step 3: Initialize Supra Native Automation.
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
         congestion_exponent,
+        task_capacity,
     )
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -121,7 +121,7 @@ module supra_framework::automation_registry {
         congestion_base_fee_in_quants_per_sec: u64,
         /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
         congestion_exponent: u8,
-        /// Mximum tasks that registry can hold.
+        /// Maximum number of tasks that registry can hold.
         task_capacity: u16,
     }
 
@@ -1393,8 +1393,9 @@ module supra_framework::automation_registry {
             1005,
             700000000,
             70,
-            2000, 5,
-        200);
+            2000,
+            5,
+            200);
 
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         assert!(state.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 1);

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -71,6 +71,8 @@ module supra_framework::automation_registry {
     const EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH: u64 = 21;
     /// Automation registry max gas capacity cannot be zero.
     const EREGISTRY_MAX_GAS_CAP_NON_ZERO: u64 = 22;
+    /// Registry task capacity has reached.
+    const EREGISTRY_IS_FULL: u64 = 23;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -119,6 +121,8 @@ module supra_framework::automation_registry {
         congestion_base_fee_in_quants_per_sec: u64,
         /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
         congestion_exponent: u8,
+        /// Mximum tasks that registry can hold.
+        task_capacity: u16,
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -430,6 +434,7 @@ module supra_framework::automation_registry {
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
+        task_capacity: u16,
     ) {
         system_addresses::assert_supra_framework(supra_framework);
         validate_configuration_parameters_common(
@@ -464,6 +469,7 @@ module supra_framework::automation_registry {
                 congestion_threshold_percentage,
                 congestion_base_fee_in_quants_per_sec,
                 congestion_exponent,
+                task_capacity
             },
             next_epoch_registry_max_gas_cap: registry_max_gas_cap
         });
@@ -835,6 +841,7 @@ module supra_framework::automation_registry {
             automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
             automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
             automation_registry_config.congestion_exponent = buffer.congestion_exponent;
+            automation_registry_config.task_capacity = buffer.task_capacity;
         };
     }
 
@@ -874,6 +881,7 @@ module supra_framework::automation_registry {
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
+        task_capacity: u16,
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -900,6 +908,7 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
+            task_capacity
         };
         config_buffer::upsert(copy new_automation_registry_config);
 
@@ -925,9 +934,12 @@ module supra_framework::automation_registry {
         assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
         assert!(vector::is_empty(&aux_data), ENO_AUX_DATA_SUPPORTED);
 
+        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
+        // If registry is full, reject task registration
+        assert!((get_task_count() as u16) < automation_registry_config.main_config.task_capacity, EREGISTRY_IS_FULL);
+
         let owner = signer::address_of(owner_signer);
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
 
         //Well-formedness check of payload_tx is done in native layer beforehand.
@@ -1089,6 +1101,8 @@ module supra_framework::automation_registry {
     #[test_only]
     const CONGESTION_EXPONENT_TEST: u8 = 6;
     #[test_only]
+    const TASK_CAPACITY_TEST: u16 = 50;
+    #[test_only]
     /// Value defined in microsecond
     const EPOCH_INTERVAL_FOR_TEST_IN_SECS: u64 = 7200;
     #[test_only]
@@ -1123,6 +1137,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
         );
         let ar = borrow_global<AutomationRegistry>(address_of(supra_framework));
         let resource_signer = account::create_signer_with_capability(
@@ -1164,6 +1179,7 @@ module supra_framework::automation_registry {
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
+        task_capacity: u16,
     ) acquires ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -1175,6 +1191,7 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
+            task_capacity
         };
 
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
@@ -1260,6 +1277,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
         );
     }
 
@@ -1278,6 +1296,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST
         );
     }
 
@@ -1296,6 +1315,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             0,
+            TASK_CAPACITY_TEST
         );
     }
 
@@ -1314,6 +1334,7 @@ module supra_framework::automation_registry {
             200,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
         );
     }
 
@@ -1366,7 +1387,14 @@ module supra_framework::automation_registry {
         config_buffer::initialize(framework);
         // Next epoch gas committed gas is less than the new limit value.
         // Configuration parameter will update after on new epoch
-        update_config(framework, 1_626_560, 75, 1005, 700000000, 70, 2000, 5);
+        update_config(framework,
+            1_626_560,
+            75,
+            1005,
+            700000000,
+            70,
+            2000, 5,
+        200);
 
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         assert!(state.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 1);
@@ -1382,6 +1410,7 @@ module supra_framework::automation_registry {
         assert!(state.congestion_threshold_percentage == 70, 6);
         assert!(state.congestion_base_fee_in_quants_per_sec == 2000, 7);
         assert!(state.congestion_exponent == 5, 8);
+        assert!(state.task_capacity == 200, 9);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
@@ -1410,6 +1439,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
         );
     }
 
@@ -1429,6 +1459,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
         );
     }
 
@@ -1448,6 +1479,7 @@ module supra_framework::automation_registry {
             150,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST
         );
     }
 
@@ -1467,6 +1499,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             0,
+            TASK_CAPACITY_TEST,
         );
     }
 
@@ -1486,6 +1519,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST
         );
     }
 
@@ -1506,6 +1540,54 @@ module supra_framework::automation_registry {
         );
         assert!(1 == get_next_task_index(), 1);
         assert!(10 == get_gas_committed_for_next_epoch(), 1)
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = EREGISTRY_IS_FULL, location = Self)]
+    fun check_registration_with_full_tasks(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        update_config_for_tests(
+            framework,
+            TTL_UPPER_BOUND_TEST,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            2,
+        );
+        register(user,
+            PAYLOAD,
+            86400,
+            10,
+            20,
+            1000,
+            PARENT_HASH,
+            AUX_DATA
+        );
+        register(user,
+            PAYLOAD,
+            86400,
+            10,
+            20,
+            1000,
+            PARENT_HASH,
+            AUX_DATA
+        );
+        // Registry is already full
+        register(user,
+            PAYLOAD,
+            86400,
+            10,
+            20,
+            1000,
+            PARENT_HASH,
+            AUX_DATA
+        );
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
@@ -2089,6 +2171,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST / 2,
             CONGESTION_BASE_FEE_TEST / 2,
             CONGESTION_EXPONENT_TEST - 1,
+            TASK_CAPACITY_TEST,
         );
         // Disable feature in order to avoid charges and check only refunds.
         toggle_feature_flag(framework, false);
@@ -2288,6 +2371,7 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST * 100,
             CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
         );
 
         // TASK 1 and 2 expected epoch fee calculation

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -221,6 +221,7 @@ module supra_framework::genesis {
         congestion_threshold_percentage: u8,
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
+        task_capacity: u16,
     ) {
         let epoch_interval_secs = block::get_epoch_interval_secs();
         automation_registry::initialize(
@@ -233,6 +234,7 @@ module supra_framework::genesis {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
+            task_capacity,
         )
     }
 

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -36,7 +36,7 @@ pub struct AutomationRegistryConfigV1 {
     congestion_base_fee_in_quants_per_sec: u64,
     /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
     congestion_exponent: u8,
-    /// Number maximum task that registry can hold.
+    /// Maximum number of tasks that registry can hold.
     task_capacity: u16,
 }
 

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -13,6 +13,7 @@ const ONE_SUPRA_IN_QUANTS: u64 = 100_000_000;
 const DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE: u8 = 80;
 const DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 100;
 const DEFAULT_CONGESTION_EXPONENT: u8 = 6;
+const DEFAULT_TASK_CAPACITY: u16 = 500;
 
 /// Initial version of configuration parameters for Supra native automation feature
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -35,6 +36,8 @@ pub struct AutomationRegistryConfigV1 {
     congestion_base_fee_in_quants_per_sec: u64,
     /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
     congestion_exponent: u8,
+    /// Number maximum task that registry can hold.
+    task_capacity: u16,
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -47,6 +50,7 @@ impl Default for AutomationRegistryConfigV1 {
             congestion_threshold_percentage: DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE,
             congestion_base_fee_in_quants_per_sec: DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC,
             congestion_exponent: DEFAULT_CONGESTION_EXPONENT,
+            task_capacity: DEFAULT_TASK_CAPACITY,
         }
     }
 }
@@ -77,6 +81,10 @@ impl AutomationRegistryConfigV1 {
     pub fn congestion_exponent(&self) -> u8 {
         self.congestion_exponent
     }
+
+    pub fn task_capacity(&self) -> u16 {
+        self.task_capacity
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -105,6 +113,7 @@ impl AutomationRegistryConfig {
             MoveValue::U8(config.congestion_threshold_percentage()),
             MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
             MoveValue::U8(config.congestion_exponent()),
+            MoveValue::U16(config.task_capacity()),
         ];
         serialize_values(&arguments)
     }


### PR DESCRIPTION

- Updated register function to reject a new task registration if registry is full, i.e. task_capacity has been reached