### PR TITLE
[Issue-1823] Bound task registration with task_max_gas_cap configuration parameter

### DIFF
--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -196,6 +196,12 @@ Automation registry configuration parameters
 <dd>
  Maximum number of tasks that registry can hold.
 </dd>
+<dt>
+<code>task_max_gas_cap: u64</code>
+</dt>
+<dd>
+ Maximum gas amount task may be registered with.
+</dd>
 </dl>
 
 
@@ -1073,6 +1079,26 @@ Requested amount exceeds the locked balance
 
 
 
+<a id="0x1_automation_registry_ETASK_MAX_GAS_CAP_NONE_ZERO"></a>
+
+Task max gas capacity should not be 0
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_ETASK_MAX_GAS_CAP_NONE_ZERO">ETASK_MAX_GAS_CAP_NONE_ZERO</a>: u64 = 24;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_ETASK_MAX_GAS_OVERFLOW"></a>
+
+Task max gas exceeds configured task max gas capacity
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_ETASK_MAX_GAS_OVERFLOW">ETASK_MAX_GAS_OVERFLOW</a>: u64 = 25;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT"></a>
 
 Current committed gas amount is greater than the automation gas limit.
@@ -1707,7 +1733,7 @@ maximum allowed occupancy for the next epoch.
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, congestion_threshold_percentage: u8, congestion_exponent: u8)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, congestion_threshold_percentage: u8, congestion_exponent: u8, task_max_gas_cap: u64)
 </code></pre>
 
 
@@ -1722,11 +1748,13 @@ maximum allowed occupancy for the next epoch.
     registry_max_gas_cap: u64,
     congestion_threshold_percentage: u8,
     congestion_exponent: u8,
+    task_max_gas_cap: u64,
 )  {
     <b>assert</b>!(congestion_threshold_percentage &lt;= <a href="automation_registry.md#0x1_automation_registry_MAX_PERCENTAGE">MAX_PERCENTAGE</a>, <a href="automation_registry.md#0x1_automation_registry_EMAX_CONGESTION_THRESHOLD">EMAX_CONGESTION_THRESHOLD</a>);
     <b>assert</b>!(congestion_exponent &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECONGESTION_EXP_NON_ZERO">ECONGESTION_EXP_NON_ZERO</a>);
     <b>assert</b>!(task_duration_cap_in_secs &gt; epoch_interval_secs, <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>);
     <b>assert</b>!(registry_max_gas_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EREGISTRY_MAX_GAS_CAP_NON_ZERO">EREGISTRY_MAX_GAS_CAP_NON_ZERO</a>);
+    <b>assert</b>!(task_max_gas_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ETASK_MAX_GAS_CAP_NONE_ZERO">ETASK_MAX_GAS_CAP_NONE_ZERO</a>);
 }
 </code></pre>
 
@@ -1770,7 +1798,7 @@ maximum allowed occupancy for the next epoch.
 Initialization of Automation Registry with configuration parameters is expected metrics.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, task_max_gas_cap: u64)
 </code></pre>
 
 
@@ -1790,6 +1818,7 @@ Initialization of Automation Registry with configuration parameters is expected 
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
     task_capacity: u16,
+    task_max_gas_cap: u64,
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
@@ -1797,7 +1826,9 @@ Initialization of Automation Registry with configuration parameters is expected 
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         congestion_threshold_percentage,
-        congestion_exponent);
+        congestion_exponent,
+        task_max_gas_cap,
+    );
 
     <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="automation_registry.md#0x1_automation_registry_create_registry_resource_account">create_registry_resource_account</a>(supra_framework);
 
@@ -1821,7 +1852,8 @@ Initialization of Automation Registry with configuration parameters is expected 
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
-            task_capacity
+            task_capacity,
+            task_max_gas_cap
         },
         next_epoch_registry_max_gas_cap: registry_max_gas_cap
     });
@@ -2460,6 +2492,7 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
         automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
         automation_registry_config.congestion_exponent = buffer.congestion_exponent;
         automation_registry_config.task_capacity = buffer.task_capacity;
+        automation_registry_config.task_max_gas_cap = buffer.task_max_gas_cap;
     };
 }
 </code></pre>
@@ -2541,7 +2574,7 @@ Transfers the specified fee amount from the resource account to the target accou
 Update Automation Registry Config
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, task_max_gas_cap: u64)
 </code></pre>
 
 
@@ -2560,6 +2593,7 @@ Update Automation Registry Config
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
     task_capacity: u16,
+    task_max_gas_cap: u64,
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
@@ -2571,7 +2605,8 @@ Update Automation Registry Config
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         congestion_threshold_percentage,
-        congestion_exponent);
+        congestion_exponent,
+        task_max_gas_cap);
 
     <b>assert</b>!(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &lt; registry_max_gas_cap,
@@ -2586,7 +2621,8 @@ Update Automation Registry Config
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
         congestion_exponent,
-        task_capacity
+        task_capacity,
+        task_max_gas_cap,
     };
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_automation_registry_config);
 
@@ -2652,6 +2688,7 @@ Registers a new automation task entry.
 
     <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
     <b>assert</b>!(max_gas_amount &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>);
+    <b>assert</b>!(max_gas_amount &lt;= automation_registry_config.main_config.task_max_gas_cap, <a href="automation_registry.md#0x1_automation_registry_ETASK_MAX_GAS_OVERFLOW">ETASK_MAX_GAS_OVERFLOW</a>);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&tx_hash) == <a href="automation_registry.md#0x1_automation_registry_TXN_HASH_LENGTH">TXN_HASH_LENGTH</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>);
 
     <b>let</b> committed_gas = (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch <b>as</b> u128) + (max_gas_amount <b>as</b> u128);

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -681,7 +681,7 @@ Genesis step 2: Initialize Supra coin.
 Genesis step 3: Initialize Supra Native Automation.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, task_max_gas_cap: u64)
 </code></pre>
 
 
@@ -700,6 +700,7 @@ Genesis step 3: Initialize Supra Native Automation.
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
     task_capacity: u16,
+    task_max_gas_cap: u64,
 ) {
     <b>let</b> epoch_interval_secs = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
     <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
@@ -713,6 +714,7 @@ Genesis step 3: Initialize Supra Native Automation.
         congestion_base_fee_in_quants_per_sec,
         congestion_exponent,
         task_capacity,
+        task_max_gas_cap
     )
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -72,6 +72,10 @@ module supra_framework::automation_registry {
     const EREGISTRY_MAX_GAS_CAP_NON_ZERO: u64 = 22;
     /// Registry task capacity has reached.
     const EREGISTRY_IS_FULL: u64 = 23;
+    /// Task max gas capacity should not be 0
+    const ETASK_MAX_GAS_CAP_NONE_ZERO: u64 = 24;
+    /// Task max gas exceeds configured task max gas capacity
+    const ETASK_MAX_GAS_OVERFLOW: u64 = 25;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -122,6 +126,8 @@ module supra_framework::automation_registry {
         congestion_exponent: u8,
         /// Maximum number of tasks that registry can hold.
         task_capacity: u16,
+        /// Maximum gas amount task may be registered with.
+        task_max_gas_cap: u64,
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -447,11 +453,13 @@ module supra_framework::automation_registry {
         registry_max_gas_cap: u64,
         congestion_threshold_percentage: u8,
         congestion_exponent: u8,
+        task_max_gas_cap: u64,
     )  {
         assert!(congestion_threshold_percentage <= MAX_PERCENTAGE, EMAX_CONGESTION_THRESHOLD);
         assert!(congestion_exponent > 0, ECONGESTION_EXP_NON_ZERO);
         assert!(task_duration_cap_in_secs > epoch_interval_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
         assert!(registry_max_gas_cap > 0, EREGISTRY_MAX_GAS_CAP_NON_ZERO);
+        assert!(task_max_gas_cap > 0, ETASK_MAX_GAS_CAP_NONE_ZERO);
     }
 
     fun create_registry_resource_account(supra_framework: &signer): (signer, SignerCapability) {
@@ -475,6 +483,7 @@ module supra_framework::automation_registry {
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
         task_capacity: u16,
+        task_max_gas_cap: u64,
     ) {
         system_addresses::assert_supra_framework(supra_framework);
         validate_configuration_parameters_common(
@@ -482,7 +491,9 @@ module supra_framework::automation_registry {
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             congestion_threshold_percentage,
-            congestion_exponent);
+            congestion_exponent,
+            task_max_gas_cap,
+        );
 
         let (registry_fee_resource_signer, registry_fee_address_signer_cap) = create_registry_resource_account(supra_framework);
 
@@ -506,7 +517,8 @@ module supra_framework::automation_registry {
                 congestion_threshold_percentage,
                 congestion_base_fee_in_quants_per_sec,
                 congestion_exponent,
-                task_capacity
+                task_capacity,
+                task_max_gas_cap
             },
             next_epoch_registry_max_gas_cap: registry_max_gas_cap
         });
@@ -906,6 +918,7 @@ module supra_framework::automation_registry {
             automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
             automation_registry_config.congestion_exponent = buffer.congestion_exponent;
             automation_registry_config.task_capacity = buffer.task_capacity;
+            automation_registry_config.task_max_gas_cap = buffer.task_max_gas_cap;
         };
     }
 
@@ -946,6 +959,7 @@ module supra_framework::automation_registry {
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
         task_capacity: u16,
+        task_max_gas_cap: u64,
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -957,7 +971,8 @@ module supra_framework::automation_registry {
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             congestion_threshold_percentage,
-            congestion_exponent);
+            congestion_exponent,
+            task_max_gas_cap);
 
         assert!(
             automation_registry.gas_committed_for_next_epoch < registry_max_gas_cap,
@@ -972,7 +987,8 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
-            task_capacity
+            task_capacity,
+            task_max_gas_cap,
         };
         config_buffer::upsert(copy new_automation_registry_config);
 
@@ -1018,6 +1034,7 @@ module supra_framework::automation_registry {
 
         assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
         assert!(max_gas_amount > 0, EINVALID_MAX_GAS_AMOUNT);
+        assert!(max_gas_amount <= automation_registry_config.main_config.task_max_gas_cap, ETASK_MAX_GAS_OVERFLOW);
         assert!(vector::length(&tx_hash) == TXN_HASH_LENGTH, EINVALID_TXN_HASH);
 
         let committed_gas = (automation_registry.gas_committed_for_next_epoch as u128) + (max_gas_amount as u128);
@@ -1167,6 +1184,8 @@ module supra_framework::automation_registry {
     #[test_only]
     const TASK_CAPACITY_TEST: u16 = 50;
     #[test_only]
+    const TASK_MAX_GAS_CAP_TEST: u64 = 90_000_000;
+    #[test_only]
     /// Value defined in microsecond
     const EPOCH_INTERVAL_FOR_TEST_IN_SECS: u64 = 7200;
     #[test_only]
@@ -1204,6 +1223,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
 
         coin::register<SupraCoin>(user);
@@ -1240,6 +1260,7 @@ module supra_framework::automation_registry {
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
         task_capacity: u16,
+        task_max_gas_cap: u64,
     ) acquires ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
 
@@ -1251,7 +1272,8 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
-            task_capacity
+            task_capacity,
+            task_max_gas_cap
         };
 
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
@@ -1338,6 +1360,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST,
         );
     }
 
@@ -1356,7 +1379,8 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
-            TASK_CAPACITY_TEST
+            TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
 
@@ -1375,7 +1399,8 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             0,
-            TASK_CAPACITY_TEST
+            TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
 
@@ -1395,8 +1420,30 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
+
+    #[test(supra_framework = @supra_framework)]
+    #[expected_failure(abort_code = ETASK_MAX_GAS_CAP_NONE_ZERO, location = Self)]
+    fun test_initialization_with_invalid_task_max_gas_cap(
+        supra_framework: &signer,
+    )  {
+        initialize(
+            supra_framework,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            0
+        );
+    }
+
 
     #[test(supra_framework = @supra_framework, user = @0x1cafe)]
     fun test_registry(
@@ -1455,6 +1502,7 @@ module supra_framework::automation_registry {
             70,
             2000,
             5,
+            200,
             200);
 
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
@@ -1501,6 +1549,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST,
         );
     }
 
@@ -1521,6 +1570,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
 
@@ -1540,7 +1590,8 @@ module supra_framework::automation_registry {
             150,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
-            TASK_CAPACITY_TEST
+            TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
 
@@ -1561,6 +1612,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             0,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
 
@@ -1580,9 +1632,32 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
-            TASK_CAPACITY_TEST
+            TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
     }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = ETASK_MAX_GAS_CAP_NONE_ZERO, location = Self)]
+    fun check_config_udpate_with_invalid_task_max_gas_cap(
+        framework: &signer, user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        // Specified task duration cap is less than epoch length
+        update_config(
+            framework,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            0
+        );
+    }
+
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_task_registration(
@@ -1620,6 +1695,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             2,
+            TASK_MAX_GAS_CAP_TEST,
         );
         register(user,
             PAYLOAD,
@@ -1842,6 +1918,35 @@ module supra_framework::automation_registry {
             PAYLOAD,
             86400,
             10_000,
+            70,
+            1,
+            PARENT_HASH,
+            AUX_DATA
+        );
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = ETASK_MAX_GAS_OVERFLOW, location = Self)]
+    fun check_registration_task_max_gas_overflow(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        update_config_for_tests( framework,
+            TTL_UPPER_BOUND_TEST,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            200
+        );
+        register(user,
+            PAYLOAD,
+            86400,
+            400,
             70,
             1,
             PARENT_HASH,
@@ -2270,6 +2375,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST / 2,
             CONGESTION_EXPONENT_TEST - 1,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
         // Disable feature in order to avoid charges and check only refunds.
         toggle_feature_flag(framework, false);
@@ -2475,6 +2581,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
 
         let tcmg = ((2 * t1_t2_max_gas) as u256);
@@ -2506,6 +2613,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
 
         let tcmg = ((2 * t1_t2_max_gas) as u256);
@@ -2537,6 +2645,7 @@ module supra_framework::automation_registry {
             0,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
 
         let tcmg = ((2 * t1_t2_max_gas) as u256);
@@ -2568,6 +2677,7 @@ module supra_framework::automation_registry {
             0,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
 
         let tcmg = ((2 * t1_t2_max_gas) as u256);
@@ -2625,6 +2735,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST * 100,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            TASK_MAX_GAS_CAP_TEST
         );
 
         // TASK 1 and 2 expected epoch fee calculation

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -222,6 +222,7 @@ module supra_framework::genesis {
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
         task_capacity: u16,
+        task_max_gas_cap: u64,
     ) {
         let epoch_interval_secs = block::get_epoch_interval_secs();
         automation_registry::initialize(
@@ -235,6 +236,7 @@ module supra_framework::genesis {
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
             task_capacity,
+            task_max_gas_cap
         )
     }
 

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -38,6 +38,8 @@ pub struct AutomationRegistryConfigV1 {
     congestion_exponent: u8,
     /// Maximum number of tasks that registry can hold.
     task_capacity: u16,
+    /// Maximum gas amount task may be registered with.
+    task_max_gas_cap: u64,
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -51,6 +53,7 @@ impl Default for AutomationRegistryConfigV1 {
             congestion_base_fee_in_quants_per_sec: DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC,
             congestion_exponent: DEFAULT_CONGESTION_EXPONENT,
             task_capacity: DEFAULT_TASK_CAPACITY,
+            task_max_gas_cap: DEFAULT_REGISTRY_MAX_GAS_CAP / (DEFAULT_TASK_CAPACITY as u64),
         }
     }
 }
@@ -85,6 +88,10 @@ impl AutomationRegistryConfigV1 {
     pub fn task_capacity(&self) -> u16 {
         self.task_capacity
     }
+
+    pub fn task_max_gas_cap(&self) -> u64 {
+        self.task_max_gas_cap
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -114,6 +121,7 @@ impl AutomationRegistryConfig {
             MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
             MoveValue::U8(config.congestion_exponent()),
             MoveValue::U16(config.task_capacity()),
+            MoveValue::U64(config.task_max_gas_cap()),
         ];
         serialize_values(&arguments)
     }


### PR DESCRIPTION

- Now task registration will fail if its task max gas amount exceeds configured task-max-gas-cap

Fixes [Automation] Limit task registration based on task max gas amount to avoid abusive usage
[#1823](https://github.com/Entropy-Foundation/smr-moonshot/issues/1823)