### PR TITLE
[AN-Issue-1839] Enabled gas check for automation task before move registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9609,6 +9609,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-gas-algebra",
  "aptos-gas-schedule",
+ "aptos-global-constants",
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-types",

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{move_vm_ext::AptosMoveResolver, transaction_metadata::TransactionMetadata};
-use aptos_gas_algebra::{Gas, GasExpression, InternalGas};
+use aptos_gas_algebra::{FeePerGasUnit, Gas, GasExpression, InternalGas};
 use aptos_gas_meter::{StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
     gas_feature_versions::RELEASE_V1_13, gas_params::txn::KEYLESS_BASE_COST, AptosGasParameters,
@@ -21,6 +21,7 @@ use move_core_types::{
     gas_algebra::NumArgs,
     vm_status::{StatusCode, VMStatus},
 };
+use move_core_types::gas_algebra::NumBytes;
 
 /// This is used until gas version 18, which introduces a configurable entry for this.
 const MAXIMUM_APPROVED_TRANSACTION_SIZE_LEGACY: u64 = 1024 * 1024;
@@ -120,6 +121,16 @@ pub fn make_prod_gas_meter(
     )))
 }
 
+/// Invariants facilitating gas checks of the transactions.
+pub (crate) struct TransactionGasCheckInvariants {
+    pub(crate) gas_unit_price: FeePerGasUnit,
+    pub(crate) max_gas_amount: Gas,
+    pub(crate) transaction_size: NumBytes,
+    pub(crate) script_size: NumBytes,
+    pub(crate) is_keyless: bool,
+    pub(crate) is_account_init_for_sponsored_transaction: bool,
+}
+
 pub(crate) fn check_gas(
     gas_params: &AptosGasParameters,
     gas_feature_version: u64,
@@ -129,8 +140,27 @@ pub(crate) fn check_gas(
     is_approved_gov_script: bool,
     log_context: &AdapterLogSchema,
 ) -> Result<(), VMStatus> {
+    let txn_gas_metadata = TransactionGasCheckInvariants {
+        gas_unit_price: txn_metadata.gas_unit_price(),
+        max_gas_amount: txn_metadata.max_gas_amount(),
+        transaction_size: txn_metadata.transaction_size,
+        script_size: txn_metadata.script_size,
+        is_keyless: txn_metadata.is_keyless(),
+        is_account_init_for_sponsored_transaction: crate::aptos_vm::is_account_init_for_sponsored_transaction(txn_metadata, features, resolver)?,
+    };
+    check_gas_for_parameters(gas_params, gas_feature_version, features, txn_gas_metadata, is_approved_gov_script, log_context)
+}
+
+pub(crate) fn check_gas_for_parameters(
+    gas_params: &AptosGasParameters,
+    gas_feature_version: u64,
+    features: &Features,
+    txn_gas_metadata: TransactionGasCheckInvariants,
+    is_approved_gov_script: bool,
+    log_context: &AdapterLogSchema,
+) -> Result<(), VMStatus> {
     let txn_gas_params = &gas_params.vm.txn;
-    let raw_bytes_len = txn_metadata.transaction_size;
+    let raw_bytes_len = txn_gas_metadata.transaction_size;
 
     if is_approved_gov_script {
         let max_txn_size_gov = if gas_feature_version >= RELEASE_V1_13 {
@@ -139,18 +169,18 @@ pub(crate) fn check_gas(
             MAXIMUM_APPROVED_TRANSACTION_SIZE_LEGACY.into()
         };
 
-        if txn_metadata.transaction_size > max_txn_size_gov
+        if txn_gas_metadata.transaction_size > max_txn_size_gov
             // Ensure that it is only the approved payload that exceeds the
             // maximum. The (unknown) user input should be restricted to the original
             // maximum transaction size.
-            || txn_metadata.transaction_size
-                > txn_metadata.script_size + txn_gas_params.max_transaction_size_in_bytes
+            || txn_gas_metadata.transaction_size
+            > txn_gas_metadata.script_size + txn_gas_params.max_transaction_size_in_bytes
         {
             speculative_warn!(
                 log_context,
                 format!(
                     "[VM] Governance transaction size too big {} payload size {}",
-                    txn_metadata.transaction_size, txn_metadata.script_size,
+                    txn_gas_metadata.transaction_size, txn_gas_metadata.script_size,
                 ),
             );
             return Err(VMStatus::error(
@@ -158,12 +188,12 @@ pub(crate) fn check_gas(
                 None,
             ));
         }
-    } else if txn_metadata.transaction_size > txn_gas_params.max_transaction_size_in_bytes {
+    } else if txn_gas_metadata.transaction_size > txn_gas_params.max_transaction_size_in_bytes {
         speculative_warn!(
             log_context,
             format!(
                 "[VM] Transaction size too big {} (max {})",
-                txn_metadata.transaction_size, txn_gas_params.max_transaction_size_in_bytes
+                txn_gas_metadata.transaction_size, txn_gas_params.max_transaction_size_in_bytes
             ),
         );
         return Err(VMStatus::error(
@@ -175,13 +205,13 @@ pub(crate) fn check_gas(
     // The submitted max gas units that the transaction can consume is greater than the
     // maximum number of gas units bound that we have set for any
     // transaction.
-    if txn_metadata.max_gas_amount() > txn_gas_params.maximum_number_of_gas_units {
+    if txn_gas_metadata.max_gas_amount > txn_gas_params.maximum_number_of_gas_units {
         speculative_warn!(
             log_context,
             format!(
                 "[VM] Gas unit error; max {}, submitted {}",
                 txn_gas_params.maximum_number_of_gas_units,
-                txn_metadata.max_gas_amount()
+                txn_gas_metadata.max_gas_amount
             ),
         );
         return Err(VMStatus::error(
@@ -193,7 +223,7 @@ pub(crate) fn check_gas(
     // The submitted transactions max gas units needs to be at least enough to cover the
     // intrinsic cost of the transaction as calculated against the size of the
     // underlying `RawTransaction`.
-    let keyless = if txn_metadata.is_keyless() {
+    let keyless = if txn_gas_metadata.is_keyless {
         KEYLESS_BASE_COST.evaluate(gas_feature_version, &gas_params.vm)
     } else {
         InternalGas::zero()
@@ -203,13 +233,13 @@ pub(crate) fn check_gas(
         .evaluate(gas_feature_version, &gas_params.vm);
     let total_rounded: Gas = (intrinsic_gas + keyless).to_unit_round_up_with_params(txn_gas_params);
 
-    if txn_metadata.max_gas_amount() < total_rounded {
+    if txn_gas_metadata.max_gas_amount < total_rounded {
         speculative_warn!(
             log_context,
             format!(
                 "[VM] Gas unit error; min {}, submitted {}",
                 total_rounded,
-                txn_metadata.max_gas_amount()
+                txn_gas_metadata.max_gas_amount
             ),
         );
         return Err(VMStatus::error(
@@ -222,14 +252,14 @@ pub(crate) fn check_gas(
     // NB: MIN_PRICE_PER_GAS_UNIT may equal zero, but need not in the future. Hence why
     // we turn off the clippy warning.
     #[allow(clippy::absurd_extreme_comparisons)]
-    let below_min_bound = txn_metadata.gas_unit_price() < txn_gas_params.min_price_per_gas_unit;
+    let below_min_bound = txn_gas_metadata.gas_unit_price < txn_gas_params.min_price_per_gas_unit;
     if below_min_bound {
         speculative_warn!(
             log_context,
             format!(
                 "[VM] Gas unit error; min {}, submitted {}",
                 txn_gas_params.min_price_per_gas_unit,
-                txn_metadata.gas_unit_price()
+                txn_gas_metadata.gas_unit_price
             ),
         );
         return Err(VMStatus::error(
@@ -239,13 +269,13 @@ pub(crate) fn check_gas(
     }
 
     // The submitted gas price is greater than the maximum gas unit price set by the VM.
-    if txn_metadata.gas_unit_price() > txn_gas_params.max_price_per_gas_unit {
+    if txn_gas_metadata.gas_unit_price > txn_gas_params.max_price_per_gas_unit {
         speculative_warn!(
             log_context,
             format!(
                 "[VM] Gas unit error; min {}, submitted {}",
                 txn_gas_params.max_price_per_gas_unit,
-                txn_metadata.gas_unit_price()
+                txn_gas_metadata.gas_unit_price
             ),
         );
         return Err(VMStatus::error(
@@ -258,10 +288,9 @@ pub(crate) fn check_gas(
     // gas to cover storage, execution, and IO costs.
     // TODO: This isn't the cleaning code, thus we localize it just here and will remove it
     // once accountv2 is available and we no longer need to create accounts.
-    if crate::aptos_vm::is_account_init_for_sponsored_transaction(txn_metadata, features, resolver)?
-    {
-        let gas_unit_price: u64 = txn_metadata.gas_unit_price().into();
-        let max_gas_amount: u64 = txn_metadata.max_gas_amount().into();
+    if  txn_gas_metadata.is_account_init_for_sponsored_transaction {
+        let gas_unit_price: u64 = txn_gas_metadata.gas_unit_price.into();
+        let max_gas_amount: u64 = txn_gas_metadata.max_gas_amount.into();
         let pricing = DiskSpacePricing::new(gas_feature_version, features);
         let storage_fee_per_account_create: u64 = pricing
             .hack_estimated_fee_for_account_creation(txn_gas_params)
@@ -284,6 +313,5 @@ pub(crate) fn check_gas(
             ));
         }
     }
-
     Ok(())
 }

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -195,7 +195,7 @@ impl From<&AutomatedTransaction> for TransactionMetadata {
             script_hash: vec![],
             script_size: NumBytes::zero(),
             is_keyless: false,
-            payload_type_reference: PayloadTypeReferenceMeta::AutomationRegistration,
+            payload_type_reference: PayloadTypeReferenceMeta::UserEntryFunction(txn.payload().clone().into_entry_function()),
             txn_app_hash: txn.hash().to_vec(),
         }
     }

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -30,6 +30,7 @@ move-core-types = { workspace = true }
 move-ir-compiler = { workspace = true }
 proptest = { workspace = true }
 bcs = { workspace = true }
+aptos-global-constants = { workspace = true }
 
 [features]
 default = [

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -330,6 +330,24 @@ fn check_invalid_gas_params_of_automation_task() {
         0,
         inner_entry_function.clone(),
         3600,
+        aptos_global_constants::MAX_GAS_AMOUNT + 1,
+        100,
+        automation_fee_cap,
+        aux_data.clone(),
+    );
+
+    let output = test_context.execute_transaction(automation_txn.clone());
+    AutomationRegistrationTestContext::check_discarded_output(
+        output,
+        StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
+    );
+    let validation_output = test_context.validate_transaction(automation_txn);
+    assert_eq!(validation_output.status(), Some(StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND));
+
+    let automation_txn = test_context.create_automation_txn(
+        0,
+        inner_entry_function.clone(),
+        3600,
         100,
         10_000_000_001,
         automation_fee_cap,

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -296,3 +296,51 @@ fn check_invalid_automation_txn() {
         StatusCode::INVALID_AUTOMATION_INNER_PAYLOAD,
     );
 }
+
+#[test]
+fn check_invalid_gas_params_of_automation_task() {
+    let mut test_context = AutomationRegistrationTestContext::new();
+    test_context.set_supra_native_automation(true);
+    // Create automation registration transaction with entry-function with invalid arguments.
+    let dest_account = test_context.new_account_data(0, 0);
+    let inner_entry_function =
+        aptos_framework_sdk_builder::supra_coin_mint(dest_account.address().clone(), 100)
+            .into_entry_function();
+    let automation_fee_cap = 100_000;
+    let aux_data = Vec::new();
+    let automation_txn = test_context.create_automation_txn(
+        0,
+        inner_entry_function.clone(),
+        3600,
+        2,
+        100,
+        automation_fee_cap,
+        aux_data.clone(),
+    );
+
+    let output = test_context.execute_transaction(automation_txn.clone());
+    AutomationRegistrationTestContext::check_discarded_output(
+        output,
+        StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
+    );
+    let validation_output = test_context.validate_transaction(automation_txn);
+    assert_eq!(validation_output.status(), Some(StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS));
+
+    let automation_txn = test_context.create_automation_txn(
+        0,
+        inner_entry_function.clone(),
+        3600,
+        100,
+        10_000_000_001,
+        automation_fee_cap,
+        aux_data,
+    );
+
+    let output = test_context.execute_transaction(automation_txn.clone());
+    AutomationRegistrationTestContext::check_discarded_output(
+        output,
+        StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND,
+    );
+    let validation_output = test_context.validate_transaction(automation_txn);
+    assert_eq!(validation_output.status(), Some(StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND));
+}

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -10,7 +10,6 @@ use move_core_types::language_storage::ModuleId;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf};
-use std::fmt::Display;
 use aptos_crypto::HashValue;
 
 /// A release bundle consists of a list of release packages.

--- a/aptos-move/framework/supra-framework/doc/vesting_without_staking.md
+++ b/aptos-move/framework/supra-framework/doc/vesting_without_staking.md
@@ -1343,6 +1343,10 @@ Create a vesting schedule with the given schedule of distributions, a vesting st
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="vesting_without_staking.md#0x1_vesting_without_staking_EINVALID_VESTING_SCHEDULE">EINVALID_VESTING_SCHEDULE</a>),
     );
     <b>assert</b>!(
+        sum &lt;= denominator,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="vesting_without_staking.md#0x1_vesting_without_staking_EINVALID_VESTING_SCHEDULE">EINVALID_VESTING_SCHEDULE</a>)
+    );
+    <b>assert</b>!(
         denominator != 0,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="vesting_without_staking.md#0x1_vesting_without_staking_EINVALID_VESTING_SCHEDULE">EINVALID_VESTING_SCHEDULE</a>),
     );
@@ -1717,9 +1721,6 @@ Unlock any vested portion of the grant.
 
     <b>if</b> (last_completed_period &gt;= next_period_to_vest && vesting_record.left_amount != 0) {
         <b>let</b> final_fraction = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(schedule, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(schedule) - 1);
-        <b>let</b> final_fraction_amount = <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_multiply_u64">fixed_point32::multiply_u64</a>(
-            vesting_record.init_amount, final_fraction
-        );
         // Determine how many periods is needed based on the left_amount
         periods_fast_forward = last_completed_period - next_period_to_vest + 1;
         <b>let</b> added_fraction = <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_multiply_u64_return_fixpoint32">fixed_point32::multiply_u64_return_fixpoint32</a>(
@@ -1731,10 +1732,6 @@ Unlock any vested portion of the grant.
         );
 
     };
-    <b>let</b> total_vesting_fraction_amount = <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_multiply_u64">fixed_point32::multiply_u64</a>(
-        vesting_record.init_amount,
-        total_vesting_fraction,
-    );
     // We don't need <b>to</b> check vesting_record.left_amount &gt; 0 because vest_transfer will handle that.
     <b>let</b> transfer_happened = <a href="vesting_without_staking.md#0x1_vesting_without_staking_vest_transfer">vest_transfer</a>(
         vesting_record, signer_cap, beneficiary, total_vesting_fraction
@@ -1794,14 +1791,12 @@ Unlock any vested portion of the grant.
             vesting_record.left_amount,
             <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_multiply_u64">fixed_point32::multiply_u64</a>(vesting_record.init_amount, vesting_fraction),
         );
-    <b>let</b> result =
         <b>if</b> (amount &gt; 0) {
             //<b>update</b> left_amount for the shareholder
             vesting_record.left_amount = vesting_record.left_amount - amount;
             <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&vesting_signer, beneficiary, amount);
             <b>true</b>
-        } <b>else</b> { <b>false</b> };
-    result
+        } <b>else</b> { <b>false</b> }
 }
 </code></pre>
 
@@ -1841,9 +1836,7 @@ Unlock any vested portion of the grant.
     <b>let</b> schedule = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(
         &vesting_numerators,
         |numerator| {
-            <b>let</b> e =
-                <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_create_from_rational">fixed_point32::create_from_rational</a>(*numerator, vesting_denominator);
-            e
+                <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32_create_from_rational">fixed_point32::create_from_rational</a>(*numerator, vesting_denominator)
         },
     );
 
@@ -1858,7 +1851,6 @@ Unlock any vested portion of the grant.
             <b>let</b> new_last_vested_period = (
                 msrecord.last_vested_period * old_period_duration
             ) / period_duration;
-            msrecord.last_vested_period = new_last_vested_period;
             msrecord.last_vested_period = new_last_vested_period;
         },
     );

--- a/types/src/transaction/automation.rs
+++ b/types/src/transaction/automation.rs
@@ -53,6 +53,21 @@ impl RegistrationParams {
         v1_self.automated_function()
     }
 
+    pub fn expiration_timestamp_secs(&self) -> u64 {
+        let RegistrationParams::V1(v1_self) = self;
+        v1_self.expiration_timestamp_secs
+    }
+
+    pub fn gas_price_cap(&self) -> u64 {
+        let RegistrationParams::V1(v1_self) = self;
+        v1_self.gas_price_cap
+    }
+
+    pub fn max_gas_amount(&self) -> u64 {
+        let RegistrationParams::V1(v1_self) = self;
+        v1_self.max_gas_amount
+    }
+
     pub fn into_v1(self) -> Option<RegistrationParamsV1> {
         let RegistrationParams::V1(v1_self) = self;
         Some(v1_self)


### PR DESCRIPTION
- Now validation or execution of the automation task registration will
    fail if task's max-gas amount and gas-price-cap do not fall in the
    defined boundaries.
Fixes https://github.com/Entropy-Foundation/smr-moonshot/issues/1839
