### PR TITLE
[Feat #1813] Make cli work with v3 apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14808,6 +14808,7 @@ dependencies = [
  "anyhow",
  "aptos-types",
  "async-trait",
+ "clap 4.4.14",
  "reqwest",
 ]
 

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -230,7 +230,7 @@ impl CliCommand<RotateSummary> for RotateKey {
             ..self.txn_options.profile_options.profile()?
         };
 
-        if let Some(url) = self.txn_options.rest_options.url {
+        if let Some(url) = self.txn_options.rest_options.rpc_url {
             profile_config.rest_url = Some(url.into());
         }
 

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -69,6 +69,7 @@ use std::{
 };
 use thiserror::Error;
 use aptos_crypto::hash::HashValueParseError;
+use supra_aptos::ApiVersion;
 
 pub const USER_AGENT: &str = concat!("aptos-cli/", env!("CARGO_PKG_VERSION"));
 const US_IN_SECS: u64 = 1_000_000;
@@ -988,6 +989,8 @@ pub struct RestOptions {
     /// environment variable.
     #[clap(long, env)]
     pub node_api_key: Option<String>,
+    #[clap(long, default_value_t = ApiVersion::V3)]
+    pub(crate) api_version: ApiVersion,
 }
 
 impl RestOptions {
@@ -996,6 +999,7 @@ impl RestOptions {
             url,
             connection_timeout_secs: connection_timeout_secs.unwrap_or(DEFAULT_EXPIRATION_SECS),
             node_api_key: None,
+            api_version: ApiVersion::default(),
         }
     }
 

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -978,7 +978,7 @@ pub struct RestOptions {
     ///
     /// Defaults to the URL in the `default` profile
     #[clap(long)]
-    pub(crate) url: Option<reqwest::Url>,
+    pub(crate) rpc_url: Option<reqwest::Url>,
 
     /// Connection timeout in seconds, used for the REST endpoint of the fullnode
     #[clap(long, default_value_t = DEFAULT_EXPIRATION_SECS, alias = "connection-timeout-s")]
@@ -996,7 +996,7 @@ pub struct RestOptions {
 impl RestOptions {
     pub fn new(url: Option<reqwest::Url>, connection_timeout_secs: Option<u64>) -> Self {
         RestOptions {
-            url,
+            rpc_url: url,
             connection_timeout_secs: connection_timeout_secs.unwrap_or(DEFAULT_EXPIRATION_SECS),
             node_api_key: None,
             api_version: ApiVersion::default(),
@@ -1005,7 +1005,7 @@ impl RestOptions {
 
     /// Retrieve the URL from the profile or the command line
     pub fn url(&self, profile: &ProfileOptions) -> CliTypedResult<reqwest::Url> {
-        if let Some(ref url) = self.url {
+        if let Some(ref url) = self.rpc_url {
             Ok(url.clone())
         } else if let Some(Some(url)) = CliConfig::load_profile(
             profile.profile_name(),

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -39,6 +39,10 @@ impl fmt::Display for CachedPackageMetadata<'_> {
 }
 
 impl CachedPackageRegistry {
+    pub fn new(inner: PackageRegistry, bytecode: BTreeMap<String, Vec<u8>>) -> Self {
+        Self { inner, bytecode }
+    }
+
     /// Creates a new registry.
     pub async fn create(
         url: Url,

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -39,10 +39,6 @@ impl fmt::Display for CachedPackageMetadata<'_> {
 }
 
 impl CachedPackageRegistry {
-    pub fn new(inner: PackageRegistry, bytecode: BTreeMap<String, Vec<u8>>) -> Self {
-        Self { inner, bytecode }
-    }
-
     /// Creates a new registry.
     pub async fn create(
         url: Url,

--- a/crates/aptos/src/supra_specific.rs
+++ b/crates/aptos/src/supra_specific.rs
@@ -1,5 +1,4 @@
-// Copyright (c) Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright © Entropy Foundation
 
 use crate::common::types::{GasOptions, ProfileOptions, RestOptions};
 
@@ -15,6 +14,7 @@ impl From<RestOptions> for supra_aptos::RestOptions {
             url: value.url,
             connection_timeout_secs: value.connection_timeout_secs,
             node_api_key: value.node_api_key,
+            api_version: value.api_version,
         }
     }
 }

--- a/crates/aptos/src/supra_specific.rs
+++ b/crates/aptos/src/supra_specific.rs
@@ -11,7 +11,7 @@ impl From<ProfileOptions> for supra_aptos::ProfileOptions {
 impl From<RestOptions> for supra_aptos::RestOptions {
     fn from(value: RestOptions) -> Self {
         Self {
-            url: value.url,
+            rpc_url: value.rpc_url,
             connection_timeout_secs: value.connection_timeout_secs,
             node_api_key: value.node_api_key,
             api_version: value.api_version,

--- a/crates/supra/Cargo.toml
+++ b/crates/supra/Cargo.toml
@@ -13,4 +13,5 @@ rust-version.workspace = true
 aptos-types = { workspace = true }
 reqwest = { workspace = true }
 anyhow = { workspace = true }
-async-trait= { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }

--- a/crates/supra/src/lib.rs
+++ b/crates/supra/src/lib.rs
@@ -40,7 +40,7 @@ pub struct RestOptions {
     /// URL to a fullnode on the network
     ///
     /// Defaults to the URL in the `default` profile
-    pub url: Option<reqwest::Url>,
+    pub rpc_url: Option<reqwest::Url>,
 
     /// Connection timeout in seconds, used for the REST endpoint of the fullnode
     pub connection_timeout_secs: u64,

--- a/crates/supra/src/lib.rs
+++ b/crates/supra/src/lib.rs
@@ -1,12 +1,30 @@
-// Copyright (c) Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
-
 // Copyright © Entropy Foundation
 
 use anyhow::Result;
-use async_trait::async_trait;
 use aptos_types::account_address::AccountAddress;
 use aptos_types::transaction::TransactionPayload;
+use async_trait::async_trait;
+use clap::ValueEnum;
+use std::fmt::{Display, Formatter};
+
+/// RPC api versions maintained by this module.
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Default, ValueEnum)]
+pub enum ApiVersion {
+    V1,
+    V2,
+    #[default]
+    V3,
+}
+
+impl Display for ApiVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiVersion::V1 => write!(f, "v1"),
+            ApiVersion::V2 => write!(f, "v2"),
+            ApiVersion::V3 => write!(f, "v3"),
+        }
+    }
+}
 
 pub struct ProfileOptions {
     /// Profile to use from the CLI config
@@ -31,6 +49,7 @@ pub struct RestOptions {
     /// as `Authorization: Bearer <key>`. You may also set this with the NODE_API_KEY
     /// environment variable.
     pub node_api_key: Option<String>,
+    pub api_version: ApiVersion,
 }
 
 pub struct GasOptions {
@@ -74,13 +93,11 @@ pub struct SupraCommandArguments {
     pub profile_options: ProfileOptions,
     pub rest_options: RestOptions,
     pub gas_options: GasOptions,
-
 }
 
 /// Trait required by supra cli for its operation.
 #[async_trait]
 pub trait SupraCommand {
-
     /// consume self and returns [SupraCommandArguments]
     async fn supra_command_arguments(self) -> Result<SupraCommandArguments>;
 }


### PR DESCRIPTION
- rest_options.url => rest_options.rpc_url
- Default ApiVersion is V3

# Release/v9
- https://github.com/Entropy-Foundation/smr-moonshot/pull/1849

# Dev PR
- https://github.com/Entropy-Foundation/aptos-core/pull/218