### PR TITLE
[AN-Issue-1701] Guarded new gas-parameters for `eth-trie` to be loaded based on a new version

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -7,7 +7,7 @@
 use crate::{
     gas_feature_versions::{RELEASE_V1_14, RELEASE_V1_8, RELEASE_V1_9_SKIPPED},
     gas_schedule::NativeGasParameters,
-    ver::gas_feature_versions::{RELEASE_V1_12, RELEASE_V1_13},
+    ver::gas_feature_versions::{RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_16_SUPRA_V1_6_0},
 };
 use aptos_gas_algebra::{
     InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerArg, InternalGasPerByte,
@@ -231,14 +231,14 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [hash_keccak256_base: InternalGas, { 1.. => "hash.keccak256.base" }, 14704],
         [hash_keccak256_per_byte: InternalGasPerByte, { 1.. => "hash.keccak256.per_byte" }, 165],
 
-        [eth_trie_proof_base: InternalGas, { 12.. => "eth.trie.proof.base" }, 15000],
-        [eth_trie_proof_hash_base: InternalGasPerArg, { 12.. => "eth.trie.proof.hash.base" }, 14704],
-        [eth_trie_proof_hash_per_byte: InternalGasPerByte, { 12.. => "eth.trie.proof.hash.per_byte" }, 165],
-        [eth_trie_proof_decode_base: InternalGasPerArg, { 12.. => "eth.trie.proof.decode.base" }, 1102],
-        [eth_trie_proof_decode_per_byte: InternalGasPerByte, { 12.. => "eth.trie.proof.decode.per_byte"}, 18],
+        [eth_trie_proof_base: InternalGas, { RELEASE_V1_16_SUPRA_V1_6_0.. => "eth.trie.proof.base" }, 15000],
+        [eth_trie_proof_hash_base: InternalGasPerArg, { RELEASE_V1_16_SUPRA_V1_6_0.. => "eth.trie.proof.hash.base" }, 14704],
+        [eth_trie_proof_hash_per_byte: InternalGasPerByte, { RELEASE_V1_16_SUPRA_V1_6_0.. => "eth.trie.proof.hash.per_byte" }, 165],
+        [eth_trie_proof_decode_base: InternalGasPerArg, { RELEASE_V1_16_SUPRA_V1_6_0.. => "eth.trie.proof.decode.base" }, 1102],
+        [eth_trie_proof_decode_per_byte: InternalGasPerByte, { RELEASE_V1_16_SUPRA_V1_6_0.. => "eth.trie.proof.decode.per_byte"}, 18],
 
-        [rlp_encode_decode_base: InternalGas, { 12.. => "rlp.encode.decode.base" }, 1102],
-        [rlp_encode_decode_per_byte: InternalGasPerByte, { 12.. => "rlp.encode.decode.per_byte"}, 18],
+        [rlp_encode_decode_base: InternalGas, { RELEASE_V1_16_SUPRA_V1_6_0.. => "rlp.encode.decode.base" }, 1102],
+        [rlp_encode_decode_per_byte: InternalGasPerByte, { RELEASE_V1_16_SUPRA_V1_6_0.. => "rlp.encode.decode.per_byte"}, 18],
 
         // Bulletproofs gas parameters begin.
         // Generated at time 1683148919.0628748 by `scripts/algebra-gas/update_bulletproofs_gas_params.py` with gas_per_ns=10.0.

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,9 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V23
+///   - Introduced eth_trie_proof* gas-schedule parameters utilized in native crypto function
+///     referenced from `0x1::supra_std::eth_trie`
 /// - V22
 ///   - Increased governance transaction execution limit from 4B to 5B to enable framework upgrades without changing
 ///     the gas schedule.
@@ -70,7 +73,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_16_SUPRA_V1_5_1;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_16_SUPRA_V1_6_0;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -84,4 +87,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_15: u64 = 20;
     pub const RELEASE_V1_16: u64 = 21;
     pub const RELEASE_V1_16_SUPRA_V1_5_1: u64 = 22;
+    pub const RELEASE_V1_16_SUPRA_V1_6_0: u64 = 23;
 }


### PR DESCRIPTION
For more details see: [smr-moonshot-issue-1701](https://github.com/Entropy-Foundation/smr-moonshot/issues/1701)