### PR TITLE
Ensured that Automation Registration transaction verification fails if the feature is not active

### DIFF
--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -238,25 +238,17 @@ fn check_successful_registration() {
     // When the SUPRA_NATIVE_AUTOMATION feature flag is not enabled registration requests must fail
     // to validate. This ensures that they won't be accepted by the RPC nodes or the Mempool.
     let validation_result = test_context.validate_transaction(automation_txn.clone());
-    assert!(matches!(
-        validation_result.status().status(),
-        Err(VMStatus::Error {
-            status_code: StatusCode::FEATURE_UNDER_GATING,
-            sub_status: None,
-            ..
-        })
-    ));
+    assert_eq!(
+        validation_result.status(),
+        Some(StatusCode::FEATURE_UNDER_GATING)
+    );
 
     // When the SUPRA_NATIVE_AUTOMATION feature flag is not enabled registration requests must fail
     // to execute.
     let result = test_context.execute_transaction(automation_txn.clone());
     assert!(matches!(
         result.status().status(),
-        Err(VMStatus::Error {
-            status_code: StatusCode::FEATURE_UNDER_GATING,
-            sub_status: None,
-            ..
-        })
+        Err(StatusCode::FEATURE_UNDER_GATING)
     ));
 
     // enable the supra native automation, registration should succeed.

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -2,17 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_cached_packages::aptos_framework_sdk_builder;
-use aptos_language_e2e_tests::account::{Account, AccountData};
-use aptos_language_e2e_tests::executor::FakeExecutor;
-use aptos_types::on_chain_config::FeatureFlag;
-use aptos_types::transaction::automation::{AutomationTaskMetaData, RegistrationParams};
-use aptos_types::transaction::{
-    EntryFunction, ExecutionStatus, SignedTransaction, TransactionOutput, TransactionPayload,
-    TransactionStatus,
+use aptos_language_e2e_tests::{
+    account::{Account, AccountData},
+    executor::FakeExecutor,
 };
-use move_core_types::account_address::AccountAddress;
-use move_core_types::value::MoveValue;
-use move_core_types::vm_status::StatusCode;
+use aptos_types::{
+    on_chain_config::FeatureFlag,
+    transaction::{
+        automation::{AutomationTaskMetaData, RegistrationParams},
+        EntryFunction, ExecutionStatus, SignedTransaction, TransactionOutput, TransactionPayload,
+        TransactionStatus,
+    },
+};
+use move_core_types::{account_address::AccountAddress, value::MoveValue, vm_status::StatusCode};
 use std::ops::{Deref, DerefMut};
 
 const TIMESTAMP_NOW_SECONDS: &str = "0x1::timestamp::now_seconds";
@@ -31,6 +33,7 @@ impl AutomationRegistrationTestContext {
     pub(crate) fn sender_account_data(&self) -> &AccountData {
         &self.txn_sender
     }
+
     pub(crate) fn sender_account_address(&self) -> AccountAddress {
         *self.txn_sender.address()
     }
@@ -63,16 +66,12 @@ impl AutomationRegistrationTestContext {
         } else {
             (vec![], flag_value)
         };
-        self.executor.exec(
-            "features",
-            "change_feature_flags_internal",
-            vec![],
-            vec![
+        self.executor
+            .exec("features", "change_feature_flags_internal", vec![], vec![
                 MoveValue::Signer(acc).simple_serialize().unwrap(),
                 bcs::to_bytes(&enabled).unwrap(),
                 bcs::to_bytes(&disabled).unwrap(),
-            ],
-        );
+            ]);
     }
 
     pub(crate) fn new_account_data(&mut self, amount: u64, seq_num: u64) -> AccountData {
@@ -124,6 +123,7 @@ impl AutomationRegistrationTestContext {
             _ => panic!("Unexpected transaction status: {output:?}"),
         }
     }
+
     pub(crate) fn check_discarded_output(
         output: TransactionOutput,
         expected_status_code: StatusCode,
@@ -161,11 +161,10 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn account_sequence_number(&mut self, account_address: AccountAddress) -> u64 {
-        let view_output = self.execute_view_function(
-            str::parse(ACCOUNT_SEQ_NUM).unwrap(),
-            vec![],
-            vec![account_address.to_vec()],
-        );
+        let view_output =
+            self.execute_view_function(str::parse(ACCOUNT_SEQ_NUM).unwrap(), vec![], vec![
+                account_address.to_vec(),
+            ]);
         let result = view_output.values.expect("Valid result");
         assert_eq!(result.len(), 1);
         bcs::from_bytes::<u64>(&result[0]).unwrap()
@@ -183,13 +182,12 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn get_task_details(&mut self, index: u64) -> AutomationTaskMetaData {
-        let view_output = self.execute_view_function(
-            str::parse(AUTOMATION_TASK_DETAILS).unwrap(),
-            vec![],
-            vec![MoveValue::U64(index)
-                .simple_serialize()
-                .expect("Successful serialization")],
-        );
+        let view_output =
+            self.execute_view_function(str::parse(AUTOMATION_TASK_DETAILS).unwrap(), vec![], vec![
+                MoveValue::U64(index)
+                    .simple_serialize()
+                    .expect("Successful serialization"),
+            ]);
         let result = view_output.values.expect("Valid result");
         assert!(!result.is_empty());
         bcs::from_bytes::<AutomationTaskMetaData>(&result[0])
@@ -237,11 +235,28 @@ fn check_successful_registration() {
     let sender_address = test_context.sender_account_address();
     let sender_seq_num_old = test_context.account_sequence_number(sender_address);
 
-    // when flag is not enabled although registry in initialized, registration will fail.
+    // When the SUPRA_NATIVE_AUTOMATION feature flag is not enabled registration requests must fail
+    // to validate. This ensures that they won't be accepted by the RPC nodes or the Mempool.
+    let validation_result = test_context.validate_transaction(automation_txn.clone());
+    assert!(matches!(
+        validation_result.status().status(),
+        Err(VMStatus::Error {
+            status_code: StatusCode::FEATURE_UNDER_GATING,
+            sub_status: None,
+            ..
+        })
+    ));
+
+    // When the SUPRA_NATIVE_AUTOMATION feature flag is not enabled registration requests must fail
+    // to execute.
     let result = test_context.execute_transaction(automation_txn.clone());
     assert!(matches!(
         result.status().status(),
-        Ok(ExecutionStatus::MoveAbort { .. })
+        Err(VMStatus::Error {
+            status_code: StatusCode::FEATURE_UNDER_GATING,
+            sub_status: None,
+            ..
+        })
     ));
 
     // enable the supra native automation, registration should succeed.

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -5,3 +5,4 @@ cd ./aptos-move/framework/supra-framework && "$ROOT"/target/release/aptos move t
 cd ..
 cargo test --release -p aptos-framework -- --skip prover || exit 2
 RUST_MIN_STACK=104857600 cargo nextest run -p e2e-move-tests || exit 3
+RUST_MIN_STACK=104857600 cargo nextest run -p language-e2e-testsuite --no-fail-fast || exit 4


### PR DESCRIPTION
Ensured that Automation Registration transaction verification fails if the feature is not active. Fixes https://github.com/Entropy-Foundation/smr-moonshot/issues/1793. Supersedes https://github.com/Entropy-Foundation/smr-moonshot/pull/1797.