### PR TITLE
[AN-Issue-1629] Optimize on_new_epoch to reduce gas-usage

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -123,6 +123,7 @@ pub enum FeatureFlag {
     AbortIfMultisigPayloadMismatch,
     SupraNativeAutomation,
     SupraEthTrie,
+    SupraAutomationPayloadGasCheck
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -320,6 +321,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             },
             FeatureFlag::SupraNativeAutomation => AptosFeatureFlag::SUPRA_NATIVE_AUTOMATION,
             FeatureFlag::SupraEthTrie => AptosFeatureFlag::SUPRA_ETH_TRIE,
+            FeatureFlag::SupraAutomationPayloadGasCheck => AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK,
         }
     }
 }
@@ -446,6 +448,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             },
             AptosFeatureFlag::SUPRA_NATIVE_AUTOMATION => FeatureFlag::SupraNativeAutomation,
             AptosFeatureFlag::SUPRA_ETH_TRIE=> FeatureFlag::SupraEthTrie,
+            AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK => FeatureFlag::SupraAutomationPayloadGasCheck
         }
     }
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -133,6 +133,8 @@ return true.
 -  [Function `supra_native_automation_enabled`](#0x1_features_supra_native_automation_enabled)
 -  [Function `get_supra_eth_trie_feature`](#0x1_features_get_supra_eth_trie_feature)
 -  [Function `supra_eth_trie_enabled`](#0x1_features_supra_eth_trie_enabled)
+-  [Function `get_supra_automation_payload_gas_check_feature`](#0x1_features_get_supra_automation_payload_gas_check_feature)
+-  [Function `supra_automation_payload_gas_check_enabled`](#0x1_features_supra_automation_payload_gas_check_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -854,6 +856,19 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_STRUCT_CONSTRUCTORS">STRUCT_CONSTRUCTORS</a>: u64 = 15;
+</code></pre>
+
+
+
+<a id="0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK"></a>
+
+Whether gas check of automation-task during registration is enabled. Once enabled, the inner payload along with
+task gas parameters in scope of automation registration transaction will pass gas check.
+
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>: u64 = 90;
 </code></pre>
 
 
@@ -3351,6 +3366,54 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_eth_trie_enabled">supra_eth_trie_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SUPRA_ETH_TRIE">SUPRA_ETH_TRIE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_get_supra_automation_payload_gas_check_feature"></a>
+
+## Function `get_supra_automation_payload_gas_check_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_supra_automation_payload_gas_check_feature">get_supra_automation_payload_gas_check_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_supra_automation_payload_gas_check_feature">get_supra_automation_payload_gas_check_feature</a>(): u64 {
+    <a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_supra_automation_payload_gas_check_enabled"></a>
+
+## Function `supra_automation_payload_gas_check_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_automation_payload_gas_check_enabled">supra_automation_payload_gas_check_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_automation_payload_gas_check_enabled">supra_automation_payload_gas_check_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -687,6 +687,20 @@ module std::features {
         is_enabled(SUPRA_ETH_TRIE)
     }
 
+    /// Whether gas check of automation-task during registration is enabled. Once enabled, the inner payload along with
+    /// task gas parameters in scope of automation registration transaction will pass gas check.
+    ///
+    /// Lifetime: transient
+    const SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK: u64 = 90;
+
+    public fun get_supra_automation_payload_gas_check_feature(): u64 {
+        SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK
+    }
+
+    public fun supra_automation_payload_gas_check_enabled(): bool acquires Features {
+        is_enabled(SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -1365,7 +1365,7 @@ Represents intermediate state of the registry on epoch change.
 
 </dd>
 <dt>
-<code>gas_committed_for_new_epoch: u256</code>
+<code>gas_committed_for_new_epoch: u64</code>
 </dt>
 <dd>
 
@@ -1803,7 +1803,8 @@ Constants describing task state.
 
 <a id="0x1_automation_registry_REFUND_FACTOR"></a>
 
-Defines refund factor for refunds of deposit fees with penalty
+Defines divisor for refunds of deposit fees with penalty
+Factor of <code>2</code> suggests that <code>1/2</code> of the deposit will be refunded.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>: u64 = 2;
@@ -2605,6 +2606,7 @@ Initialization of Automation Registry with configuration parameters is expected 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
         total_deposited_automation_fee: 0
     });
@@ -2724,7 +2726,7 @@ On new epoch this function will be triggered and update the automation registry 
 
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees_value;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = gas_committed_for_new_epoch;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (gas_committed_for_new_epoch <b>as</b> u256);
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
@@ -2919,7 +2921,7 @@ that have been removed from the registry.
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
         } <b>else</b> {
             task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-            tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
+            tcmg = tcmg + task.max_gas_amount;
         }
     });
     <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
@@ -2982,7 +2984,7 @@ that have been removed from the registry.
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
         } <b>else</b> {
             task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-            tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
+            tcmg = tcmg + task.max_gas_amount;
         }
     });
 
@@ -3517,7 +3519,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     // Compute the automation fee multiplier for epoch
     <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
         arc,
-        intermediate_state.gas_committed_for_new_epoch,
+        (intermediate_state.gas_committed_for_new_epoch <b>as</b> u256),
         arc.registry_max_gas_cap);
 
     <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -13,7 +13,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
 -  [Resource `AutomationRefundBookkeeping`](#0x1_automation_registry_AutomationRefundBookkeeping)
--  [Resource `ToggleNewEpoch`](#0x1_automation_registry_ToggleNewEpoch)
 -  [Resource `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
 -  [Struct `TaskRegistrationFeeWithdraw`](#0x1_automation_registry_TaskRegistrationFeeWithdraw)
 -  [Struct `TaskRegistrationDepositFeeWithdraw`](#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw)
@@ -35,10 +34,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `DisabledRegistrationEvent`](#0x1_automation_registry_DisabledRegistrationEvent)
 -  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
 -  [Struct `AutomationTaskFeeMeta`](#0x1_automation_registry_AutomationTaskFeeMeta)
--  [Struct `IntermediateState`](#0x1_automation_registry_IntermediateState)
 -  [Struct `IntermediateStateWithCoins`](#0x1_automation_registry_IntermediateStateWithCoins)
 -  [Constants](#@Constants_0)
--  [Function `deposit_epoch_fee_to_registry_fee_address`](#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
@@ -65,13 +62,11 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `initialize`](#0x1_automation_registry_initialize)
 -  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
--  [Function `on_new_epoch_old`](#0x1_automation_registry_on_new_epoch_old)
 -  [Function `adjust_tasks_epoch_fee_refund`](#0x1_automation_registry_adjust_tasks_epoch_fee_refund)
 -  [Function `refund_tasks_fee`](#0x1_automation_registry_refund_tasks_fee)
--  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
--  [Function `on_new_epoch_2`](#0x1_automation_registry_on_new_epoch_2)
 -  [Function `update_state_for_new_epoch`](#0x1_automation_registry_update_state_for_new_epoch)
 -  [Function `refund_cleanup_and_activate_tasks`](#0x1_automation_registry_refund_cleanup_and_activate_tasks)
+-  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
 -  [Function `safe_refund`](#0x1_automation_registry_safe_refund)
 -  [Function `safe_deposit_refund`](#0x1_automation_registry_safe_deposit_refund)
 -  [Function `safe_unlock_locked_deposit`](#0x1_automation_registry_safe_unlock_locked_deposit)
@@ -84,13 +79,10 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
 -  [Function `try_withdraw_task_automation_fee`](#0x1_automation_registry_try_withdraw_task_automation_fee)
--  [Function `try_withdraw_task_automation_fees_2`](#0x1_automation_registry_try_withdraw_task_automation_fees_2)
--  [Function `try_withdraw_task_automation_fee_2`](#0x1_automation_registry_try_withdraw_task_automation_fee_2)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `update_config`](#0x1_automation_registry_update_config)
--  [Function `toggle_new_epoch`](#0x1_automation_registry_toggle_new_epoch)
 -  [Function `enable_registration`](#0x1_automation_registry_enable_registration)
 -  [Function `disable_registration`](#0x1_automation_registry_disable_registration)
 -  [Function `register`](#0x1_automation_registry_register)
@@ -98,8 +90,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `cancel_task`](#0x1_automation_registry_cancel_task)
 -  [Function `stop_tasks`](#0x1_automation_registry_stop_tasks)
 -  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
--  [Function `sort_by_task_index`](#0x1_automation_registry_sort_by_task_index)
--  [Function `sort`](#0x1_automation_registry_sort)
+-  [Function `sort_vector`](#0x1_automation_registry_sort_vector)
 -  [Function `upscale_from_u8`](#0x1_automation_registry_upscale_from_u8)
 -  [Function `upscale_from_u64`](#0x1_automation_registry_upscale_from_u64)
 -  [Function `upscale_from_u256`](#0x1_automation_registry_upscale_from_u256)
@@ -387,34 +378,6 @@ Automation Deposited fee bookkeeping configs
 
 </details>
 
-<a id="0x1_automation_registry_ToggleNewEpoch"></a>
-
-## Resource `ToggleNewEpoch`
-
-
-
-<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a> <b>has</b> <b>copy</b>, key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>optimized: bool</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x1_automation_registry_AutomationTaskMetaData"></a>
 
 ## Resource `AutomationTaskMetaData`
@@ -505,7 +468,10 @@ Automation Deposited fee bookkeeping configs
 <code>locked_fee_for_next_epoch: u64</code>
 </dt>
 <dd>
- Fee locked for the task estimated for the next epoch at the start of the current epoch.
+ Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for the task.
+ It will be refunded fully when active task is expired or cancelled by user
+ and partially if a pending task is cancelled by user or by the system due to insufficient balance to
+ pay the automation fee for the epoch
 </dd>
 </dl>
 
@@ -590,7 +556,7 @@ Event on task registration fee withdrawal from owner account upon registration.
 
 </dd>
 <dt>
-<code>deposit_epoch_fee: u64</code>
+<code>locked_deposit_fee: u64</code>
 </dt>
 <dd>
 
@@ -1003,7 +969,7 @@ Event emitted when an automation task is cancelled due to automation fee capacit
 
 ## Struct `RemovedTasks`
 
-Event emitted when an automation task is cancelled due to automation fee capacity surpass.
+Event emitted on epoch transition containing removed task indexes.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
@@ -1092,8 +1058,9 @@ but it does not exist in the list.
 
 ## Struct `ErrorInsufficientBalanceToRefund`
 
-Event emitted when on new epoch refunds to be paid is not possible due to insufficient resource account balance.
-Type of the refund can be either deposit paid during registration (0), or caused by the shortening of the epoch (1)
+Event emitted during epoch transition when refunds to be paid is not possible due to insufficient resource account balance.
+Type of the refund can be releated either to the deposit paid during registration (0), or to epoch-fee caused by
+the shortening of the epoch (1)
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
@@ -1288,47 +1255,7 @@ Represents the fee charged for an automation task execution and some additional 
 
 </dd>
 <dt>
-<code>locked_fee_for_next_epoch: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_IntermediateState"></a>
-
-## Struct `IntermediateState`
-
-Represents intermediate state of the registry on epoch change.
-
-
-<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> <b>has</b> drop
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>removed_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>gas_committed_for_next_epoch: u64</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>epoch_locked_fees: u64</code>
+<code>locked_deposit_fee: u64</code>
 </dt>
 <dd>
 
@@ -1769,36 +1696,6 @@ The length of the transaction hash.
 
 
 
-<a id="0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address"></a>
-
-## Function `deposit_epoch_fee_to_registry_fee_address`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address">deposit_epoch_fee_to_registry_fee_address</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, value: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address">deposit_epoch_fee_to_registry_fee_address</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, value: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>) {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
-        removed_task_ids: _,
-        gas_committed_for_next_epoch: _,
-        epoch_locked_fees,
-
-    } = value;
-    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_is_initialized"></a>
 
 ## Function `is_initialized`
@@ -1821,7 +1718,6 @@ Checks whether all required resources are created.
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework)
-    && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>&gt;(@supra_framework)
 }
 </code></pre>
 
@@ -2542,9 +2438,6 @@ Initialization of Automation Registry with configuration parameters is expected 
         epoch_interval: epoch_interval_secs,
         start_time: 0,
     });
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a> {
-        optimized: <b>false</b>,
-    });
 
     <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework)
 }
@@ -2584,6 +2477,7 @@ Initialization of Automation Registry with configuration parameters is expected 
 
 ## Function `on_new_epoch`
 
+On new epoch this function will be triggered and update the automation registry state
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>()
@@ -2595,38 +2489,8 @@ Initialization of Automation Registry with configuration parameters is expected 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> , <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>{
-    <b>let</b> toggle_epoch_change = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>&gt;(@supra_framework);
-    <b>if</b> (toggle_epoch_change.optimized) {
-        <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>()
-    } <b>else</b> {
-        <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_old">on_new_epoch_old</a>()
-    }
-
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_on_new_epoch_old"></a>
-
-## Function `on_new_epoch_old`
-
-On new epoch this function will be triggered and update the automation registry state
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_old">on_new_epoch_old</a>()
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_old">on_new_epoch_old</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>(
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Unless registry in initialized, registry will not be updated on new epoch.
     // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
     //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
@@ -2644,14 +2508,14 @@ On new epoch this function will be triggered and update the automation registry 
     ).main_config;
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-
-    // Refund the task <b>if</b> the epoch was shorter than expected.
-    <a href="automation_registry.md#0x1_automation_registry_adjust_tasks_epoch_fee_refund">adjust_tasks_epoch_fee_refund</a>(
+    <b>let</b> (new_epoch_tcmg, removed_tasks) = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        refund_bookkeeping,
         &automation_registry_config,
         automation_epoch_info,
         current_time
     );
+
 
     // Apply the latest configuration <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> parameter <b>has</b> been updated
     // only after refund <b>has</b> been done for previous epoch.
@@ -2674,40 +2538,28 @@ On new epoch this function will be triggered and update the automation registry 
         <b>return</b>
     };
 
-    // Accumulated maximum gas amount of the registered tasks for the current epoch
-    <b>let</b> (tcmg, removed_tasks) = <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, current_time);
 
-
-    <b>let</b> tasks_automation_fees = <a href="automation_registry.md#0x1_automation_registry_calculate_tasks_automation_fees">calculate_tasks_automation_fees</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        &automation_registry_config,
-        automation_epoch_info.epoch_interval,
-        current_time,
-        tcmg,
-        <b>false</b>
-    );
-
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: 0,
-        removed_task_ids: removed_tasks,
-    };
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
         gas_committed_for_next_epoch,
         epoch_locked_fees,
-        removed_task_ids
+        removed_task_ids,
     } = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         refund_bookkeeping,
-        tasks_automation_fees,
-        current_time,
+        &automation_registry_config,
         automation_epoch_info.epoch_interval,
-        intermediate_state
+        current_time,
+        new_epoch_tcmg,
+        removed_tasks,
     );
 
+    <b>let</b> epoch_locked_fees_value = <a href="coin.md#0x1_coin_value">coin::value</a>(&epoch_locked_fees);
+
+    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
+
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = tcmg;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees_value;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = new_epoch_tcmg;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
@@ -2811,165 +2663,6 @@ Processes refunds for automation task fees.
 
 </details>
 
-<a id="0x1_automation_registry_cleanup_and_activate_tasks"></a>
-
-## Function `cleanup_and_activate_tasks`
-
-Cleanup and activate the automation task also it's calculate and return total committed max gas
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <b>let</b> tcmg = 0;
-    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-    // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
-        } <b>else</b> {
-            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-
-            // Drop or activate task for this current epoch.
-            <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
-                <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-                    refund_bookkeeping,
-                    &resource_signer,
-                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-                    task.task_index,
-                    task.owner,
-                    task.locked_fee_for_next_epoch,
-                task.locked_fee_for_next_epoch);
-                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-            } <b>else</b> {
-                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
-            }
-        }
-    });
-    (tcmg, removed_tasks)
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_on_new_epoch_2"></a>
-
-## Function `on_new_epoch_2`
-
-On new epoch this function will be triggered and update the automation registry state
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>()
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>(
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-    // Unless registry in initialized, registry will not be updated on new epoch.
-    // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
-    //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
-    //  - all tasks should be removed from registry state
-    // Note that <b>with</b> the current setup feature::on_new_epoch is called before <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>
-    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
-        <b>return</b>
-    };
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
-    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-
-    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
-        @supra_framework
-    ).main_config;
-
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> (new_epoch_tcmg, removed_tasks) = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        refund_bookkeeping,
-        &automation_registry_config,
-        automation_epoch_info,
-        current_time
-    );
-
-
-    // Apply the latest configuration <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> parameter <b>has</b> been updated
-    // only after refund <b>has</b> been done for previous epoch.
-    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
-
-    // If feature is not enabled then we are not charging and tasks are cleared.
-    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping);
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
-            task_indexes: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks)
-        });
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-        automation_epoch_info.start_time = current_time;
-        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-        <b>return</b>
-    };
-
-    <b>let</b> intermediate_state_with_coins = <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>&lt;SupraCoin&gt;(),
-        removed_task_ids: removed_tasks,
-    };
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-        gas_committed_for_next_epoch,
-        epoch_locked_fees,
-        removed_task_ids
-    } = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        refund_bookkeeping,
-        &automation_registry_config,
-        automation_epoch_info.epoch_interval,
-        current_time,
-        new_epoch_tcmg,
-        intermediate_state_with_coins
-    );
-
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = new_epoch_tcmg;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    automation_epoch_info.start_time = current_time;
-    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
-        task_indexes: removed_task_ids
-    });
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_update_state_for_new_epoch"></a>
 
 ## Function `update_state_for_new_epoch`
@@ -3059,8 +2752,12 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
         <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
         <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
-            <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task,
-                refund_interval, current_time, refund_automation_fee_per_sec);
+            <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
+                arc,
+                task,
+                refund_interval,
+                current_time,
+                refund_automation_fee_per_sec);
             <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
                 &resource_signer,
                 <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
@@ -3070,8 +2767,7 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
         };
 
         // Drop or activate task for this current epoch.
-        <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task.expiry_time &lt;= current_time) {
-            // Refund deposited epoch-fee for cancelled and expired tasks.
+        <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
             <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
                 refund_bookkeeping,
                 &resource_signer,
@@ -3085,6 +2781,66 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
         } <b>else</b> {
             task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
             tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
+        }
+    });
+    (tcmg, removed_tasks)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_cleanup_and_activate_tasks"></a>
+
+## Function `cleanup_and_activate_tasks`
+
+Cleanup and activate the automation task also it's calculate and return total committed max gas
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    current_time: u64
+): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <b>let</b> tcmg = 0;
+    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
+        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
+        } <b>else</b> {
+            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            // Drop or activate task for this current epoch.
+            <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
+                <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+                    refund_bookkeeping,
+                    &resource_signer,
+                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    task.locked_fee_for_next_epoch,
+                    task.locked_fee_for_next_epoch);
+                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
+            } <b>else</b> {
+                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
+            }
         }
     });
     (tcmg, removed_tasks)
@@ -3110,7 +2866,14 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_amount: u64, refund_type: u8):  bool {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    resource_address: <b>address</b>,
+    task_index: u64,
+    task_owner: <b>address</b>,
+    refundable_amount: u64,
+    refund_type: u8
+):  bool {
     <b>let</b> balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(resource_address);
     <b>if</b> (balance &lt; refundable_amount) {
         <a href="event.md#0x1_event_emit">event::emit</a>(
@@ -3143,8 +2906,22 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64):  bool {
-    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer, resouce_address, task_index, task_owner, refundable_deposit, <a href="automation_registry.md#0x1_automation_registry_DEPOSIT_EPOCH_FEE">DEPOSIT_EPOCH_FEE</a>);
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+    rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    resouce_address: <b>address</b>,
+    task_index: u64,
+    task_owner: <b>address</b>,
+    refundable_deposit: u64,
+    locked_deposit: u64
+):  bool {
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
+        resource_signer,
+        resouce_address,
+        task_index,
+        task_owner,
+        refundable_deposit,
+        <a href="automation_registry.md#0x1_automation_registry_DEPOSIT_EPOCH_FEE">DEPOSIT_EPOCH_FEE</a>);
     <b>if</b> (result) {
         <a href="event.md#0x1_event_emit">event::emit</a>(
             <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index, owner: task_owner, amount: refundable_deposit }
@@ -3174,7 +2951,11 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64) {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(
+    rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    locked_deposit: u64,
+    task_index: u64
+) {
     <b>if</b> (rb.total_deposited_automation_fee &gt;= locked_deposit) {
         rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
     } <b>else</b> {
@@ -3205,8 +2986,20 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64):  bool {
-    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer, resouce_address, task_index, task_owner, refundable_fee, <a href="automation_registry.md#0x1_automation_registry_EPOCH_FEE">EPOCH_FEE</a>);
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    resouce_address: <b>address</b>,
+    task_index: u64,
+    task_owner: <b>address</b>,
+    refundable_fee: u64
+):  bool {
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
+        resource_signer,
+        resouce_address,
+        task_index,
+        task_owner,
+        refundable_fee,
+        <a href="automation_registry.md#0x1_automation_registry_EPOCH_FEE">EPOCH_FEE</a>);
     <b>if</b> (result) {
         <a href="event.md#0x1_event_emit">event::emit</a>(
             <a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index, owner: task_owner, amount: refundable_fee }
@@ -3235,7 +3028,9 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>) {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>) {
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
@@ -3514,7 +3309,7 @@ Processes automation task fees by checking user balances and task's commitment o
 Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, tasks_automation_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>&gt;, current_time: u64, epoch_interval: u64, intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256, removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>
 </code></pre>
 
 
@@ -3526,30 +3321,54 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    tasks_automation_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt;,
-    current_time: u64,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     epoch_interval: u64,
-    intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>,
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+    current_time: u64,
+    tcmg: u256,
+    removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
+    <b>let</b> intermediate_state_with_coins = <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>&lt;SupraCoin&gt;(),
+        removed_task_ids: removed_tasks,
+    };
+    // Compute the automation congestion fee (acf) for the epoch
+    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
+    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+    <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    <b>let</b> current_epoch_end_time = current_time + epoch_interval;
 
-    <a href="automation_registry.md#0x1_automation_registry_sort_by_task_index">sort_by_task_index</a>(&<b>mut</b> tasks_automation_fees);
+    // Sort task indexes <b>to</b> charge autoamtion fees in the tasks chronological order
+    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
 
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(tasks_automation_fees, |task| {
-        <b>let</b> task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> = task;
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> { task_index: task.task_index })
-        } <b>else</b> {
-            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-                refund_bookkeeping,
-                task,
-                current_time,
-                epoch_interval,
-                &<b>mut</b> intermediate_state
-            );
+    // Process each active task and calculate fee for the epoch for the tasks
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
+        <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+        <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+            task_index,
+            owner: task_meta.owner,
+            fee: 0,
+            expiry_time: task_meta.expiry_time,
+            automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+            max_gas_amount: task_meta.max_gas_amount,
+            locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
         };
+        <b>if</b> (automation_fee_per_sec != 0) {
+            task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+        };
+        <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+            refund_bookkeeping,
+            &resource_signer,
+            task,
+            current_epoch_end_time,
+            &<b>mut</b> intermediate_state_with_coins
+        );
     });
-    intermediate_state
+    intermediate_state_with_coins
 }
 </code></pre>
 
@@ -3563,7 +3382,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_epoch_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>)
 </code></pre>
 
 
@@ -3575,178 +3394,9 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>,
-    current_time: u64,
-    epoch_interval: u64,
-    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>) {
-    <b>let</b> task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-
-    // Remove the automation task <b>if</b> the epoch fee cap is exceeded
-    <b>if</b> (task.fee &gt; task_metadata.automation_fee_cap_for_epoch) {
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-            refund_bookkeeping,
-            &resource_signer,
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-            task.task_index,
-            task.owner,
-            task_metadata.locked_fee_for_next_epoch,
-            task_metadata.locked_fee_for_next_epoch
-        );
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
-            task_index: task.task_index,
-            owner: task_metadata.owner,
-            fee: task.fee,
-            automation_fee_cap: task_metadata.automation_fee_cap_for_epoch,
-        });
-        <b>return</b>
-    };
-    <b>let</b> user_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(task_metadata.owner);
-    <b>if</b> (user_balance &lt; task.fee) {
-        // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
-            task_index: task.task_index,
-            owner: task_metadata.owner,
-            fee: task.fee,
-        });
-        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task_metadata.locked_fee_for_next_epoch, task.task_index);
-        <b>return</b>
-    };
-    <b>if</b> (task.fee != 0) {
-        // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
-        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
-            &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task_metadata.owner),
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-            task.fee
-        );
-    };
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskEpochFeeWithdraw">TaskEpochFeeWithdraw</a> {
-        task_index: task.task_index,
-        owner: task_metadata.owner,
-        fee: task.fee,
-    });
-    // Total task fees deducted from the user's <a href="account.md#0x1_account">account</a>
-    intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
-
-    // Calculate gas commitment for the next epoch only for valid active tasks
-    <b>if</b> (task_metadata.expiry_time &gt; (current_time + epoch_interval)) {
-        intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
-    };
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_try_withdraw_task_automation_fees_2"></a>
-
-## Function `try_withdraw_task_automation_fees_2`
-
-Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-- If the user has sufficient balance, deducts the fee and emits a success event.
-- If the balance is insufficient, removes the task and emits a cancellation event.
-- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256, intermediate_state_with_coins: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    epoch_interval: u64,
-    current_time: u64,
-    tcmg: u256,
-    intermediate_state_with_coins: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-    // Compute the automation congestion fee (acf) for the epoch
-    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
-    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
-    <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-
-    // Sort task indexes <b>to</b> charge autoamtion fees in the tasks chronological order
-    <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(&<b>mut</b> task_ids);
-
-    // Process each active task and calculate fee for the epoch for the tasks
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-        <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
-            task_index,
-            owner: task_meta.owner,
-            fee: 0,
-            expiry_time: task_meta.expiry_time,
-            automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-            max_gas_amount: task_meta.max_gas_amount,
-            locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
-        };
-        <b>if</b> (automation_fee_per_sec != 0) {
-            task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
-        };
-        <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-            refund_bookkeeping,
-            &resource_signer,
-            task,
-            current_time,
-            epoch_interval,
-            &<b>mut</b> intermediate_state_with_coins
-        );
-    });
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-        gas_committed_for_next_epoch: intermediate_state_with_coins.gas_committed_for_next_epoch,
-        epoch_locked_fees: <a href="coin.md#0x1_coin_value">coin::value</a>(&intermediate_state_with_coins.epoch_locked_fees),
-        removed_task_ids: intermediate_state_with_coins.removed_task_ids
-    };
-
-    <a href="automation_registry.md#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address">deposit_epoch_fee_to_registry_fee_address</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, intermediate_state_with_coins);
-    intermediate_state
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_try_withdraw_task_automation_fee_2"></a>
-
-## Function `try_withdraw_task_automation_fee_2`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a>,
-    current_time: u64,
-    epoch_interval: u64,
+    current_epoch_end_time: u64,
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>) {
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task.automation_fee_cap) {
@@ -3756,8 +3406,8 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
             task.task_index,
             task.owner,
-            task.locked_fee_for_next_epoch,
-            task.locked_fee_for_next_epoch
+            task.locked_deposit_fee,
+            task.locked_deposit_fee
         );
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
@@ -3771,7 +3421,8 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     };
     <b>let</b> user_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(task.owner);
     <b>if</b> (user_balance &lt; task.fee) {
-        // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
+        // If the user does not have enough balance, remove the task, refund the locked deposit and emit an <a href="event.md#0x1_event">event</a>
+        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task.locked_deposit_fee, task.task_index);
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
@@ -3779,7 +3430,6 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
             owner: task.owner,
             fee: task.fee,
         });
-        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
         <b>return</b>
     };
     <b>if</b> (task.fee != 0) {
@@ -3798,7 +3448,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     });
 
     // Calculate gas commitment for the next epoch only for valid active tasks
-    <b>if</b> (task.expiry_time &gt; (current_time + epoch_interval)) {
+    <b>if</b> (task.expiry_time &gt; current_epoch_end_time) {
         intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task.max_gas_amount;
     };
 }
@@ -3983,33 +3633,6 @@ Update Automation Registry Config
 
 </details>
 
-<a id="0x1_automation_registry_toggle_new_epoch"></a>
-
-## Function `toggle_new_epoch`
-
-Enables the registration process in the automation registry.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_toggle_new_epoch">toggle_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, flag: bool)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_toggle_new_epoch">toggle_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, flag: bool) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <b>let</b> toggle_new_epoch = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>&gt;(@supra_framework);
-    toggle_new_epoch.optimized = flag;
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_enable_registration"></a>
 
 ## Function `enable_registration`
@@ -4139,7 +3762,6 @@ Registers a new automation task entry.
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = committed_gas;
     <b>let</b> task_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index;
 
-    <b>let</b> deposit_automation_fee = automation_fee_cap_for_epoch;
     <b>let</b> automation_task_metadata = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> {
         task_index,
         owner,
@@ -4152,17 +3774,17 @@ Registers a new automation task entry.
         state: <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>,
         registration_time,
         tx_hash,
-        locked_fee_for_next_epoch: deposit_automation_fee
+        locked_fee_for_next_epoch: automation_fee_cap_for_epoch
     };
 
     <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index, automation_task_metadata);
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index + 1;
 
     // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
-    <b>let</b> fee = automation_registry_config.main_config.flat_registration_fee_in_quants + deposit_automation_fee;
+    <b>let</b> fee = automation_registry_config.main_config.flat_registration_fee_in_quants + automation_fee_cap_for_epoch;
 
     <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-    refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + deposit_automation_fee;
+    refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + automation_fee_cap_for_epoch;
 
     <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(owner_signer, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, fee);
 
@@ -4170,7 +3792,7 @@ Registers a new automation task entry.
         task_index,
         owner,
         registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
-        deposit_epoch_fee: deposit_automation_fee
+        locked_deposit_fee: automation_fee_cap_for_epoch
     });
     <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
 }
@@ -4265,7 +3887,7 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
             automation_task_metadata.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>,
         automation_task_metadata.locked_fee_for_next_epoch);
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-    } <b>else</b> <b>if</b> (automation_task_metadata.state == <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>) {
+    } <b>else</b> { // it is safe not <b>to</b> check the state <b>as</b> above the already cancelled task's cancellation is rejected.
         // Active tasks will be refunded at the end of the epoch
         <b>let</b> automation_task_metadata_mut = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(
             &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks,
@@ -4451,14 +4073,14 @@ Update epoch interval in registry while actually update happens in block module
 
 </details>
 
-<a id="0x1_automation_registry_sort_by_task_index"></a>
+<a id="0x1_automation_registry_sort_vector"></a>
 
-## Function `sort_by_task_index`
+## Function `sort_vector`
 
-Sorting vector implementation
+Insertion sort implementation for vector
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_by_task_index">sort_by_task_index</a>(v: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4467,42 +4089,7 @@ Sorting vector implementation
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_by_task_index">sort_by_task_index</a>(v: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt;) {
-    <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v);
-    <b>let</b> i = 1;
-    <b>while</b> (i &lt; len) {
-        <b>let</b> j = i;
-        <b>let</b> to_be_sorted = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, j).task_index;
-        <b>while</b> (j &gt; 0 && to_be_sorted &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, j - 1).task_index) {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(v, j, j - 1);
-            j = j - 1;
-        };
-        i = i + 1;
-    };
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_sort"></a>
-
-## Function `sort`
-
-Sorting vector implementation
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(input);
     <b>let</b> i = 1;
     <b>while</b> (i &lt; len) {

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -13,6 +13,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
 -  [Resource `AutomationRefundBookkeeping`](#0x1_automation_registry_AutomationRefundBookkeeping)
+-  [Resource `ToggleNewEpoch`](#0x1_automation_registry_ToggleNewEpoch)
 -  [Resource `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
 -  [Struct `TaskRegistrationFeeWithdraw`](#0x1_automation_registry_TaskRegistrationFeeWithdraw)
 -  [Struct `TaskRegistrationDepositFeeWithdraw`](#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw)
@@ -64,6 +65,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `initialize`](#0x1_automation_registry_initialize)
 -  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
+-  [Function `on_new_epoch_old`](#0x1_automation_registry_on_new_epoch_old)
 -  [Function `adjust_tasks_epoch_fee_refund`](#0x1_automation_registry_adjust_tasks_epoch_fee_refund)
 -  [Function `refund_tasks_fee`](#0x1_automation_registry_refund_tasks_fee)
 -  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
@@ -88,6 +90,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `update_config`](#0x1_automation_registry_update_config)
+-  [Function `toggle_new_epoch`](#0x1_automation_registry_toggle_new_epoch)
 -  [Function `enable_registration`](#0x1_automation_registry_enable_registration)
 -  [Function `disable_registration`](#0x1_automation_registry_disable_registration)
 -  [Function `register`](#0x1_automation_registry_register)
@@ -378,6 +381,34 @@ Automation Deposited fee bookkeeping configs
 <dd>
  Total deposited fee so far which is locked in resource account unless refund of it (fully or partially) is done.
  Independent of refund amount the actual deposited amount is deduced to unlock it from resource account.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_ToggleNewEpoch"></a>
+
+## Resource `ToggleNewEpoch`
+
+
+
+<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a> <b>has</b> <b>copy</b>, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>optimized: bool</code>
+</dt>
+<dd>
+
 </dd>
 </dl>
 
@@ -1789,6 +1820,8 @@ Checks whether all required resources are created.
     <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework)
+        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework)
+    && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>&gt;(@supra_framework)
 }
 </code></pre>
 
@@ -2509,6 +2542,9 @@ Initialization of Automation Registry with configuration parameters is expected 
         epoch_interval: epoch_interval_secs,
         start_time: 0,
     });
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a> {
+        optimized: <b>false</b>,
+    });
 
     <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework)
 }
@@ -2548,7 +2584,6 @@ Initialization of Automation Registry with configuration parameters is expected 
 
 ## Function `on_new_epoch`
 
-On new epoch this function will be triggered and update the automation registry state
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>()
@@ -2560,7 +2595,38 @@ On new epoch this function will be triggered and update the automation registry 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> , <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>{
+    <b>let</b> toggle_epoch_change = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>&gt;(@supra_framework);
+    <b>if</b> (toggle_epoch_change.optimized) {
+        <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>()
+    } <b>else</b> {
+        <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_old">on_new_epoch_old</a>()
+    }
+
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_new_epoch_old"></a>
+
+## Function `on_new_epoch_old`
+
+On new epoch this function will be triggered and update the automation registry state
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_old">on_new_epoch_old</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_old">on_new_epoch_old</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Unless registry in initialized, registry will not be updated on new epoch.
     // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
     //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
@@ -3910,6 +3976,33 @@ Update Automation Registry Config
     automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
 
     <a href="event.md#0x1_event_emit">event::emit</a>(new_automation_registry_config);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_toggle_new_epoch"></a>
+
+## Function `toggle_new_epoch`
+
+Enables the registration process in the automation registry.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_toggle_new_epoch">toggle_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, flag: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_toggle_new_epoch">toggle_new_epoch</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, flag: bool) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>let</b> toggle_new_epoch = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ToggleNewEpoch">ToggleNewEpoch</a>&gt;(@supra_framework);
+    toggle_new_epoch.optimized = flag;
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -3109,7 +3109,7 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64) {
-    <b>if</b> (rb.total_deposited_automation_fee &gt; locked_deposit) {
+    <b>if</b> (rb.total_deposited_automation_fee &gt;= locked_deposit) {
         rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
     } <b>else</b> {
         <a href="event.md#0x1_event_emit">event::emit</a>(
@@ -4224,7 +4224,7 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_stop_tasks">stop_tasks</a>(
     owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Ensure that task indexes are provided
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes), <a href="automation_registry.md#0x1_automation_registry_EEMPTY_TASK_INDEXES">EEMPTY_TASK_INDEXES</a>);
 
@@ -4232,6 +4232,7 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> arc = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework).main_config;
     <b>let</b> epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
 
     <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
 
@@ -4295,6 +4296,7 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
             } <b>else</b> {
                 (0, (task.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FRACTION">REFUND_FRACTION</a>))
             };
+            <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
 
             total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -21,6 +21,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `TaskFeeRefund`](#0x1_automation_registry_TaskFeeRefund)
 -  [Struct `TaskDepositFeeRefund`](#0x1_automation_registry_TaskDepositFeeRefund)
 -  [Struct `ErrorUnlockTaskDepositFee`](#0x1_automation_registry_ErrorUnlockTaskDepositFee)
+-  [Struct `ErrorUnlockTaskEpochFee`](#0x1_automation_registry_ErrorUnlockTaskEpochFee)
 -  [Struct `TaskCancelled`](#0x1_automation_registry_TaskCancelled)
 -  [Struct `TasksStopped`](#0x1_automation_registry_TasksStopped)
 -  [Struct `TaskStopped`](#0x1_automation_registry_TaskStopped)
@@ -32,9 +33,10 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `ErrorInsufficientBalanceToRefund`](#0x1_automation_registry_ErrorInsufficientBalanceToRefund)
 -  [Struct `EnabledRegistrationEvent`](#0x1_automation_registry_EnabledRegistrationEvent)
 -  [Struct `DisabledRegistrationEvent`](#0x1_automation_registry_DisabledRegistrationEvent)
--  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
 -  [Struct `AutomationTaskFeeMeta`](#0x1_automation_registry_AutomationTaskFeeMeta)
--  [Struct `IntermediateStateWithCoins`](#0x1_automation_registry_IntermediateStateWithCoins)
+-  [Struct `IntermediateState`](#0x1_automation_registry_IntermediateState)
+-  [Struct `IntermediateStateOfEpochChange`](#0x1_automation_registry_IntermediateStateOfEpochChange)
+-  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
 -  [Constants](#@Constants_0)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
@@ -62,19 +64,20 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `initialize`](#0x1_automation_registry_initialize)
 -  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
--  [Function `adjust_tasks_epoch_fee_refund`](#0x1_automation_registry_adjust_tasks_epoch_fee_refund)
--  [Function `refund_tasks_fee`](#0x1_automation_registry_refund_tasks_fee)
+-  [Function `finalize_epoch_change`](#0x1_automation_registry_finalize_epoch_change)
+-  [Function `finalize_epoch_change_for_feature_disabled_state`](#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state)
 -  [Function `update_state_for_new_epoch`](#0x1_automation_registry_update_state_for_new_epoch)
 -  [Function `refund_cleanup_and_activate_tasks`](#0x1_automation_registry_refund_cleanup_and_activate_tasks)
 -  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
--  [Function `safe_refund`](#0x1_automation_registry_safe_refund)
+-  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
 -  [Function `safe_deposit_refund`](#0x1_automation_registry_safe_deposit_refund)
 -  [Function `safe_unlock_locked_deposit`](#0x1_automation_registry_safe_unlock_locked_deposit)
+-  [Function `safe_unlock_locked_epoch_fee`](#0x1_automation_registry_safe_unlock_locked_epoch_fee)
 -  [Function `safe_fee_refund`](#0x1_automation_registry_safe_fee_refund)
--  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
--  [Function `calculate_tasks_automation_fees`](#0x1_automation_registry_calculate_tasks_automation_fees)
+-  [Function `safe_refund`](#0x1_automation_registry_safe_refund)
 -  [Function `calculate_task_fee`](#0x1_automation_registry_calculate_task_fee)
 -  [Function `calculate_automation_fee_for_interval`](#0x1_automation_registry_calculate_automation_fee_for_interval)
+-  [Function `calculate_automation_fee_multipler_for_epoch`](#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch)
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
@@ -371,7 +374,7 @@ Automation Deposited fee bookkeeping configs
 </dt>
 <dd>
  Total deposited fee so far which is locked in resource account unless refund of it (fully or partially) is done.
- Independent of refund amount the actual deposited amount is deduced to unlock it from resource account.
+ Regardless of the refunded amount the actual deposited amount is deduced to unlock it from the resource account.
 </dd>
 </dl>
 
@@ -468,10 +471,10 @@ Automation Deposited fee bookkeeping configs
 <code>locked_fee_for_next_epoch: u64</code>
 </dt>
 <dd>
- Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for the task.
+ Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for it.
  It will be refunded fully when active task is expired or cancelled by user
- and partially if a pending task is cancelled by user or by the system due to insufficient balance to
- pay the automation fee for the epoch
+ and partially if a pending task is cancelled by user or an active taks is cancelled by the system due to
+ insufficient balance to  pay the automation fee for the epoch
 </dd>
 </dl>
 
@@ -730,8 +733,8 @@ duration paid at the beginning of the epoch due to epoch-duration reduction by g
 
 ## Struct `ErrorUnlockTaskDepositFee`
 
-Event emitted when an automation fee is refunded but inner state bookkeeping total locked deposits is less than
-potential locked deposit which is being refunded fully or partially
+Event emitted when an automation fee is being refunded but inner state bookkeeping total locked deposits is less than
+potential locked deposit for the task.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
@@ -759,6 +762,48 @@ potential locked deposit which is being refunded fully or partially
 </dd>
 <dt>
 <code>locked_deposit: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_ErrorUnlockTaskEpochFee"></a>
+
+## Struct `ErrorUnlockTaskEpochFee`
+
+Event emitted when an task epoch fee is being refunded but locked epoch fees is less than
+potential requested refund.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ErrorUnlockTaskEpochFee">ErrorUnlockTaskEpochFee</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>locked_epoch_fees: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>refund: u64</code>
 </dt>
 <dd>
 
@@ -1161,46 +1206,6 @@ Emitted when the registration in the automation registry is disabled.
 
 </details>
 
-<a id="0x1_automation_registry_AutomationTaskFee"></a>
-
-## Struct `AutomationTaskFee`
-
-Represents the fee charged for an automation task execution and some additional information.
-
-
-<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> <b>has</b> drop
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>task_index: u64</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>owner: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>fee: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x1_automation_registry_AutomationTaskFeeMeta"></a>
 
 ## Struct `AutomationTaskFeeMeta`
@@ -1265,14 +1270,16 @@ Represents the fee charged for an automation task execution and some additional 
 
 </details>
 
-<a id="0x1_automation_registry_IntermediateStateWithCoins"></a>
+<a id="0x1_automation_registry_IntermediateState"></a>
 
-## Struct `IntermediateStateWithCoins`
+## Struct `IntermediateState`
 
 Represents intermediate state of the registry on epoch change.
+Deprectead in production, substituted with IntermediateStateWithRemovedTasks.
+Kept for backward compatible framework upgrade.
 
 
-<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> <b>has</b> drop
 </code></pre>
 
 
@@ -1283,7 +1290,53 @@ Represents intermediate state of the registry on epoch change.
 
 <dl>
 <dt>
-<code>removed_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+<code>active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_committed_for_next_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch_locked_fees: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_IntermediateStateOfEpochChange"></a>
+
+## Struct `IntermediateStateOfEpochChange`
+
+Represents intermediate state of the registry on epoch change.
+
+
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_committed_for_new_epoch: u256</code>
 </dt>
 <dd>
 
@@ -1296,6 +1349,48 @@ Represents intermediate state of the registry on epoch change.
 </dd>
 <dt>
 <code>epoch_locked_fees: <a href="coin.md#0x1_coin_Coin">coin::Coin</a>&lt;<a href="supra_coin.md#0x1_supra_coin_SupraCoin">supra_coin::SupraCoin</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationTaskFee"></a>
+
+## Struct `AutomationTaskFee`
+
+Represents the fee charged for an automation task execution and some additional information.
+Used only in tests, substituted with AutomationTaskFeeMeta in production code.
+Kept for backward compatible framework upgrade.
+
+
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>fee: u64</code>
 </dt>
 <dd>
 
@@ -1398,6 +1493,16 @@ Congestion exponent must be non-zero.
 
 
 
+<a id="0x1_automation_registry_EDEPOSIT_REFUND"></a>
+
+Failed to refund deposit for the task. For more deatils see the emitted events
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>: u64 = 27;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE"></a>
 
 Supra native automation feature is not initialized or enabled
@@ -1414,6 +1519,16 @@ Task index list is empty.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEMPTY_TASK_INDEXES">EEMPTY_TASK_INDEXES</a>: u64 = 25;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EEPOCH_FEE_REFUND"></a>
+
+Failed to refund deposit for the task. For more deatils see the emitted events
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEPOCH_FEE_REFUND">EEPOCH_FEE_REFUND</a>: u64 = 28;
 </code></pre>
 
 
@@ -2281,13 +2396,11 @@ maximum allowed occupancy for the next epoch.
 ): u64 {
     <b>let</b> total_committed_max_gas = committed_occupancy + task_occupancy;
 
-    <b>let</b> congestion_base_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(
+    // Compute the automation fee multiplier for epoch
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(
         &active_config.main_config,
         (total_committed_max_gas <b>as</b> u256),
         active_config.next_epoch_registry_max_gas_cap);
-
-    <b>let</b> automation_fee_per_sec = (active_config.main_config.automation_base_fee_in_quants_per_sec <b>as</b> u256) +
-        congestion_base_fee_per_sec;
 
     <b>if</b> (automation_fee_per_sec == 0) {
         <b>return</b> 0
@@ -2508,7 +2621,7 @@ On new epoch this function will be triggered and update the automation registry 
     ).main_config;
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> (new_epoch_tcmg, removed_tasks) = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
+    <b>let</b> intermedate_state = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         refund_bookkeeping,
         &automation_registry_config,
@@ -2523,49 +2636,72 @@ On new epoch this function will be triggered and update the automation registry 
 
     // If feature is not enabled then we are not charging and tasks are cleared.
     <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping);
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
-            task_indexes: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks)
-        });
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-        automation_epoch_info.start_time = current_time;
-        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+        <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state">finalize_epoch_change_for_feature_disabled_state</a>(
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+            automation_epoch_info,
+            refund_bookkeeping,
+            current_time,
+            intermedate_state);
         <b>return</b>
     };
 
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
-        gas_committed_for_next_epoch,
-        epoch_locked_fees,
-        removed_task_ids,
-    } = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
+    <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         refund_bookkeeping,
         &automation_registry_config,
         automation_epoch_info.epoch_interval,
         current_time,
-        new_epoch_tcmg,
-        removed_tasks,
+        &<b>mut</b> intermedate_state,
     );
 
-    <b>let</b> epoch_locked_fees_value = <a href="coin.md#0x1_coin_value">coin::value</a>(&epoch_locked_fees);
+    <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, automation_epoch_info, current_time, intermedate_state);
+}
+</code></pre>
 
+
+
+</details>
+
+<a id="0x1_automation_registry_finalize_epoch_change"></a>
+
+## Function `finalize_epoch_change`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64, intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
+    current_time: u64,
+    intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>
+) {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+        gas_committed_for_new_epoch,
+        gas_committed_for_next_epoch,
+        epoch_locked_fees,
+        removed_tasks,
+    } = intermediate_state;
+
+    <b>let</b> epoch_locked_fees_value = <a href="coin.md#0x1_coin_value">coin::value</a>(&epoch_locked_fees);
     <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
 
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees_value;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = new_epoch_tcmg;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = gas_committed_for_new_epoch;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
     automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
-        task_indexes: removed_task_ids
+        task_indexes: removed_tasks
     });
 }
 </code></pre>
@@ -2574,14 +2710,13 @@ On new epoch this function will be triggered and update the automation registry 
 
 </details>
 
-<a id="0x1_automation_registry_adjust_tasks_epoch_fee_refund"></a>
+<a id="0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state"></a>
 
-## Function `adjust_tasks_epoch_fee_refund`
-
-Adjusts task fees and processes refunds when there's a change in epoch duration.
+## Function `finalize_epoch_change_for_feature_disabled_state`
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_adjust_tasks_epoch_fee_refund">adjust_tasks_epoch_fee_refund</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64)
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state">finalize_epoch_change_for_feature_disabled_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
 </code></pre>
 
 
@@ -2590,72 +2725,36 @@ Adjusts task fees and processes refunds when there's a change in epoch duration.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_adjust_tasks_epoch_fee_refund">adjust_tasks_epoch_fee_refund</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
-    current_time: u64
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state">finalize_epoch_change_for_feature_disabled_state</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    current_time: u64,
+    intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>
 ) {
-    // If no funds were locked for the previous epoch then there is nothing <b>to</b> refund.
-    // This may happen when feature was disabled, and no automation task was registered and charged for the next epoch.
-    <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees == 0) {
-        <b>return</b>
-    };
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+        gas_committed_for_new_epoch: _,
+        gas_committed_for_next_epoch: _,
+        epoch_locked_fees,
+        removed_tasks,
+    } = intermediate_state;
 
-    // If epoch actual duration is greater or equal <b>to</b> expected epoch-duration then there is nothing <b>to</b> refund.
-    <b>let</b> epoch_duration = current_time - aei.start_time;
-    <b>if</b> (aei.expected_epoch_duration &lt;= epoch_duration) {
-        <b>return</b>
-    };
+    destroy_zero(epoch_locked_fees);
 
-    <b>let</b> residual_time = aei.expected_epoch_duration - epoch_duration;
-    <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
-    <b>let</b> registry_fee_address_signer_cap = &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap;
-    <b>let</b> tasks_automation_refund_fees = <a href="automation_registry.md#0x1_automation_registry_calculate_tasks_automation_fees">calculate_tasks_automation_fees</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        arc,
-        residual_time,
-        current_time,
-        tcmg,
-        <b>true</b>
-    );
-    <a href="automation_registry.md#0x1_automation_registry_refund_tasks_fee">refund_tasks_fee</a>(registry_fee_address_signer_cap, tasks_automation_refund_fees);
-}
-</code></pre>
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
 
+    <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(
+        &<b>mut</b> removed_tasks,
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks));
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> { task_indexes: removed_tasks });
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
-
-</details>
-
-<a id="0x1_automation_registry_refund_tasks_fee"></a>
-
-## Function `refund_tasks_fee`
-
-Processes refunds for automation task fees.
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_tasks_fee">refund_tasks_fee</a>(resource_signer_cap: &<a href="account.md#0x1_account_SignerCapability">account::SignerCapability</a>, tasks_automation_refund_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_tasks_fee">refund_tasks_fee</a>(
-    resource_signer_cap: &SignerCapability,
-    tasks_automation_refund_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt;
-) {
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(resource_signer_cap);
-    <b>let</b> resource_adderss= <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&resource_signer);
-
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(tasks_automation_refund_fees, |task| {
-        <b>let</b> task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> = task;
-        <b>if</b> (task.fee != 0) {
-            <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(&resource_signer, resource_adderss, task.task_index, task.owner, task.fee);
-        }
-    });
+    automation_epoch_info.start_time = current_time;
+    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
 }
 </code></pre>
 
@@ -2671,7 +2770,7 @@ Checks all tasks for refunds, cancellation and expirations.
 Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
 </code></pre>
 
 
@@ -2686,7 +2785,7 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
     current_time: u64
-): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
     <b>let</b> previous_epoch_duration = current_time - aei.start_time;
     <b>let</b> refund_interval = 0;
     <b>let</b> refund_automation_fee_per_sec = 0;
@@ -2695,8 +2794,8 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
     <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees != 0 && previous_epoch_duration &lt; aei.expected_epoch_duration) {
         <b>let</b> previous_tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
         refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
-        <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
-        refund_automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+        // Compute the automation fee multiplier for ended epoch
+        refund_automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
     };
 
     <b>if</b> (refund_automation_fee_per_sec != 0) {
@@ -2721,10 +2820,12 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 ## Function `refund_cleanup_and_activate_tasks`
 
-Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
+Refunds active tasks of the previeous epoch, cleans up expired and canclelled tasks and activates the pending tasks.
+Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+that have been removed from the registry.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
 </code></pre>
 
 
@@ -2740,7 +2841,7 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     refund_automation_fee_per_sec: u256,
     refund_interval: u64,
-): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> tcmg = 0;
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
@@ -2748,6 +2849,7 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
+    <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
         <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
@@ -2758,12 +2860,14 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
                 refund_interval,
                 current_time,
                 refund_automation_fee_per_sec);
-            <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
+            <b>let</b> (_, remaining_epoch_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
+                epoch_locked_fees,
                 &resource_signer,
                 <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
                 task.task_index,
                 task.owner,
                 refund);
+            epoch_locked_fees = remaining_epoch_locked_fees;
         };
 
         // Drop or activate task for this current epoch.
@@ -2783,7 +2887,12 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
             tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
         }
     });
-    (tcmg, removed_tasks)
+    <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+        removed_tasks,
+        gas_committed_for_new_epoch: tcmg,
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>(),
+    }
 }
 </code></pre>
 
@@ -2795,10 +2904,12 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 
 ## Function `cleanup_and_activate_tasks`
 
-Cleanup and activate the automation task also it's calculate and return total committed max gas
+Cleans up expired and canclelled tasks and activates the pending tasks.
+Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+that have been removed from the registry.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
 </code></pre>
 
 
@@ -2811,7 +2922,7 @@ Cleanup and activate the automation task also it's calculate and return total co
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     current_time: u64
-): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> tcmg = 0;
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
@@ -2821,29 +2932,259 @@ Cleanup and activate the automation task also it's calculate and return total co
     );
     // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+        // Drop or activate task for this current epoch.
+        <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
+            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+                refund_bookkeeping,
+                &resource_signer,
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch);
+            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
         } <b>else</b> {
-            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            // Drop or activate task for this current epoch.
-            <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
-                <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-                    refund_bookkeeping,
-                    &resource_signer,
-                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-                    task.task_index,
-                    task.owner,
-                    task.locked_fee_for_next_epoch,
-                    task.locked_fee_for_next_epoch);
-                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-            } <b>else</b> {
-                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
-            }
+            task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+            tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
         }
     });
-    (tcmg, removed_tasks)
+
+    <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+        removed_tasks,
+        gas_committed_for_new_epoch: tcmg,
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>(),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_deposit_refund_all"></a>
+
+## Function `safe_deposit_refund_all`
+
+Traverses through all existing tasks and refunds deposited fee upon registration fully.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>) {
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+            refund_bookkeeping,
+            &resource_signer,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            task.task_index,
+            task.owner,
+            task.locked_fee_for_next_epoch,
+            task.locked_fee_for_next_epoch);
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_deposit_refund"></a>
+
+## Function `safe_deposit_refund`
+
+Refunds specified ammount of deposit to the task ower and unlocks full deposit from registry resource account.
+Error events are emitted
+- if the registry resource account does not have enough balance for refund.
+- if the full deposit can not be unlocked.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+    rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    resouce_address: <b>address</b>,
+    task_index: u64,
+    task_owner: <b>address</b>,
+    refundable_deposit: u64,
+    locked_deposit: u64
+):  bool {
+    // This check will make sure that no more than totally locked deposited will be refunced.
+    // If there is an attempt then it means implementation bug.
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb, locked_deposit, task_index);
+    <b>if</b> (!result) {
+        <b>return</b> result
+    };
+
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
+        resource_signer,
+        resouce_address,
+        task_index,
+        task_owner,
+        refundable_deposit,
+        <a href="automation_registry.md#0x1_automation_registry_DEPOSIT_EPOCH_FEE">DEPOSIT_EPOCH_FEE</a>);
+
+    <b>if</b> (result) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index, owner: task_owner, amount: refundable_deposit }
+        );
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_unlock_locked_deposit"></a>
+
+## Function `safe_unlock_locked_deposit`
+
+Unlocks the deposit paied by the task from internal deposit refund bookkeeping state.
+Error event is emitted if the deposit refund bookkeeping state is inconsistent with the requested unlock ammount.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(
+    rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    locked_deposit: u64,
+    task_index: u64
+): bool {
+    <b>let</b> has_locked_deposit = rb.total_deposited_automation_fee &gt;= locked_deposit;
+    <b>if</b> (has_locked_deposit) {
+        rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
+    } <b>else</b> {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_ErrorUnlockTaskDepositFee">ErrorUnlockTaskDepositFee</a> { total_registered_deposit: rb.total_deposited_automation_fee, locked_deposit, task_index }
+        );
+    };
+    has_locked_deposit
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_unlock_locked_epoch_fee"></a>
+
+## Function `safe_unlock_locked_epoch_fee`
+
+Unlocks the locked fee paid by the task for epoch.
+Error event is emitted if the epoch locked fee amount is inconsistent with the requested unlock ammount.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(epoch_locked_fees: u64, refundable_fee: u64, task_index: u64): (bool, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(
+    epoch_locked_fees: u64,
+    refundable_fee: u64,
+    task_index: u64
+): (bool, u64) {
+    // This check makes sure that more than locked amount of the fees will be not be refunded.
+    // Any attempt means <b>internal</b> bug.
+    <b>let</b> has_locked_fee = epoch_locked_fees &gt;= refundable_fee;
+    <b>if</b> (has_locked_fee) {
+        // unlock the refunded amount
+        epoch_locked_fees = epoch_locked_fees - refundable_fee;
+    } <b>else</b> {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_ErrorUnlockTaskEpochFee">ErrorUnlockTaskEpochFee</a> { locked_epoch_fees: epoch_locked_fees, task_index, refund: refundable_fee}
+        );
+    };
+    (has_locked_fee, epoch_locked_fees)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_fee_refund"></a>
+
+## Function `safe_fee_refund`
+
+Refunds fee paied by the task for the epoch to the task owner.
+Note that here we do not unlock the fee, as on epoch change locked epoch-fees for the ended epoch are
+automatically unlocked.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(epoch_locked_fees: u64, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64): (bool, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
+    epoch_locked_fees: u64,
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    resouce_address: <b>address</b>,
+    task_index: u64,
+    task_owner: <b>address</b>,
+    refundable_fee: u64
+):  (bool, u64) {
+    <b>let</b> (result, remaining_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(epoch_locked_fees, refundable_fee, task_index);
+    <b>if</b> (!result) {
+        <b>return</b> (result, remaining_locked_fees)
+    };
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
+        resource_signer,
+        resouce_address,
+        task_index,
+        task_owner,
+        refundable_fee,
+        <a href="automation_registry.md#0x1_automation_registry_EPOCH_FEE">EPOCH_FEE</a>);
+    <b>if</b> (result) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index, owner: task_owner, amount: refundable_fee }
+        );
+    };
+    (result, remaining_locked_fees)
 }
 </code></pre>
 
@@ -2855,6 +3196,8 @@ Cleanup and activate the automation task also it's calculate and return total co
 
 ## Function `safe_refund`
 
+Refunds specified amount to the task owner.
+Error event is emitted if the resource account does not have enough balace.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_amount: u64, refund_type: u8): bool
@@ -2891,227 +3234,6 @@ Cleanup and activate the automation task also it's calculate and return total co
 
 </details>
 
-<a id="0x1_automation_registry_safe_deposit_refund"></a>
-
-## Function `safe_deposit_refund`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-    rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    resouce_address: <b>address</b>,
-    task_index: u64,
-    task_owner: <b>address</b>,
-    refundable_deposit: u64,
-    locked_deposit: u64
-):  bool {
-    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
-        resource_signer,
-        resouce_address,
-        task_index,
-        task_owner,
-        refundable_deposit,
-        <a href="automation_registry.md#0x1_automation_registry_DEPOSIT_EPOCH_FEE">DEPOSIT_EPOCH_FEE</a>);
-    <b>if</b> (result) {
-        <a href="event.md#0x1_event_emit">event::emit</a>(
-            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index, owner: task_owner, amount: refundable_deposit }
-        );
-        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb, locked_deposit, task_index)
-    };
-    result
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_safe_unlock_locked_deposit"></a>
-
-## Function `safe_unlock_locked_deposit`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(
-    rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    locked_deposit: u64,
-    task_index: u64
-) {
-    <b>if</b> (rb.total_deposited_automation_fee &gt;= locked_deposit) {
-        rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
-    } <b>else</b> {
-        <a href="event.md#0x1_event_emit">event::emit</a>(
-            <a href="automation_registry.md#0x1_automation_registry_ErrorUnlockTaskDepositFee">ErrorUnlockTaskDepositFee</a> { total_registered_deposit: rb.total_deposited_automation_fee, locked_deposit, task_index }
-        );
-    }
-
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_safe_fee_refund"></a>
-
-## Function `safe_fee_refund`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
-    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    resouce_address: <b>address</b>,
-    task_index: u64,
-    task_owner: <b>address</b>,
-    refundable_fee: u64
-):  bool {
-    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
-        resource_signer,
-        resouce_address,
-        task_index,
-        task_owner,
-        refundable_fee,
-        <a href="automation_registry.md#0x1_automation_registry_EPOCH_FEE">EPOCH_FEE</a>);
-    <b>if</b> (result) {
-        <a href="event.md#0x1_event_emit">event::emit</a>(
-            <a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index, owner: task_owner, amount: refundable_fee }
-        );
-    };
-    result
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_safe_deposit_refund_all"></a>
-
-## Function `safe_deposit_refund_all`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>) {
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-            refund_bookkeeping,
-            &resource_signer,
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-            task.task_index,
-            task.owner,
-            task.locked_fee_for_next_epoch,
-        task.locked_fee_for_next_epoch);
-    });
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_calculate_tasks_automation_fees"></a>
-
-## Function `calculate_tasks_automation_fees`
-
-Calculates automation task fees for the active tasks for the provided interval with provided tcmg occupancy.
-The CANCELLED tasks are also taken into account if include_cancelled_task is true.
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_tasks_automation_fees">calculate_tasks_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, interval: u64, current_time: u64, tcmg: u256, include_cancelled_task: bool): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_tasks_automation_fees">calculate_tasks_automation_fees</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    interval: u64,
-    current_time: u64,
-    tcmg: u256,
-    include_cancelled_task: bool
-): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt; {
-    // Compute the automation congestion fee (acf) for the epoch
-    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
-    <b>let</b> task_with_fees = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    // Automation fee per second is the sum of the automation base fee per second and congeation fee per second
-    // calculated based on the current registry occupancy.
-    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
-
-    // Return early <b>if</b> automation fee per second is 0
-    <b>if</b> (automation_fee_per_sec == 0) {
-        <b>return</b> task_with_fees
-    };
-
-    // Process each active task and calculate fee for the epoch for the tasks
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_for_each_value_ref">enumerable_map::for_each_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, |task| {
-        <b>let</b> task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> = task;
-        <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a> || (include_cancelled_task && task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>)) {
-            <b>let</b> task_fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task, interval, current_time, automation_fee_per_sec);
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> task_with_fees, <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> {
-                task_index: task.task_index,
-                owner: task.owner,
-                fee: task_fee,
-            });
-        }
-    });
-    task_with_fees
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_calculate_task_fee"></a>
 
 ## Function `calculate_task_fee`
@@ -3137,6 +3259,7 @@ It returns calculated task fee for the interval the task will be active.
     current_time: u64,
     automation_fee_per_sec: u256
 ): u64 {
+    <b>if</b> (automation_fee_per_sec == 0) { <b>return</b> 0 };
     <b>if</b> (task.expiry_time &lt;= current_time) { <b>return</b> 0 };
     // Subtraction is safe here, <b>as</b> we already excluded expired tasks
     <b>let</b> remaining_time = task.expiry_time - current_time;
@@ -3183,6 +3306,36 @@ This is supposed to be called only after removing expired task and must not be c
     <b>let</b> automation_fee_for_interval = automation_fee_per_sec * task_occupancy_ratio_by_duration;
 
     <a href="automation_registry.md#0x1_automation_registry_downscale_to_u64">downscale_to_u64</a>(automation_fee_for_interval)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_calculate_automation_fee_multipler_for_epoch"></a>
+
+## Function `calculate_automation_fee_multipler_for_epoch`
+
+Calculate automation fee multiplier for epoch. It is measured in quants/sec.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, tcmg: u256, registry_max_gas_cap: u64): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    tcmg: u256,
+    registry_max_gas_cap: u64
+): u256 {
+    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, registry_max_gas_cap);
+    acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256)
 }
 </code></pre>
 
@@ -3309,7 +3462,7 @@ Processes automation task fees by checking user balances and task's commitment o
 Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256, removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
 </code></pre>
 
 
@@ -3324,17 +3477,14 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     epoch_interval: u64,
     current_time: u64,
-    tcmg: u256,
-    removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
-    <b>let</b> intermediate_state_with_coins = <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>&lt;SupraCoin&gt;(),
-        removed_task_ids: removed_tasks,
-    };
-    // Compute the automation congestion fee (acf) for the epoch
-    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
-    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
+) {
+    // Compute the automation fee multiplier for epoch
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(
+        arc,
+        intermediate_state.gas_committed_for_new_epoch,
+        arc.registry_max_gas_cap);
+
     <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
@@ -3350,14 +3500,11 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
         <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
             task_index,
             owner: task_meta.owner,
-            fee: 0,
+            fee: <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec),
             expiry_time: task_meta.expiry_time,
             automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
             max_gas_amount: task_meta.max_gas_amount,
             locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
-        };
-        <b>if</b> (automation_fee_per_sec != 0) {
-            task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
         };
         <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
@@ -3365,10 +3512,9 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
             &resource_signer,
             task,
             current_epoch_end_time,
-            &<b>mut</b> intermediate_state_with_coins
+            intermediate_state
         );
     });
-    intermediate_state_with_coins
 }
 </code></pre>
 
@@ -3382,7 +3528,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_epoch_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_epoch_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
 </code></pre>
 
 
@@ -3397,7 +3543,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a>,
     current_epoch_end_time: u64,
-    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>) {
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>) {
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task.automation_fee_cap) {
         <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
@@ -3410,7 +3556,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
             task.locked_deposit_fee
         );
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_tasks, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
             owner: task.owner,
@@ -3421,10 +3567,11 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     };
     <b>let</b> user_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(task.owner);
     <b>if</b> (user_balance &lt; task.fee) {
-        // If the user does not have enough balance, remove the task, refund the locked deposit and emit an <a href="event.md#0x1_event">event</a>
+        // If the user does not have enough balance, remove the task, DON'T refund the locked deposit, but simply unlock it
+        // and emit an <a href="event.md#0x1_event">event</a>
         <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task.locked_deposit_fee, task.task_index);
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_tasks, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
             task_index: task.task_index,
             owner: task.owner,
@@ -3550,9 +3697,9 @@ Transfers the specified fee amount from the resource account to the target accou
 
     <b>assert</b>!(resource_balance &gt;= amount, <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_BALANCE">EINSUFFICIENT_BALANCE</a>);
 
-    <b>assert</b>!((resource_balance - amount) &gt;=
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees +
-            refund_bookkeeping.total_deposited_automation_fee, <a href="automation_registry.md#0x1_automation_registry_EREQUEST_EXCEEDS_LOCKED_BALANCE">EREQUEST_EXCEEDS_LOCKED_BALANCE</a>);
+    <b>assert</b>!((resource_balance - amount)
+        &gt;= <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees + refund_bookkeeping.total_deposited_automation_fee,
+        <a href="automation_registry.md#0x1_automation_registry_EREQUEST_EXCEEDS_LOCKED_BALANCE">EREQUEST_EXCEEDS_LOCKED_BALANCE</a>);
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
@@ -3878,7 +4025,7 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
             &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
         );
         // When Pending tasks are cancelled, refund of the deposit fee is done <b>with</b> penalty
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+        <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
             refund_bookkeeping,
             &resource_signer,
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
@@ -3886,9 +4033,10 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
             owner,
             automation_task_metadata.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>,
         automation_task_metadata.locked_fee_for_next_epoch);
+        <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>);
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-    } <b>else</b> { // it is safe not <b>to</b> check the state <b>as</b> above the already cancelled task's cancellation is rejected.
-        // Active tasks will be refunded at the end of the epoch
+    } <b>else</b> { // it is safe not <b>to</b> check the state <b>as</b> above, the cancelled tasks are already rejected.
+        // Active tasks will be refunded the deposited amount fully at the end of the epoch
         <b>let</b> automation_task_metadata_mut = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(
             &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks,
             task_index
@@ -3951,18 +4099,12 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
 
     <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
 
-    // Calculate the automation congestion fee
-    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(
-        &arc,
-        tcmg,
-        arc.registry_max_gas_cap
-    );
-
-    // Total fee per second (base + congestion fee)
-    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+    // Compute the automation fee multiplier for epoch
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(&arc, tcmg, arc.registry_max_gas_cap);
 
     <b>let</b> stopped_task_details = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>let</b> total_refund_fee = 0;
+    <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
 
     // Calculate refundable fee for this remaining time task in current epoch
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
@@ -3972,6 +4114,7 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
     } <b>else</b> {
         epoch_end_time - current_time
     };
+
 
     // Loop through each task index <b>to</b> validate and stop the task
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
@@ -4011,7 +4154,17 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
             } <b>else</b> {
                 (0, (task.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FRACTION">REFUND_FRACTION</a>))
             };
-            <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
+            <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(
+                refund_bookkeeping,
+                task.locked_fee_for_next_epoch,
+                task.task_index);
+            <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>);
+            <b>let</b> (result, remaining_epoch_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(
+                epoch_locked_fees,
+                epoch_fee_refund,
+                task.task_index);
+            <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EEPOCH_FEE_REFUND">EEPOCH_FEE_REFUND</a>);
+            epoch_locked_fees = remaining_epoch_locked_fees;
 
             total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
 
@@ -4080,7 +4233,7 @@ Update epoch interval in registry while actually update happens in block module
 Insertion sort implementation for vector
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4089,7 +4242,7 @@ Insertion sort implementation for vector
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(input);
     <b>let</b> i = 1;
     <b>while</b> (i &lt; len) {

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -29,7 +29,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `DisabledRegistrationEvent`](#0x1_automation_registry_DisabledRegistrationEvent)
 -  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
 -  [Struct `AutomationTaskFeeMeta`](#0x1_automation_registry_AutomationTaskFeeMeta)
--  [Struct `IntermediateStatePhase1`](#0x1_automation_registry_IntermediateStatePhase1)
 -  [Struct `IntermediateState`](#0x1_automation_registry_IntermediateState)
 -  [Constants](#@Constants_0)
 -  [Function `active_task_ids`](#0x1_automation_registry_active_task_ids)
@@ -55,20 +54,21 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
--  [Function `prepare_for_new_epoch`](#0x1_automation_registry_prepare_for_new_epoch)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
--  [Function `on_new_epoch_2`](#0x1_automation_registry_on_new_epoch_2)
 -  [Function `adjust_tasks_epoch_fee_refund`](#0x1_automation_registry_adjust_tasks_epoch_fee_refund)
 -  [Function `refund_tasks_fee`](#0x1_automation_registry_refund_tasks_fee)
 -  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
+-  [Function `on_new_epoch_2`](#0x1_automation_registry_on_new_epoch_2)
+-  [Function `update_state_for_new_epoch`](#0x1_automation_registry_update_state_for_new_epoch)
+-  [Function `refund_cleanup_and_activate_tasks`](#0x1_automation_registry_refund_cleanup_and_activate_tasks)
 -  [Function `calculate_tasks_automation_fees`](#0x1_automation_registry_calculate_tasks_automation_fees)
 -  [Function `calculate_task_fee`](#0x1_automation_registry_calculate_task_fee)
 -  [Function `calculate_automation_fee_for_interval`](#0x1_automation_registry_calculate_automation_fee_for_interval)
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
--  [Function `try_withdraw_task_automation_fees_2`](#0x1_automation_registry_try_withdraw_task_automation_fees_2)
 -  [Function `try_withdraw_task_automation_fee`](#0x1_automation_registry_try_withdraw_task_automation_fee)
+-  [Function `try_withdraw_task_automation_fees_2`](#0x1_automation_registry_try_withdraw_task_automation_fees_2)
 -  [Function `try_withdraw_task_automation_fee_2`](#0x1_automation_registry_try_withdraw_task_automation_fee_2)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
@@ -1057,40 +1057,6 @@ Represents the fee charged for an automation task execution and some additional 
 
 </details>
 
-<a id="0x1_automation_registry_IntermediateStatePhase1"></a>
-
-## Struct `IntermediateStatePhase1`
-
-Represents intermediate state of the registry on epoch change.
-
-
-<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">IntermediateStatePhase1</a> <b>has</b> drop
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>estimated_gas_committed_for_this_epoch: u256</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>estimated_refunds: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x1_automation_registry_IntermediateState"></a>
 
 ## Struct `IntermediateState`
@@ -1983,7 +1949,12 @@ maximum allowed occupancy for the next epoch.
 ): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>let</b> epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
     <b>let</b> config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(task_occupancy, committed_occupancy, epoch_info, config)
+    <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
+        task_occupancy,
+        committed_occupancy,
+        epoch_info,
+        config
+    )
 }
 </code></pre>
 
@@ -2088,7 +2059,7 @@ maximum allowed occupancy for the next epoch.
     registry_max_gas_cap: u64,
     congestion_threshold_percentage: u8,
     congestion_exponent: u8,
-){
+) {
     <b>assert</b>!(congestion_threshold_percentage &lt;= <a href="automation_registry.md#0x1_automation_registry_MAX_PERCENTAGE">MAX_PERCENTAGE</a>, <a href="automation_registry.md#0x1_automation_registry_EMAX_CONGESTION_THRESHOLD">EMAX_CONGESTION_THRESHOLD</a>);
     <b>assert</b>!(congestion_exponent &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECONGESTION_EXP_NON_ZERO">ECONGESTION_EXP_NON_ZERO</a>);
     <b>assert</b>!(task_duration_cap_in_secs &gt; epoch_interval_secs, <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>);
@@ -2165,7 +2136,9 @@ Initialization of Automation Registry with configuration parameters is expected 
         congestion_threshold_percentage,
         congestion_exponent);
 
-    <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="automation_registry.md#0x1_automation_registry_create_registry_resource_account">create_registry_resource_account</a>(supra_framework);
+    <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="automation_registry.md#0x1_automation_registry_create_registry_resource_account">create_registry_resource_account</a>(
+        supra_framework
+    );
 
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
         tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
@@ -2198,85 +2171,6 @@ Initialization of Automation Registry with configuration parameters is expected 
         epoch_interval: epoch_interval_secs,
         start_time: 0,
     });
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_prepare_for_new_epoch"></a>
-
-## Function `prepare_for_new_epoch`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_prepare_for_new_epoch">prepare_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">automation_registry::IntermediateStatePhase1</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_prepare_for_new_epoch">prepare_for_new_epoch</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
-    current_time: u64
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">IntermediateStatePhase1</a> {
-    <b>let</b> epoch_duration = current_time - aei.start_time;
-    <b>let</b> epoch_residual_interval = 0;
-    <b>let</b> automation_fee_per_sec= 0;
-    <b>let</b> refund_expected = <b>false</b>;
-
-    <b>let</b> estimated_refunds = 0;
-    <b>let</b> tcmg: u256 = 0;
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
-
-    // If epoch actual duration is greater or equal <b>to</b> expected epoch-duration then there is nothing <b>to</b> refund.
-    // <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees !=0 && aei.expected_epoch_duration &gt; epoch_duration) {
-    <b>if</b> (aei.expected_epoch_duration &gt; epoch_duration) {
-        <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
-        epoch_residual_interval = aei.expected_epoch_duration - epoch_duration;
-        <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
-        automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
-        refund_expected = automation_fee_per_sec != 0;
-    };
-
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
-        } <b>else</b> {
-            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <b>if</b> (refund_expected && task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a> ) {
-                <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task,
-                    epoch_residual_interval, current_time, automation_fee_per_sec);
-                estimated_refunds = estimated_refunds + refund;
-                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, refund);
-                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: refund });
-            };
-
-            // Drop or activate task for this current epoch.
-            <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task.expiry_time &lt;= current_time) {
-                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch });
-                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            } <b>else</b> {
-                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
-            }
-        }
-    });
-    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">IntermediateStatePhase1</a> {
-        estimated_gas_committed_for_this_epoch: tcmg,
-        estimated_refunds
-    };
-    result
 }
 </code></pre>
 
@@ -2332,7 +2226,6 @@ On new epoch this function will be triggered and update the automation registry 
 
     // If feature is not enabled then we are not charging and tasks are cleared.
     <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
@@ -2367,88 +2260,6 @@ On new epoch this function will be triggered and update the automation registry 
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = tcmg;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    automation_epoch_info.start_time = current_time;
-    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_on_new_epoch_2"></a>
-
-## Function `on_new_epoch_2`
-
-On new epoch this function will be triggered and update the automation registry state
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>()
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    // Unless registry in initialized, registry will not be updated on new epoch.
-    // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
-    //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
-    //  - all tasks should be removed from registry state
-    // Note that <b>with</b> the current setup feature::on_new_epoch is called before <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>
-    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
-        <b>return</b>
-    };
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
-
-    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
-        @supra_framework
-    ).main_config;
-
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> result= <a href="automation_registry.md#0x1_automation_registry_prepare_for_new_epoch">prepare_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        &automation_registry_config,
-        automation_epoch_info,
-        current_time
-    );
-
-
-    // Apply the latest configuration <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> parameter <b>has</b> been updated
-    // only after refund <b>has</b> been done for previous epoch.
-    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
-
-    // If feature is not enabled then we are not charging and tasks are cleared.
-    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-        // TODO before cleaning refund locked automation fee deposit
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-        automation_epoch_info.start_time = current_time;
-        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-        <b>return</b>
-    };
-
-
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        &automation_registry_config,
-        automation_epoch_info.epoch_interval,
-        current_time,
-        result.estimated_gas_committed_for_this_epoch,
-    );
-
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = result.estimated_gas_committed_for_this_epoch;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
@@ -2569,7 +2380,9 @@ Cleanup and activate the automation task also it's calculate and return total co
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> tcmg = 0;
 
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
     // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
         <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
@@ -2580,7 +2393,209 @@ Cleanup and activate the automation task also it's calculate and return total co
             // Drop or activate task for this current epoch.
             <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
                 <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch });
+                <a href="event.md#0x1_event_emit">event::emit</a>(
+                    <a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+                );
+                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            } <b>else</b> {
+                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
+            }
+        }
+    });
+    tcmg
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_new_epoch_2"></a>
+
+## Function `on_new_epoch_2`
+
+On new epoch this function will be triggered and update the automation registry state
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>(
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    // Unless registry in initialized, registry will not be updated on new epoch.
+    // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
+    //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
+    //  - all tasks should be removed from registry state
+    // Note that <b>with</b> the current setup feature::on_new_epoch is called before <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
+        <b>return</b>
+    };
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+
+    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
+        @supra_framework
+    ).main_config;
+
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <b>let</b> new_epoch_tcmg = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        &automation_registry_config,
+        automation_epoch_info,
+        current_time
+    );
+
+
+    // Apply the latest configuration <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> parameter <b>has</b> been updated
+    // only after refund <b>has</b> been done for previous epoch.
+    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
+
+    // If feature is not enabled then we are not charging and tasks are cleared.
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+        // TODO before cleaning refund locked automation fee deposit
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+        automation_epoch_info.start_time = current_time;
+        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+        <b>return</b>
+    };
+
+
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        &automation_registry_config,
+        automation_epoch_info.epoch_interval,
+        current_time,
+        new_epoch_tcmg,
+    );
+
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = new_epoch_tcmg;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    automation_epoch_info.start_time = current_time;
+    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_state_for_new_epoch"></a>
+
+## Function `update_state_for_new_epoch`
+
+Checks all tasks for refunds, cancellation and expirations.
+Cleans the stale tasks and calculates gas-committed for the new epoch.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
+    current_time: u64
+): u256 {
+    <b>let</b> previous_epoch_duration = current_time - aei.start_time;
+    <b>let</b> refund_interval = 0;
+    <b>let</b> refund_automation_fee_per_sec = 0;
+
+    // If epoch actual duration is greater or equal <b>to</b> expected epoch-duration then there is nothing <b>to</b> refund.
+    <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees != 0 && previous_epoch_duration &lt; aei.expected_epoch_duration) {
+        <b>let</b> previous_tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
+        refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
+        <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
+        refund_automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+    };
+
+    <b>let</b> new_epoch_tcmg = <b>if</b> (refund_automation_fee_per_sec != 0) {
+        <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+            current_time,
+            arc,
+            refund_automation_fee_per_sec,
+            refund_interval)
+    } <b>else</b> {
+        <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, current_time)
+    };
+
+    new_epoch_tcmg
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_refund_cleanup_and_activate_tasks"></a>
+
+## Function `refund_cleanup_and_activate_tasks`
+
+Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    current_time: u64,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    refund_automation_fee_per_sec: u256,
+    refund_interval: u64,
+): u256 {
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <b>let</b> tcmg = 0;
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
+        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
+        } <b>else</b> {
+            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+                <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task,
+                    refund_interval, current_time, refund_automation_fee_per_sec);
+                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, refund);
+                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: refund });
+            };
+
+            // Drop or activate task for this current epoch.
+            <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task.expiry_time &lt;= current_time) {
+                // Refund deposited epoch-fee for cancelled and expired tasks.
+                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+                <a href="event.md#0x1_event_emit">event::emit</a>(
+                    <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+                );
                 <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
             } <b>else</b> {
                 task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
@@ -2876,76 +2891,15 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(tasks_automation_fees, |task| {
         <b>let</b> task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> = task;
         <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> {task_index: task.task_index})
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> { task_index: task.task_index })
         } <b>else</b> {
-            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, task, current_time, epoch_interval, &<b>mut</b> intermediate_state);
-        };
-    });
-    intermediate_state
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_try_withdraw_task_automation_fees_2"></a>
-
-## Function `try_withdraw_task_automation_fees_2`
-
-Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-- If the user has sufficient balance, deducts the fee and emits a success event.
-- If the balance is insufficient, removes the task and emits a cancellation event.
-- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b>  <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    epoch_interval: u64,
-    current_time: u64,
-    tcmg: u256,
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: 0,
-        active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
-    };
-    // Compute the automation congestion fee (acf) for the epoch
-    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
-    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
-    <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(&<b>mut</b> task_ids);
-
-    // Process each active task and calculate fee for the epoch for the tasks
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> {task_index})
-        } <b>else</b> {
-            <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
-                task_index,
-                owner: task_meta.owner,
-                fee: 0,
-                expiry_time: task_meta.expiry_time,
-                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                max_gas_amount: task_meta.max_gas_amount,
-                locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
-            };
-            <b>if</b> (automation_fee_per_sec != 0) {
-                task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
-            };
-            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, task, current_time, epoch_interval, &<b>mut</b> intermediate_state);
+            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+                task,
+                current_time,
+                epoch_interval,
+                &<b>mut</b> intermediate_state
+            );
         };
     });
     intermediate_state
@@ -2977,14 +2931,17 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     current_time: u64,
     epoch_interval: u64,
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>) {
-
     <b>let</b> task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
 
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task_metadata.automation_fee_cap_for_epoch) {
         <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task_metadata.locked_fee_for_next_epoch);
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task_metadata.locked_fee_for_next_epoch });
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task_metadata.locked_fee_for_next_epoch }
+        );
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
@@ -3005,7 +2962,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
         });
         <b>return</b>
     };
-    <b>if</b> (task.fee != 0 ) {
+    <b>if</b> (task.fee != 0) {
         // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
         <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
             &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task_metadata.owner),
@@ -3025,6 +2982,81 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     <b>if</b> (task_metadata.expiry_time &gt; (current_time + epoch_interval)) {
         intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
     };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_try_withdraw_task_automation_fees_2"></a>
+
+## Function `try_withdraw_task_automation_fees_2`
+
+Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
+- If the user has sufficient balance, deducts the fee and emits a success event.
+- If the balance is insufficient, removes the task and emits a cancellation event.
+- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
+Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    epoch_interval: u64,
+    current_time: u64,
+    tcmg: u256,
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: 0,
+        active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+    };
+    // Compute the automation congestion fee (acf) for the epoch
+    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
+    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+    <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    // Sort task indexes <b>to</b> charge autoamtion fees in the tasks chronological order
+    <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(&<b>mut</b> task_ids);
+
+    // Process each active task and calculate fee for the epoch for the tasks
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
+        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> { task_index })
+        } <b>else</b> {
+            <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+                task_index,
+                owner: task_meta.owner,
+                fee: 0,
+                expiry_time: task_meta.expiry_time,
+                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                max_gas_amount: task_meta.max_gas_amount,
+                locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
+            };
+            <b>if</b> (automation_fee_per_sec != 0) {
+                task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+            };
+            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+                task,
+                current_time,
+                epoch_interval,
+                &<b>mut</b> intermediate_state
+            );
+        };
+    });
+    intermediate_state
 }
 </code></pre>
 
@@ -3053,13 +3085,15 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     current_time: u64,
     epoch_interval: u64,
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>) {
-
-
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task.automation_fee_cap) {
         <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch });
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+        );
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
@@ -3080,7 +3114,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
         });
         <b>return</b>
     };
-    <b>if</b> (task.fee != 0 ) {
+    <b>if</b> (task.fee != 0) {
         // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
         <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
             &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task.owner),

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -78,7 +78,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `safe_refund`](#0x1_automation_registry_safe_refund)
 -  [Function `calculate_task_fee`](#0x1_automation_registry_calculate_task_fee)
 -  [Function `calculate_automation_fee_for_interval`](#0x1_automation_registry_calculate_automation_fee_for_interval)
--  [Function `calculate_automation_fee_multipler_for_epoch`](#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch)
+-  [Function `calculate_automation_fee_multiplier_for_epoch`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch)
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
@@ -474,7 +474,7 @@ Automation Deposited fee bookkeeping configs
 <dd>
  Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for it.
  It will be refunded fully when active task is expired or cancelled by user
- and partially if a pending task is cancelled by user or an active taks is cancelled by the system due to
+ and partially if a pending task is cancelled by user or an active task is cancelled by the system due to
  insufficient balance to  pay the automation fee for the epoch
 </dd>
 </dl>
@@ -692,8 +692,7 @@ duration paid at the beginning of the epoch due to epoch-duration reduction by g
 
 ## Struct `TaskDepositFeeRefund`
 
-Event emitted when an automation fee is refunded for an automation task at the end of the epoch for excessive
-duration paid at the beginning of the epoch due to epoch-duration reduction by governance.
+Event emitted when a deposit fee is refunded for an automation task.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
@@ -776,7 +775,7 @@ potential locked deposit for the task.
 
 ## Struct `ErrorUnlockTaskEpochFee`
 
-Event emitted when an task epoch fee is being refunded but locked epoch fees is less than
+Event emitted when a task epoch fee is being refunded but locked epoch fees is less than
 potential requested refund.
 
 
@@ -1134,7 +1133,7 @@ but it does not exist in the list.
 ## Struct `ErrorInsufficientBalanceToRefund`
 
 Event emitted during epoch transition when refunds to be paid is not possible due to insufficient resource account balance.
-Type of the refund can be releated either to the deposit paid during registration (0), or to epoch-fee caused by
+Type of the refund can be related either to the deposit paid during registration (0), or to epoch-fee caused by
 the shortening of the epoch (1)
 
 
@@ -1305,7 +1304,7 @@ Represents the fee charged for an automation task execution and some additional 
 ## Struct `IntermediateState`
 
 Represents intermediate state of the registry on epoch change.
-Deprectead in production, substituted with IntermediateStateWithRemovedTasks.
+Deprecated in production, substituted with <code><a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a></code>.
 Kept for backward compatible framework upgrade.
 
 
@@ -1525,7 +1524,7 @@ Congestion exponent must be non-zero.
 
 <a id="0x1_automation_registry_EDEPOSIT_REFUND"></a>
 
-Failed to refund deposit for the task. For more deatils see the emitted events
+Failed to unlock/refund deposit for a task. Internal error, for more details see emitted error events.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>: u64 = 27;
@@ -1555,7 +1554,7 @@ Task index list is empty.
 
 <a id="0x1_automation_registry_EEPOCH_FEE_REFUND"></a>
 
-Failed to refund deposit for the task. For more deatils see the emitted events
+Failed to unlock/refund epoch fee for a task. Internal error, for more details see emitted error events.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEPOCH_FEE_REFUND">EEPOCH_FEE_REFUND</a>: u64 = 28;
@@ -2427,7 +2426,7 @@ maximum allowed occupancy for the next epoch.
     <b>let</b> total_committed_max_gas = committed_occupancy + task_occupancy;
 
     // Compute the automation fee multiplier for epoch
-    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
         &active_config.main_config,
         (total_committed_max_gas <b>as</b> u256),
         active_config.next_epoch_registry_max_gas_cap);
@@ -2651,7 +2650,7 @@ On new epoch this function will be triggered and update the automation registry 
     ).main_config;
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> intermedate_state = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         refund_bookkeeping,
         &automation_registry_config,
@@ -2671,7 +2670,7 @@ On new epoch this function will be triggered and update the automation registry 
             automation_epoch_info,
             refund_bookkeeping,
             current_time,
-            intermedate_state);
+            intermediate_state);
         <b>return</b>
     };
 
@@ -2681,10 +2680,10 @@ On new epoch this function will be triggered and update the automation registry 
         &automation_registry_config,
         automation_epoch_info.epoch_interval,
         current_time,
-        &<b>mut</b> intermedate_state,
+        &<b>mut</b> intermediate_state,
     );
 
-    <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, automation_epoch_info, current_time, intermedate_state);
+    <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, automation_epoch_info, current_time, intermediate_state);
 }
 </code></pre>
 
@@ -2831,7 +2830,7 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
         <b>let</b> previous_tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
         refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
         // Compute the automation fee multiplier for ended epoch
-        refund_automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
+        refund_automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
     };
 
     <b>if</b> (refund_automation_fee_per_sec != 0) {
@@ -2856,8 +2855,8 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 ## Function `refund_cleanup_and_activate_tasks`
 
-Refunds active tasks of the previeous epoch, cleans up expired and canclelled tasks and activates the pending tasks.
-Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks and activates the pending tasks.
+Also calculates and returns the total committed max gas for the new epoch along with the task indexes
 that have been removed from the registry.
 
 
@@ -2940,8 +2939,8 @@ that have been removed from the registry.
 
 ## Function `cleanup_and_activate_tasks`
 
-Cleans up expired and canclelled tasks and activates the pending tasks.
-Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+Cleans up expired and cancelled tasks and activates the pending tasks.
+Also calculates and returns the total committed max gas for the new epoch along with the task indexes
 that have been removed from the registry.
 
 
@@ -3047,13 +3046,13 @@ Traverses through all existing tasks and refunds deposited fee upon registration
 
 ## Function `safe_deposit_refund`
 
-Refunds specified ammount of deposit to the task ower and unlocks full deposit from registry resource account.
+Refunds specified amount of deposit to the task owner and unlocks full deposit from registry resource account.
 Error events are emitted
 - if the registry resource account does not have enough balance for refund.
 - if the full deposit can not be unlocked.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64): bool
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64): bool
 </code></pre>
 
 
@@ -3065,13 +3064,13 @@ Error events are emitted
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
     rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    resouce_address: <b>address</b>,
+    resource_address: <b>address</b>,
     task_index: u64,
     task_owner: <b>address</b>,
     refundable_deposit: u64,
     locked_deposit: u64
 ):  bool {
-    // This check will make sure that no more than totally locked deposited will be refunced.
+    // This check will make sure that no more than totally locked deposited will be refunded.
     // If there is an attempt then it means implementation bug.
     <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb, locked_deposit, task_index);
     <b>if</b> (!result) {
@@ -3080,7 +3079,7 @@ Error events are emitted
 
     <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
         resource_signer,
-        resouce_address,
+        resource_address,
         task_index,
         task_owner,
         refundable_deposit,
@@ -3103,8 +3102,8 @@ Error events are emitted
 
 ## Function `safe_unlock_locked_deposit`
 
-Unlocks the deposit paied by the task from internal deposit refund bookkeeping state.
-Error event is emitted if the deposit refund bookkeeping state is inconsistent with the requested unlock ammount.
+Unlocks the deposit paid by the task from internal deposit refund bookkeeping state.
+Error event is emitted if the deposit refund bookkeeping state is inconsistent with the requested unlock amount.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64): bool
@@ -3142,7 +3141,7 @@ Error event is emitted if the deposit refund bookkeeping state is inconsistent w
 ## Function `safe_unlock_locked_epoch_fee`
 
 Unlocks the locked fee paid by the task for epoch.
-Error event is emitted if the epoch locked fee amount is inconsistent with the requested unlock ammount.
+Error event is emitted if the epoch locked fee amount is inconsistent with the requested unlock amount.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(epoch_locked_fees: u64, refundable_fee: u64, task_index: u64): (bool, u64)
@@ -3182,12 +3181,12 @@ Error event is emitted if the epoch locked fee amount is inconsistent with the r
 
 ## Function `safe_fee_refund`
 
-Refunds fee paied by the task for the epoch to the task owner.
+Refunds fee paid by the task for the epoch to the task owner.
 Note that here we do not unlock the fee, as on epoch change locked epoch-fees for the ended epoch are
 automatically unlocked.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(epoch_locked_fees: u64, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64): (bool, u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(epoch_locked_fees: u64, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64): (bool, u64)
 </code></pre>
 
 
@@ -3199,7 +3198,7 @@ automatically unlocked.
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
     epoch_locked_fees: u64,
     resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    resouce_address: <b>address</b>,
+    resource_address: <b>address</b>,
     task_index: u64,
     task_owner: <b>address</b>,
     refundable_fee: u64
@@ -3210,7 +3209,7 @@ automatically unlocked.
     };
     <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(
         resource_signer,
-        resouce_address,
+        resource_address,
         task_index,
         task_owner,
         refundable_fee,
@@ -3233,7 +3232,7 @@ automatically unlocked.
 ## Function `safe_refund`
 
 Refunds specified amount to the task owner.
-Error event is emitted if the resource account does not have enough balace.
+Error event is emitted if the resource account does not have enough balance.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_amount: u64, refund_type: u8): bool
@@ -3349,14 +3348,14 @@ This is supposed to be called only after removing expired task and must not be c
 
 </details>
 
-<a id="0x1_automation_registry_calculate_automation_fee_multipler_for_epoch"></a>
+<a id="0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch"></a>
 
-## Function `calculate_automation_fee_multipler_for_epoch`
+## Function `calculate_automation_fee_multiplier_for_epoch`
 
 Calculate automation fee multiplier for epoch. It is measured in quants/sec.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, tcmg: u256, registry_max_gas_cap: u64): u256
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, tcmg: u256, registry_max_gas_cap: u64): u256
 </code></pre>
 
 
@@ -3365,7 +3364,7 @@ Calculate automation fee multiplier for epoch. It is measured in quants/sec.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     tcmg: u256,
     registry_max_gas_cap: u64
@@ -3516,7 +3515,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
 ) {
     // Compute the automation fee multiplier for epoch
-    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
         arc,
         intermediate_state.gas_committed_for_new_epoch,
         arc.registry_max_gas_cap);
@@ -3527,7 +3526,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     );
     <b>let</b> current_epoch_end_time = current_time + epoch_interval;
 
-    // Sort task indexes <b>to</b> charge autoamtion fees in the tasks chronological order
+    // Sort task indexes <b>to</b> charge automation fees in the tasks chronological order
     <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
 
     // Process each active task and calculate fee for the epoch for the tasks
@@ -4136,7 +4135,7 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
     <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
 
     // Compute the automation fee multiplier for epoch
-    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multipler_for_epoch">calculate_automation_fee_multipler_for_epoch</a>(&arc, tcmg, arc.registry_max_gas_cap);
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(&arc, tcmg, arc.registry_max_gas_cap);
 
     <b>let</b> stopped_task_details = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>let</b> total_refund_fee = 0;

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -17,6 +17,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `RegistryFeeWithdraw`](#0x1_automation_registry_RegistryFeeWithdraw)
 -  [Struct `TaskEpochFeeWithdraw`](#0x1_automation_registry_TaskEpochFeeWithdraw)
 -  [Struct `TaskFeeRefund`](#0x1_automation_registry_TaskFeeRefund)
+-  [Struct `TaskDepositFeeRefund`](#0x1_automation_registry_TaskDepositFeeRefund)
 -  [Struct `TaskCancelled`](#0x1_automation_registry_TaskCancelled)
 -  [Struct `TasksStopped`](#0x1_automation_registry_TasksStopped)
 -  [Struct `TaskStopped`](#0x1_automation_registry_TaskStopped)
@@ -27,6 +28,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `EnabledRegistrationEvent`](#0x1_automation_registry_EnabledRegistrationEvent)
 -  [Struct `DisabledRegistrationEvent`](#0x1_automation_registry_DisabledRegistrationEvent)
 -  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
+-  [Struct `AutomationTaskFeeMeta`](#0x1_automation_registry_AutomationTaskFeeMeta)
+-  [Struct `IntermediateStatePhase1`](#0x1_automation_registry_IntermediateStatePhase1)
 -  [Struct `IntermediateState`](#0x1_automation_registry_IntermediateState)
 -  [Constants](#@Constants_0)
 -  [Function `active_task_ids`](#0x1_automation_registry_active_task_ids)
@@ -52,7 +55,9 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
+-  [Function `prepare_for_new_epoch`](#0x1_automation_registry_prepare_for_new_epoch)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
+-  [Function `on_new_epoch_2`](#0x1_automation_registry_on_new_epoch_2)
 -  [Function `adjust_tasks_epoch_fee_refund`](#0x1_automation_registry_adjust_tasks_epoch_fee_refund)
 -  [Function `refund_tasks_fee`](#0x1_automation_registry_refund_tasks_fee)
 -  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
@@ -62,7 +67,9 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
+-  [Function `try_withdraw_task_automation_fees_2`](#0x1_automation_registry_try_withdraw_task_automation_fees_2)
 -  [Function `try_withdraw_task_automation_fee`](#0x1_automation_registry_try_withdraw_task_automation_fee)
+-  [Function `try_withdraw_task_automation_fee_2`](#0x1_automation_registry_try_withdraw_task_automation_fee_2)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
@@ -75,6 +82,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `stop_tasks`](#0x1_automation_registry_stop_tasks)
 -  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
 -  [Function `sort_by_task_index`](#0x1_automation_registry_sort_by_task_index)
+-  [Function `sort`](#0x1_automation_registry_sort)
 -  [Function `upscale_from_u8`](#0x1_automation_registry_upscale_from_u8)
 -  [Function `upscale_from_u64`](#0x1_automation_registry_upscale_from_u64)
 -  [Function `upscale_from_u256`](#0x1_automation_registry_upscale_from_u256)
@@ -588,6 +596,48 @@ duration paid at the beginning of the epoch due to epoch-duration reduction by g
 
 </details>
 
+<a id="0x1_automation_registry_TaskDepositFeeRefund"></a>
+
+## Struct `TaskDepositFeeRefund`
+
+Event emitted when an automation fee is refunded for an automation task at the end of the epoch for excessive
+duration paid at the beginning of the epoch due to epoch-duration reduction by governance.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a id="0x1_automation_registry_TaskCancelled"></a>
 
 ## Struct `TaskCancelled`
@@ -934,6 +984,104 @@ Represents the fee charged for an automation task execution and some additional 
 </dd>
 <dt>
 <code>fee: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationTaskFeeMeta"></a>
+
+## Struct `AutomationTaskFeeMeta`
+
+Represents the fee charged for an automation task execution and some additional information.
+
+
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>fee: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>automation_fee_cap: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>expiry_time: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>max_gas_amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>locked_fee_for_next_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_IntermediateStatePhase1"></a>
+
+## Struct `IntermediateStatePhase1`
+
+Represents intermediate state of the registry on epoch change.
+
+
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">IntermediateStatePhase1</a> <b>has</b> drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>estimated_gas_committed_for_this_epoch: u256</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>estimated_refunds: u64</code>
 </dt>
 <dd>
 
@@ -2057,6 +2205,85 @@ Initialization of Automation Registry with configuration parameters is expected 
 
 </details>
 
+<a id="0x1_automation_registry_prepare_for_new_epoch"></a>
+
+## Function `prepare_for_new_epoch`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_prepare_for_new_epoch">prepare_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">automation_registry::IntermediateStatePhase1</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_prepare_for_new_epoch">prepare_for_new_epoch</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
+    current_time: u64
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">IntermediateStatePhase1</a> {
+    <b>let</b> epoch_duration = current_time - aei.start_time;
+    <b>let</b> epoch_residual_interval = 0;
+    <b>let</b> automation_fee_per_sec= 0;
+    <b>let</b> refund_expected = <b>false</b>;
+
+    <b>let</b> estimated_refunds = 0;
+    <b>let</b> tcmg: u256 = 0;
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
+
+    // If epoch actual duration is greater or equal <b>to</b> expected epoch-duration then there is nothing <b>to</b> refund.
+    // <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees !=0 && aei.expected_epoch_duration &gt; epoch_duration) {
+    <b>if</b> (aei.expected_epoch_duration &gt; epoch_duration) {
+        <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
+        epoch_residual_interval = aei.expected_epoch_duration - epoch_duration;
+        <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
+        automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+        refund_expected = automation_fee_per_sec != 0;
+    };
+
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
+        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
+        } <b>else</b> {
+            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <b>if</b> (refund_expected && task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a> ) {
+                <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task,
+                    epoch_residual_interval, current_time, automation_fee_per_sec);
+                estimated_refunds = estimated_refunds + refund;
+                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, refund);
+                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: refund });
+            };
+
+            // Drop or activate task for this current epoch.
+            <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task.expiry_time &lt;= current_time) {
+                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch });
+                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            } <b>else</b> {
+                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
+            }
+        }
+    });
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_IntermediateStatePhase1">IntermediateStatePhase1</a> {
+        estimated_gas_committed_for_this_epoch: tcmg,
+        estimated_refunds
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_on_new_epoch"></a>
 
 ## Function `on_new_epoch`
@@ -2140,7 +2367,89 @@ On new epoch this function will be triggered and update the automation registry 
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = tcmg;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="automation_registry.md#0x1_automation_registry_active_task_ids">active_task_ids</a>(intermediate_state);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    automation_epoch_info.start_time = current_time;
+    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_new_epoch_2"></a>
+
+## Function `on_new_epoch_2`
+
+On new epoch this function will be triggered and update the automation registry state
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    // Unless registry in initialized, registry will not be updated on new epoch.
+    // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
+    //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
+    //  - all tasks should be removed from registry state
+    // Note that <b>with</b> the current setup feature::on_new_epoch is called before <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
+        <b>return</b>
+    };
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+
+    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
+        @supra_framework
+    ).main_config;
+
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <b>let</b> result= <a href="automation_registry.md#0x1_automation_registry_prepare_for_new_epoch">prepare_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        &automation_registry_config,
+        automation_epoch_info,
+        current_time
+    );
+
+
+    // Apply the latest configuration <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> parameter <b>has</b> been updated
+    // only after refund <b>has</b> been done for previous epoch.
+    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
+
+    // If feature is not enabled then we are not charging and tasks are cleared.
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+        // TODO before cleaning refund locked automation fee deposit
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+        automation_epoch_info.start_time = current_time;
+        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+        <b>return</b>
+    };
+
+
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        &automation_registry_config,
+        automation_epoch_info.epoch_interval,
+        current_time,
+        result.estimated_gas_committed_for_this_epoch,
+    );
+
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = result.estimated_gas_committed_for_this_epoch;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
     automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
@@ -2260,6 +2569,7 @@ Cleanup and activate the automation task also it's calculate and return total co
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> tcmg = 0;
 
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
     // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
         <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
@@ -2269,6 +2579,8 @@ Cleanup and activate the automation task also it's calculate and return total co
 
             // Drop or activate task for this current epoch.
             <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
+                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch });
                 <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
             } <b>else</b> {
                 task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
@@ -2577,6 +2889,73 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 </details>
 
+<a id="0x1_automation_registry_try_withdraw_task_automation_fees_2"></a>
+
+## Function `try_withdraw_task_automation_fees_2`
+
+Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
+- If the user has sufficient balance, deducts the fee and emits a success event.
+- If the balance is insufficient, removes the task and emits a cancellation event.
+- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
+Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b>  <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    epoch_interval: u64,
+    current_time: u64,
+    tcmg: u256,
+): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: 0,
+        active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+    };
+    // Compute the automation congestion fee (acf) for the epoch
+    <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
+    <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
+    <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(&<b>mut</b> task_ids);
+
+    // Process each active task and calculate fee for the epoch for the tasks
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
+        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> {task_index})
+        } <b>else</b> {
+            <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+                task_index,
+                owner: task_meta.owner,
+                fee: 0,
+                expiry_time: task_meta.expiry_time,
+                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                max_gas_amount: task_meta.max_gas_amount,
+                locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
+            };
+            <b>if</b> (automation_fee_per_sec != 0) {
+                task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+            };
+            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, task, current_time, epoch_interval, &<b>mut</b> intermediate_state);
+        };
+    });
+    intermediate_state
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_try_withdraw_task_automation_fee"></a>
 
 ## Function `try_withdraw_task_automation_fee`
@@ -2600,9 +2979,12 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>) {
 
     <b>let</b> task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
 
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task_metadata.automation_fee_cap_for_epoch) {
+        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task_metadata.locked_fee_for_next_epoch);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task_metadata.locked_fee_for_next_epoch });
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
@@ -2610,38 +2992,114 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
             fee: task.fee,
             automation_fee_cap: task_metadata.automation_fee_cap_for_epoch,
         });
-    } <b>else</b> {
-        <b>let</b> user_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(task_metadata.owner);
-        <b>if</b> (user_balance &lt; task.fee) {
-            // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
-            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
-                task_index: task.task_index,
-                owner: task_metadata.owner,
-                fee: task.fee,
-            });
-        } <b>else</b> {
-            // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
-            <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
-                &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task_metadata.owner),
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-                task.fee
-            );
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskEpochFeeWithdraw">TaskEpochFeeWithdraw</a> {
-                task_index: task.task_index,
-                owner: task_metadata.owner,
-                fee: task.fee,
-            });
-            // Total task fees deducted from the user's <a href="account.md#0x1_account">account</a>
-            intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.active_task_ids, task.task_index);
+        <b>return</b>
+    };
+    <b>let</b> user_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(task_metadata.owner);
+    <b>if</b> (user_balance &lt; task.fee) {
+        // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
+            task_index: task.task_index,
+            owner: task_metadata.owner,
+            fee: task.fee,
+        });
+        <b>return</b>
+    };
+    <b>if</b> (task.fee != 0 ) {
+        // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
+        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
+            &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task_metadata.owner),
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            task.fee
+        );
+    };
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskEpochFeeWithdraw">TaskEpochFeeWithdraw</a> {
+        task_index: task.task_index,
+        owner: task_metadata.owner,
+        fee: task.fee,
+    });
+    // Total task fees deducted from the user's <a href="account.md#0x1_account">account</a>
+    intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
 
-            // Calculate gas commitment for the next epoch only for valid active tasks
-            <b>if</b> (task_metadata.expiry_time &gt; (current_time + epoch_interval)) {
-                intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
-            };
-        };
-    }
+    // Calculate gas commitment for the next epoch only for valid active tasks
+    <b>if</b> (task_metadata.expiry_time &gt; (current_time + epoch_interval)) {
+        intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_try_withdraw_task_automation_fee_2"></a>
+
+## Function `try_withdraw_task_automation_fee_2`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a>,
+    current_time: u64,
+    epoch_interval: u64,
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>) {
+
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap);
+    // Remove the automation task <b>if</b> the epoch fee cap is exceeded
+    <b>if</b> (task.fee &gt; task.automation_fee_cap) {
+        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch });
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
+            task_index: task.task_index,
+            owner: task.owner,
+            fee: task.fee,
+            automation_fee_cap: task.automation_fee_cap,
+        });
+        <b>return</b>
+    };
+    <b>let</b> user_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(task.owner);
+    <b>if</b> (user_balance &lt; task.fee) {
+        // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
+            task_index: task.task_index,
+            owner: task.owner,
+            fee: task.fee,
+        });
+        <b>return</b>
+    };
+    <b>if</b> (task.fee != 0 ) {
+        // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
+        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
+            &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task.owner),
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            task.fee
+        );
+    };
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskEpochFeeWithdraw">TaskEpochFeeWithdraw</a> {
+        task_index: task.task_index,
+        owner: task.owner,
+        fee: task.fee,
+    });
+    // Total task fees deducted from the user's <a href="account.md#0x1_account">account</a>
+    intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
+
+    // Calculate gas commitment for the next epoch only for valid active tasks
+    <b>if</b> (task.expiry_time &gt; (current_time + epoch_interval)) {
+        intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task.max_gas_amount;
+    };
 }
 </code></pre>
 
@@ -3260,6 +3718,42 @@ Sorting vector implementation
         <b>while</b> (j &lt; len) {
             <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, i).task_index &gt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, j).task_index) {
                 <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(v, i, j)
+            };
+            j = j + 1;
+        };
+        i = i + 1;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_sort"></a>
+
+## Function `sort`
+
+Sorting vector implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+    <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(input);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; len) {
+        <b>let</b> j = i + 1;
+        <b>while</b> (j &lt; len) {
+            <b>if</b> (*<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, i) &gt; *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, j)) {
+                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(input, i, j)
             };
             j = j + 1;
         };

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -28,6 +28,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `TaskCancelledInsufficentBalance`](#0x1_automation_registry_TaskCancelledInsufficentBalance)
 -  [Struct `TaskCancelledCapacitySurpassed`](#0x1_automation_registry_TaskCancelledCapacitySurpassed)
 -  [Struct `RemovedTasks`](#0x1_automation_registry_RemovedTasks)
+-  [Struct `ActiveTasks`](#0x1_automation_registry_ActiveTasks)
 -  [Struct `ErrorTaskDoesNotExist`](#0x1_automation_registry_ErrorTaskDoesNotExist)
 -  [Struct `ErrorTaskDoesNotExistForWithdrawal`](#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal)
 -  [Struct `ErrorInsufficientBalanceToRefund`](#0x1_automation_registry_ErrorInsufficientBalanceToRefund)
@@ -1019,6 +1020,35 @@ Event emitted on epoch transition containing removed task indexes.
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
 <b>struct</b> <a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_ActiveTasks"></a>
+
+## Struct `ActiveTasks`
+
+Event emitted on epoch transition containing active task indexes for the new epoch.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> <b>has</b> drop, store
 </code></pre>
 
 
@@ -2703,6 +2733,9 @@ On new epoch this function will be triggered and update the automation registry 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
         task_indexes: removed_tasks
     });
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
+        task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
+    });
 }
 </code></pre>
 
@@ -2751,6 +2784,9 @@ On new epoch this function will be triggered and update the automation registry 
         &<b>mut</b> removed_tasks,
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks));
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> { task_indexes: removed_tasks });
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
+        task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+    });
     <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -12,32 +12,40 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `AutomationRegistryConfig`](#0x1_automation_registry_AutomationRegistryConfig)
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
+-  [Resource `AutomationRefundBookkeeping`](#0x1_automation_registry_AutomationRefundBookkeeping)
 -  [Resource `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
 -  [Struct `TaskRegistrationFeeWithdraw`](#0x1_automation_registry_TaskRegistrationFeeWithdraw)
+-  [Struct `TaskRegistrationDepositFeeWithdraw`](#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw)
 -  [Struct `RegistryFeeWithdraw`](#0x1_automation_registry_RegistryFeeWithdraw)
 -  [Struct `TaskEpochFeeWithdraw`](#0x1_automation_registry_TaskEpochFeeWithdraw)
 -  [Struct `TaskFeeRefund`](#0x1_automation_registry_TaskFeeRefund)
 -  [Struct `TaskDepositFeeRefund`](#0x1_automation_registry_TaskDepositFeeRefund)
+-  [Struct `ErrorUnlockTaskDepositFee`](#0x1_automation_registry_ErrorUnlockTaskDepositFee)
 -  [Struct `TaskCancelled`](#0x1_automation_registry_TaskCancelled)
 -  [Struct `TasksStopped`](#0x1_automation_registry_TasksStopped)
 -  [Struct `TaskStopped`](#0x1_automation_registry_TaskStopped)
 -  [Struct `TaskCancelledInsufficentBalance`](#0x1_automation_registry_TaskCancelledInsufficentBalance)
 -  [Struct `TaskCancelledCapacitySurpassed`](#0x1_automation_registry_TaskCancelledCapacitySurpassed)
+-  [Struct `RemovedTasks`](#0x1_automation_registry_RemovedTasks)
 -  [Struct `ErrorTaskDoesNotExist`](#0x1_automation_registry_ErrorTaskDoesNotExist)
 -  [Struct `ErrorTaskDoesNotExistForWithdrawal`](#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal)
+-  [Struct `ErrorInsufficientBalanceToRefund`](#0x1_automation_registry_ErrorInsufficientBalanceToRefund)
 -  [Struct `EnabledRegistrationEvent`](#0x1_automation_registry_EnabledRegistrationEvent)
 -  [Struct `DisabledRegistrationEvent`](#0x1_automation_registry_DisabledRegistrationEvent)
 -  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
 -  [Struct `AutomationTaskFeeMeta`](#0x1_automation_registry_AutomationTaskFeeMeta)
 -  [Struct `IntermediateState`](#0x1_automation_registry_IntermediateState)
+-  [Struct `IntermediateStateWithCoins`](#0x1_automation_registry_IntermediateStateWithCoins)
 -  [Constants](#@Constants_0)
--  [Function `active_task_ids`](#0x1_automation_registry_active_task_ids)
+-  [Function `deposit_epoch_fee_to_registry_fee_address`](#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
 -  [Function `get_task_count`](#0x1_automation_registry_get_task_count)
 -  [Function `get_task_ids`](#0x1_automation_registry_get_task_ids)
 -  [Function `get_epoch_locked_balance`](#0x1_automation_registry_get_epoch_locked_balance)
+-  [Function `get_locked_deposit_balance`](#0x1_automation_registry_get_locked_deposit_balance)
+-  [Function `get_registry_total_locked_balance`](#0x1_automation_registry_get_registry_total_locked_balance)
 -  [Function `get_active_task_ids`](#0x1_automation_registry_get_active_task_ids)
 -  [Function `get_task_details`](#0x1_automation_registry_get_task_details)
 -  [Function `has_sender_active_task_with_id`](#0x1_automation_registry_has_sender_active_task_with_id)
@@ -54,6 +62,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
+-  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
 -  [Function `adjust_tasks_epoch_fee_refund`](#0x1_automation_registry_adjust_tasks_epoch_fee_refund)
 -  [Function `refund_tasks_fee`](#0x1_automation_registry_refund_tasks_fee)
@@ -61,6 +70,11 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `on_new_epoch_2`](#0x1_automation_registry_on_new_epoch_2)
 -  [Function `update_state_for_new_epoch`](#0x1_automation_registry_update_state_for_new_epoch)
 -  [Function `refund_cleanup_and_activate_tasks`](#0x1_automation_registry_refund_cleanup_and_activate_tasks)
+-  [Function `safe_refund`](#0x1_automation_registry_safe_refund)
+-  [Function `safe_deposit_refund`](#0x1_automation_registry_safe_deposit_refund)
+-  [Function `safe_unlock_locked_deposit`](#0x1_automation_registry_safe_unlock_locked_deposit)
+-  [Function `safe_fee_refund`](#0x1_automation_registry_safe_fee_refund)
+-  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
 -  [Function `calculate_tasks_automation_fees`](#0x1_automation_registry_calculate_tasks_automation_fees)
 -  [Function `calculate_task_fee`](#0x1_automation_registry_calculate_task_fee)
 -  [Function `calculate_automation_fee_for_interval`](#0x1_automation_registry_calculate_automation_fee_for_interval)
@@ -340,6 +354,36 @@ Epoch state
 
 </details>
 
+<a id="0x1_automation_registry_AutomationRefundBookkeeping"></a>
+
+## Resource `AutomationRefundBookkeeping`
+
+Automation Deposited fee bookkeeping configs
+
+
+<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> <b>has</b> <b>copy</b>, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>total_deposited_automation_fee: u64</code>
+</dt>
+<dd>
+ Total deposited fee so far which is locked in resource account unless refund of it (fully or partially) is done.
+ Independent of refund amount the actual deposited amount is deduced to unlock it from resource account.
+</dd>
+</dl>
+
+
+</details>
+
 <a id="0x1_automation_registry_AutomationTaskMetaData"></a>
 
 ## Resource `AutomationTaskMetaData`
@@ -469,6 +513,53 @@ Event on task registration fee withdrawal from owner account upon registration.
 </dd>
 <dt>
 <code>fee: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_TaskRegistrationDepositFeeWithdraw"></a>
+
+## Struct `TaskRegistrationDepositFeeWithdraw`
+
+Event on task registration fee withdrawal from owner account upon registration.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw">TaskRegistrationDepositFeeWithdraw</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>registration_fee: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>deposit_epoch_fee: u64</code>
 </dt>
 <dd>
 
@@ -629,6 +720,48 @@ duration paid at the beginning of the epoch due to epoch-duration reduction by g
 </dd>
 <dt>
 <code>amount: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_ErrorUnlockTaskDepositFee"></a>
+
+## Struct `ErrorUnlockTaskDepositFee`
+
+Event emitted when an automation fee is refunded but inner state bookkeeping total locked deposits is less than
+potential locked deposit which is being refunded fully or partially
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ErrorUnlockTaskDepositFee">ErrorUnlockTaskDepositFee</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_registered_deposit: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>locked_deposit: u64</code>
 </dt>
 <dd>
 
@@ -835,6 +968,35 @@ Event emitted when an automation task is cancelled due to automation fee capacit
 
 </details>
 
+<a id="0x1_automation_registry_RemovedTasks"></a>
+
+## Struct `RemovedTasks`
+
+Event emitted when an automation task is cancelled due to automation fee capacity surpass.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a id="0x1_automation_registry_ErrorTaskDoesNotExist"></a>
 
 ## Struct `ErrorTaskDoesNotExist`
@@ -886,6 +1048,54 @@ but it does not exist in the list.
 <dl>
 <dt>
 <code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_ErrorInsufficientBalanceToRefund"></a>
+
+## Struct `ErrorInsufficientBalanceToRefund`
+
+Event emitted when on new epoch refunds to be paid is not possible due to insufficient resource account balance.
+Type of the refund can be either deposit paid during registration (0), or caused by the shortening of the epoch (1)
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ErrorInsufficientBalanceToRefund">ErrorInsufficientBalanceToRefund</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>refund_type: u8</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>task_index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount: u64</code>
 </dt>
 <dd>
 
@@ -1075,7 +1285,7 @@ Represents intermediate state of the registry on epoch change.
 
 <dl>
 <dt>
-<code>active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+<code>removed_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
 </dt>
 <dd>
 
@@ -1088,6 +1298,46 @@ Represents intermediate state of the registry on epoch change.
 </dd>
 <dt>
 <code>epoch_locked_fees: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_IntermediateStateWithCoins"></a>
+
+## Struct `IntermediateStateWithCoins`
+
+Represents intermediate state of the registry on epoch change.
+
+
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>removed_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>gas_committed_for_next_epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch_locked_fees: <a href="coin.md#0x1_coin_Coin">coin::Coin</a>&lt;<a href="supra_coin.md#0x1_supra_coin_SupraCoin">supra_coin::SupraCoin</a>&gt;</code>
 </dt>
 <dd>
 
@@ -1146,6 +1396,16 @@ Decimal place to make
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a>: u256 = 100000000;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_DEPOSIT_EPOCH_FEE"></a>
+
+Constants describing REFUND TYPE
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_DEPOSIT_EPOCH_FEE">DEPOSIT_EPOCH_FEE</a>: u8 = 0;
 </code></pre>
 
 
@@ -1330,6 +1590,15 @@ Auxiliary data during registration is not supported
 
 
 
+<a id="0x1_automation_registry_EPOCH_FEE"></a>
+
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EPOCH_FEE">EPOCH_FEE</a>: u8 = 1;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EREGISTRY_IS_FULL"></a>
 
 Registry task capacity has reached.
@@ -1430,6 +1699,16 @@ Constants describing task state.
 
 
 
+<a id="0x1_automation_registry_REFUND_FACTOR"></a>
+
+Defines refund factor for refunds of deposit fees with penalty
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>: u64 = 2;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_REFUND_FRACTION"></a>
 
 
@@ -1459,13 +1738,13 @@ The length of the transaction hash.
 
 
 
-<a id="0x1_automation_registry_active_task_ids"></a>
+<a id="0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address"></a>
 
-## Function `active_task_ids`
+## Function `deposit_epoch_fee_to_registry_fee_address`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_active_task_ids">active_task_ids</a>(intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address">deposit_epoch_fee_to_registry_fee_address</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, value: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>)
 </code></pre>
 
 
@@ -1474,8 +1753,14 @@ The length of the transaction hash.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_active_task_ids">active_task_ids</a>(intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
-    intermediate_state.active_task_ids
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address">deposit_epoch_fee_to_registry_fee_address</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, value: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>) {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
+        removed_task_ids: _,
+        gas_committed_for_next_epoch: _,
+        epoch_locked_fees,
+
+    } = value;
+    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
 }
 </code></pre>
 
@@ -1622,7 +1907,7 @@ List all automation task ids available in register.
 
 ## Function `get_epoch_locked_balance`
 
-Get locked balance of the resource account
+Get locked balance of the resource account in terms of epoch-fees
 
 
 <pre><code>#[view]
@@ -1638,6 +1923,59 @@ Get locked balance of the resource account
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_epoch_locked_balance">get_epoch_locked_balance</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_get_locked_deposit_balance"></a>
+
+## Function `get_locked_deposit_balance`
+
+Get locked balance of the resource account in terms of deposited automation fees.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_locked_deposit_balance">get_locked_deposit_balance</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_locked_deposit_balance">get_locked_deposit_balance</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+    <b>let</b> refund_bookkeeping = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    refund_bookkeeping.total_deposited_automation_fee
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_get_registry_total_locked_balance"></a>
+
+## Function `get_registry_total_locked_balance`
+
+Get total locked balance of the resource account.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_registry_total_locked_balance">get_registry_total_locked_balance</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_registry_total_locked_balance">get_registry_total_locked_balance</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    <a href="automation_registry.md#0x1_automation_registry_get_epoch_locked_balance">get_epoch_locked_balance</a>() + <a href="automation_registry.md#0x1_automation_registry_get_locked_deposit_balance">get_locked_deposit_balance</a>()
 }
 </code></pre>
 
@@ -2171,6 +2509,34 @@ Initialization of Automation Registry with configuration parameters is expected 
         epoch_interval: epoch_interval_secs,
         start_time: 0,
     });
+
+    <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_initialize_refund_bookkeeping_resource"></a>
+
+## Function `initialize_refund_bookkeeping_resource`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+        total_deposited_automation_fee: 0
+    });
 }
 </code></pre>
 
@@ -2194,7 +2560,7 @@ On new epoch this function will be triggered and update the automation registry 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Unless registry in initialized, registry will not be updated on new epoch.
     // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
     //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
@@ -2205,6 +2571,7 @@ On new epoch this function will be triggered and update the automation registry 
     };
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
 
     <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
         @supra_framework
@@ -2230,6 +2597,10 @@ On new epoch this function will be triggered and update the automation registry 
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
+            task_indexes: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks)
+        });
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
         automation_epoch_info.start_time = current_time;
@@ -2238,7 +2609,7 @@ On new epoch this function will be triggered and update the automation registry 
     };
 
     // Accumulated maximum gas amount of the registered tasks for the current epoch
-    <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, current_time);
+    <b>let</b> (tcmg, removed_tasks) = <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, current_time);
 
 
     <b>let</b> tasks_automation_fees = <a href="automation_registry.md#0x1_automation_registry_calculate_tasks_automation_fees">calculate_tasks_automation_fees</a>(
@@ -2250,20 +2621,34 @@ On new epoch this function will be triggered and update the automation registry 
         <b>false</b>
     );
 
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: 0,
+        removed_task_ids: removed_tasks,
+    };
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+        gas_committed_for_next_epoch,
+        epoch_locked_fees,
+        removed_task_ids
+    } = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        refund_bookkeeping,
         tasks_automation_fees,
         current_time,
-        automation_epoch_info.epoch_interval
+        automation_epoch_info.epoch_interval,
+        intermediate_state
     );
 
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = tcmg;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
     automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
+        task_indexes: removed_task_ids
+    });
 }
 </code></pre>
 
@@ -2345,12 +2730,12 @@ Processes refunds for automation task fees.
     tasks_automation_refund_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt;
 ) {
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(resource_signer_cap);
+    <b>let</b> resource_adderss= <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&resource_signer);
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(tasks_automation_refund_fees, |task| {
         <b>let</b> task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a> = task;
         <b>if</b> (task.fee != 0) {
-            <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.fee);
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.fee });
+            <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(&resource_signer, resource_adderss, task.task_index, task.owner, task.fee);
         }
     });
 }
@@ -2367,7 +2752,7 @@ Processes refunds for automation task fees.
 Cleanup and activate the automation task also it's calculate and return total committed max gas
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, current_time: u64): u256
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -2376,9 +2761,10 @@ Cleanup and activate the automation task also it's calculate and return total co
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, current_time: u64): u256 {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> tcmg = 0;
+    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
@@ -2392,18 +2778,23 @@ Cleanup and activate the automation task also it's calculate and return total co
 
             // Drop or activate task for this current epoch.
             <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
-                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-                <a href="event.md#0x1_event_emit">event::emit</a>(
-                    <a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
-                );
+                <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+                    refund_bookkeeping,
+                    &resource_signer,
+                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch);
                 <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
             } <b>else</b> {
                 task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
                 tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
             }
         }
     });
-    tcmg
+    (tcmg, removed_tasks)
 }
 </code></pre>
 
@@ -2428,7 +2819,7 @@ On new epoch this function will be triggered and update the automation registry 
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch_2">on_new_epoch_2</a>(
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Unless registry in initialized, registry will not be updated on new epoch.
     // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
     //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
@@ -2439,13 +2830,16 @@ On new epoch this function will be triggered and update the automation registry 
     };
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
 
     <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
         @supra_framework
     ).main_config;
 
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> new_epoch_tcmg = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+    <b>let</b> (new_epoch_tcmg, removed_tasks) = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        refund_bookkeeping,
         &automation_registry_config,
         automation_epoch_info,
         current_time
@@ -2462,7 +2856,10 @@ On new epoch this function will be triggered and update the automation registry 
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-        // TODO before cleaning refund locked automation fee deposit
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping);
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
+            task_indexes: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks)
+        });
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
         automation_epoch_info.start_time = current_time;
@@ -2470,22 +2867,36 @@ On new epoch this function will be triggered and update the automation registry 
         <b>return</b>
     };
 
+    <b>let</b> intermediate_state_with_coins = <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a> {
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>&lt;SupraCoin&gt;(),
+        removed_task_ids: removed_tasks,
+    };
 
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+        gas_committed_for_next_epoch,
+        epoch_locked_fees,
+        removed_task_ids
+    } = <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        refund_bookkeeping,
         &automation_registry_config,
         automation_epoch_info.epoch_interval,
         current_time,
         new_epoch_tcmg,
+        intermediate_state_with_coins
     );
 
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = new_epoch_tcmg;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
 
     automation_epoch_info.start_time = current_time;
     automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
+        task_indexes: removed_task_ids
+    });
 }
 </code></pre>
 
@@ -2501,7 +2912,7 @@ Checks all tasks for refunds, cancellation and expirations.
 Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): u256
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -2512,10 +2923,11 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
     current_time: u64
-): u256 {
+): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> previous_epoch_duration = current_time - aei.start_time;
     <b>let</b> refund_interval = 0;
     <b>let</b> refund_automation_fee_per_sec = 0;
@@ -2528,18 +2940,17 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
         refund_automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
     };
 
-    <b>let</b> new_epoch_tcmg = <b>if</b> (refund_automation_fee_per_sec != 0) {
+    <b>if</b> (refund_automation_fee_per_sec != 0) {
         <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+            refund_bookkeeping,
             current_time,
             arc,
             refund_automation_fee_per_sec,
             refund_interval)
     } <b>else</b> {
-        <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, current_time)
-    };
-
-    new_epoch_tcmg
+        <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, current_time)
+    }
 }
 </code></pre>
 
@@ -2554,7 +2965,7 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): u256
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -2565,45 +2976,217 @@ Refund, Cleanup and activate the automation task also it's calculate and return 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     current_time: u64,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     refund_automation_fee_per_sec: u256,
     refund_interval: u64,
-): u256 {
+): (u256, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
     <b>let</b> tcmg = 0;
+    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExist">ErrorTaskDoesNotExist</a> { task_index })
-        } <b>else</b> {
-            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
-                <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task,
-                    refund_interval, current_time, refund_automation_fee_per_sec);
-                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, refund);
-                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: refund });
-            };
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+        <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+            <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task,
+                refund_interval, current_time, refund_automation_fee_per_sec);
+            <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
+                &resource_signer,
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                task.task_index,
+                task.owner,
+                refund);
+        };
 
-            // Drop or activate task for this current epoch.
-            <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task.expiry_time &lt;= current_time) {
-                // Refund deposited epoch-fee for cancelled and expired tasks.
-                <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-                <a href="event.md#0x1_event_emit">event::emit</a>(
-                    <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
-                );
-                <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            } <b>else</b> {
-                task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-                tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
-            }
+        // Drop or activate task for this current epoch.
+        <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task.expiry_time &lt;= current_time) {
+            // Refund deposited epoch-fee for cancelled and expired tasks.
+            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+                refund_bookkeeping,
+                &resource_signer,
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+            task.locked_fee_for_next_epoch);
+            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
+        } <b>else</b> {
+            task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+            tcmg = tcmg + (task.max_gas_amount <b>as</b> u256);
         }
     });
-    tcmg
+    (tcmg, removed_tasks)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_refund"></a>
+
+## Function `safe_refund`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_amount: u64, refund_type: u8): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resource_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_amount: u64, refund_type: u8):  bool {
+    <b>let</b> balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(resource_address);
+    <b>if</b> (balance &lt; refundable_amount) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_ErrorInsufficientBalanceToRefund">ErrorInsufficientBalanceToRefund</a> { refund_type, task_index, owner: task_owner, amount: refundable_amount }
+        );
+        <b>return</b> <b>false</b>
+    };
+
+    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(resource_signer, task_owner, refundable_amount);
+    <b>return</b> <b>true</b>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_deposit_refund"></a>
+
+## Function `safe_deposit_refund`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_deposit: u64, locked_deposit: u64):  bool {
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer, resouce_address, task_index, task_owner, refundable_deposit, <a href="automation_registry.md#0x1_automation_registry_DEPOSIT_EPOCH_FEE">DEPOSIT_EPOCH_FEE</a>);
+    <b>if</b> (result) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index, owner: task_owner, amount: refundable_deposit }
+        );
+        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb, locked_deposit, task_index)
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_unlock_locked_deposit"></a>
+
+## Function `safe_unlock_locked_deposit`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(rb: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, locked_deposit: u64, task_index: u64) {
+    <b>if</b> (rb.total_deposited_automation_fee &gt; locked_deposit) {
+        rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
+    } <b>else</b> {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_ErrorUnlockTaskDepositFee">ErrorUnlockTaskDepositFee</a> { total_registered_deposit: rb.total_deposited_automation_fee, locked_deposit, task_index }
+        );
+    }
+
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_fee_refund"></a>
+
+## Function `safe_fee_refund`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, resouce_address: <b>address</b>, task_index: u64, task_owner: <b>address</b>, refundable_fee: u64):  bool {
+    <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_refund">safe_refund</a>(resource_signer, resouce_address, task_index, task_owner, refundable_fee, <a href="automation_registry.md#0x1_automation_registry_EPOCH_FEE">EPOCH_FEE</a>);
+    <b>if</b> (result) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(
+            <a href="automation_registry.md#0x1_automation_registry_TaskFeeRefund">TaskFeeRefund</a> { task_index, owner: task_owner, amount: refundable_fee }
+        );
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_safe_deposit_refund_all"></a>
+
+## Function `safe_deposit_refund_all`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>) {
+    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+            refund_bookkeeping,
+            &resource_signer,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            task.task_index,
+            task.owner,
+            task.locked_fee_for_next_epoch,
+        task.locked_fee_for_next_epoch);
+    });
 }
 </code></pre>
 
@@ -2865,7 +3448,7 @@ Processes automation task fees by checking user balances and task's commitment o
 Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, tasks_automation_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>&gt;, current_time: u64, epoch_interval: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, tasks_automation_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>&gt;, current_time: u64, epoch_interval: u64, intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
 </code></pre>
 
 
@@ -2876,15 +3459,12 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     tasks_automation_fees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt;,
     current_time: u64,
     epoch_interval: u64,
+    intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>,
 ): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: 0,
-        active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
-    };
 
     <a href="automation_registry.md#0x1_automation_registry_sort_by_task_index">sort_by_task_index</a>(&<b>mut</b> tasks_automation_fees);
 
@@ -2895,6 +3475,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
         } <b>else</b> {
             <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
                 <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+                refund_bookkeeping,
                 task,
                 current_time,
                 epoch_interval,
@@ -2916,7 +3497,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">automation_registry::AutomationTaskFee</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>)
 </code></pre>
 
 
@@ -2927,6 +3508,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>,
     current_time: u64,
     epoch_interval: u64,
@@ -2938,11 +3520,17 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task_metadata.automation_fee_cap_for_epoch) {
-        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task_metadata.locked_fee_for_next_epoch);
-        <a href="event.md#0x1_event_emit">event::emit</a>(
-            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task_metadata.locked_fee_for_next_epoch }
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+            refund_bookkeeping,
+            &resource_signer,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            task.task_index,
+            task.owner,
+            task_metadata.locked_fee_for_next_epoch,
+            task_metadata.locked_fee_for_next_epoch
         );
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
             owner: task_metadata.owner,
@@ -2955,11 +3543,13 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     <b>if</b> (user_balance &lt; task.fee) {
         // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
             task_index: task.task_index,
             owner: task_metadata.owner,
             fee: task.fee,
         });
+        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task_metadata.locked_fee_for_next_epoch, task.task_index);
         <b>return</b>
     };
     <b>if</b> (task.fee != 0) {
@@ -3000,7 +3590,7 @@ Processes automation task fees by checking user balances and task's commitment o
 Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, tcmg: u256, intermediate_state_with_coins: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>
 </code></pre>
 
 
@@ -3011,51 +3601,56 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees_2">try_withdraw_task_automation_fees_2</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     epoch_interval: u64,
     current_time: u64,
     tcmg: u256,
+    intermediate_state_with_coins: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>
 ): <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: 0,
-        active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
-    };
     // Compute the automation congestion fee (acf) for the epoch
     <b>let</b> acf = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_congestion_fee">calculate_automation_congestion_fee</a>(arc, tcmg, arc.registry_max_gas_cap);
     <b>let</b> automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec <b>as</b> u256);
     <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
 
     // Sort task indexes <b>to</b> charge autoamtion fees in the tasks chronological order
     <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(&<b>mut</b> task_ids);
 
     // Process each active task and calculate fee for the epoch for the tasks
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal">ErrorTaskDoesNotExistForWithdrawal</a> { task_index })
-        } <b>else</b> {
-            <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
-                task_index,
-                owner: task_meta.owner,
-                fee: 0,
-                expiry_time: task_meta.expiry_time,
-                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                max_gas_amount: task_meta.max_gas_amount,
-                locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
-            };
-            <b>if</b> (automation_fee_per_sec != 0) {
-                task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
-            };
-            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-                task,
-                current_time,
-                epoch_interval,
-                &<b>mut</b> intermediate_state
-            );
+        <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+        <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+            task_index,
+            owner: task_meta.owner,
+            fee: 0,
+            expiry_time: task_meta.expiry_time,
+            automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+            max_gas_amount: task_meta.max_gas_amount,
+            locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
         };
+        <b>if</b> (automation_fee_per_sec != 0) {
+            task.fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+        };
+        <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+            refund_bookkeeping,
+            &resource_signer,
+            task,
+            current_time,
+            epoch_interval,
+            &<b>mut</b> intermediate_state_with_coins
+        );
     });
+    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a> {
+        gas_committed_for_next_epoch: intermediate_state_with_coins.gas_committed_for_next_epoch,
+        epoch_locked_fees: <a href="coin.md#0x1_coin_value">coin::value</a>(&intermediate_state_with_coins.epoch_locked_fees),
+        removed_task_ids: intermediate_state_with_coins.removed_task_ids
+    };
+
+    <a href="automation_registry.md#0x1_automation_registry_deposit_epoch_fee_to_registry_fee_address">deposit_epoch_fee_to_registry_fee_address</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, intermediate_state_with_coins);
     intermediate_state
 }
 </code></pre>
@@ -3070,7 +3665,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">automation_registry::IntermediateState</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_time: u64, epoch_interval: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">automation_registry::IntermediateStateWithCoins</a>)
 </code></pre>
 
 
@@ -3081,20 +3676,25 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee_2">try_withdraw_task_automation_fee_2</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a>,
     current_time: u64,
     epoch_interval: u64,
-    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateState">IntermediateState</a>) {
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateWithCoins">IntermediateStateWithCoins</a>) {
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     <b>if</b> (task.fee &gt; task.automation_fee_cap) {
-        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-        <a href="event.md#0x1_event_emit">event::emit</a>(
-            <a href="automation_registry.md#0x1_automation_registry_TaskDepositFeeRefund">TaskDepositFeeRefund</a> { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+            refund_bookkeeping,
+            resource_signer,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            task.task_index,
+            task.owner,
+            task.locked_fee_for_next_epoch,
+            task.locked_fee_for_next_epoch
         );
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
             owner: task.owner,
@@ -3107,28 +3707,29 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     <b>if</b> (user_balance &lt; task.fee) {
         // If the user does not have enough balance, remove the task and emit an <a href="event.md#0x1_event">event</a>
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_task_ids, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledInsufficentBalance">TaskCancelledInsufficentBalance</a> {
             task_index: task.task_index,
             owner: task.owner,
             fee: task.fee,
         });
+        <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
         <b>return</b>
     };
     <b>if</b> (task.fee != 0) {
         // Charge the fee and emit a success <a href="event.md#0x1_event">event</a>
-        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(
+        <b>let</b> withdrawn_coins = <a href="coin.md#0x1_coin_withdraw">coin::withdraw</a>&lt;SupraCoin&gt;(
             &<a href="create_signer.md#0x1_create_signer">create_signer</a>(task.owner),
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
             task.fee
         );
+        // Merge <b>to</b> total task fees deducted from the users <a href="account.md#0x1_account">account</a>
+        <a href="coin.md#0x1_coin_merge">coin::merge</a>(&<b>mut</b> intermediate_state.epoch_locked_fees, withdrawn_coins);
     };
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskEpochFeeWithdraw">TaskEpochFeeWithdraw</a> {
         task_index: task.task_index,
         owner: task.owner,
         fee: task.fee,
     });
-    // Total task fees deducted from the user's <a href="account.md#0x1_account">account</a>
-    intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
 
     // Calculate gas commitment for the next epoch only for valid active tasks
     <b>if</b> (task.expiry_time &gt; (current_time + epoch_interval)) {
@@ -3199,7 +3800,7 @@ Withdraw accumulated automation task fees from the resource account - access by 
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <b>to</b>: <b>address</b>,
     amount: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(<b>to</b>, amount);
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RegistryFeeWithdraw">RegistryFeeWithdraw</a> { <b>to</b>, amount });
@@ -3226,13 +3827,16 @@ Transfers the specified fee amount from the resource account to the target accou
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(<b>to</b>: <b>address</b>, amount: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(<b>to</b>: <b>address</b>, amount: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
     <b>let</b> resource_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address);
 
     <b>assert</b>!(resource_balance &gt;= amount, <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_BALANCE">EINSUFFICIENT_BALANCE</a>);
 
-    <b>assert</b>!((resource_balance - amount) &gt;= <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees, <a href="automation_registry.md#0x1_automation_registry_EREQUEST_EXCEEDS_LOCKED_BALANCE">EREQUEST_EXCEEDS_LOCKED_BALANCE</a>);
+    <b>assert</b>!((resource_balance - amount) &gt;=
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees +
+            refund_bookkeeping.total_deposited_automation_fee, <a href="automation_registry.md#0x1_automation_registry_EREQUEST_EXCEEDS_LOCKED_BALANCE">EREQUEST_EXCEEDS_LOCKED_BALANCE</a>);
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
@@ -3394,7 +3998,7 @@ Registers a new automation task entry.
     automation_fee_cap_for_epoch: u64,
     tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     aux_data: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Guarding registration <b>if</b> feature is not enabled.
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&aux_data), <a href="automation_registry.md#0x1_automation_registry_ENO_AUX_DATA_SUPPORTED">ENO_AUX_DATA_SUPPORTED</a>);
@@ -3442,6 +4046,7 @@ Registers a new automation task entry.
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = committed_gas;
     <b>let</b> task_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index;
 
+    <b>let</b> deposit_automation_fee = automation_fee_cap_for_epoch;
     <b>let</b> automation_task_metadata = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> {
         task_index,
         owner,
@@ -3454,17 +4059,26 @@ Registers a new automation task entry.
         state: <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>,
         registration_time,
         tx_hash,
-        locked_fee_for_next_epoch: 0
+        locked_fee_for_next_epoch: deposit_automation_fee
     };
 
     <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index, automation_task_metadata);
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index + 1;
 
-    // Charge flat registration fee from the user at the time of registration
-    <b>let</b> fee = automation_registry_config.main_config.flat_registration_fee_in_quants;
+    // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
+    <b>let</b> fee = automation_registry_config.main_config.flat_registration_fee_in_quants + deposit_automation_fee;
+
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + deposit_automation_fee;
+
     <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(owner_signer, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, fee);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskRegistrationFeeWithdraw">TaskRegistrationFeeWithdraw</a> { task_index, owner, fee });
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw">TaskRegistrationDepositFeeWithdraw</a> {
+        task_index,
+        owner,
+        registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
+        deposit_epoch_fee: deposit_automation_fee
+    });
     <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
 }
 </code></pre>
@@ -3535,8 +4149,9 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(
     owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task_index: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>{
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
     <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
 
     <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
@@ -3544,8 +4159,21 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
     <b>assert</b>!(automation_task_metadata.owner == owner, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
     <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>, <a href="automation_registry.md#0x1_automation_registry_EALREADY_CANCELLED">EALREADY_CANCELLED</a>);
     <b>if</b> (automation_task_metadata.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+        <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+            &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+        );
+        // When Pending tasks are cancelled, refund of the deposit fee is done <b>with</b> penalty
+        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+            refund_bookkeeping,
+            &resource_signer,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            automation_task_metadata.task_index,
+            owner,
+            automation_task_metadata.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>,
+        automation_task_metadata.locked_fee_for_next_epoch);
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
     } <b>else</b> <b>if</b> (automation_task_metadata.state == <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>) {
+        // Active tasks will be refunded at the end of the epoch
         <b>let</b> automation_task_metadata_mut = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(
             &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks,
             task_index
@@ -3746,14 +4374,13 @@ Sorting vector implementation
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_by_task_index">sort_by_task_index</a>(v: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskFee">AutomationTaskFee</a>&gt;) {
     <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v);
-    <b>let</b> i = 0;
+    <b>let</b> i = 1;
     <b>while</b> (i &lt; len) {
-        <b>let</b> j = i + 1;
-        <b>while</b> (j &lt; len) {
-            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, i).task_index &gt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, j).task_index) {
-                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(v, i, j)
-            };
-            j = j + 1;
+        <b>let</b> j = i;
+        <b>let</b> to_be_sorted = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, j).task_index;
+        <b>while</b> (j &gt; 0 && to_be_sorted &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(v, j - 1).task_index) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(v, j, j - 1);
+            j = j - 1;
         };
         i = i + 1;
     };
@@ -3782,14 +4409,13 @@ Sorting vector implementation
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort">sort</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(input);
-    <b>let</b> i = 0;
+    <b>let</b> i = 1;
     <b>while</b> (i &lt; len) {
-        <b>let</b> j = i + 1;
-        <b>while</b> (j &lt; len) {
-            <b>if</b> (*<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, i) &gt; *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, j)) {
-                <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(input, i, j)
-            };
-            j = j + 1;
+        <b>let</b> j = i;
+        <b>let</b> to_be_sorted = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, j);
+        <b>while</b> (j &gt; 0 && to_be_sorted &lt; *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, j - 1)) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(input, j, j - 1);
+            j = j - 1;
         };
         i = i + 1;
     };

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -79,9 +79,9 @@ module supra_framework::automation_registry {
     const EEMPTY_TASK_INDEXES: u64 = 25;
     /// Resource Account does not have sufficient balance to process the refund for the specified task.
     const EINSUFFICIENT_BALANCE_FOR_REFUND: u64 = 26;
-    /// Failed to refund deposit for the task. For more deatils see the emitted events
+    /// Failed to unlock/refund deposit for a task. Internal error, for more details see emitted error events.
     const EDEPOSIT_REFUND: u64 = 27;
-    /// Failed to refund deposit for the task. For more deatils see the emitted events
+    /// Failed to unlock/refund epoch fee for a task. Internal error, for more details see emitted error events.
     const EEPOCH_FEE_REFUND: u64 = 28;
 
     /// The length of the transaction hash.
@@ -221,7 +221,7 @@ module supra_framework::automation_registry {
         state: u8,
         /// Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for it.
         /// It will be refunded fully when active task is expired or cancelled by user
-        /// and partially if a pending task is cancelled by user or an active taks is cancelled by the system due to
+        /// and partially if a pending task is cancelled by user or an active task is cancelled by the system due to
         /// insufficient balance to  pay the automation fee for the epoch
         locked_fee_for_next_epoch: u64,
     }
@@ -268,8 +268,7 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted when an automation fee is refunded for an automation task at the end of the epoch for excessive
-    /// duration paid at the beginning of the epoch due to epoch-duration reduction by governance.
+    /// Event emitted when a deposit fee is refunded for an automation task.
     struct TaskDepositFeeRefund has drop, store {
         task_index: u64,
         owner: address,
@@ -286,7 +285,7 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted when an task epoch fee is being refunded but locked epoch fees is less than
+    /// Event emitted when a task epoch fee is being refunded but locked epoch fees is less than
     /// potential requested refund.
     struct ErrorUnlockTaskEpochFee has drop, store {
         task_index: u64,
@@ -343,7 +342,6 @@ module supra_framework::automation_registry {
         task_indexes: vector<u64>
     }
 
-
     #[event]
     /// Event emitted when on new epoch a task is accessed with index of the task for the expected list
     /// but value does not exist in the map
@@ -360,7 +358,7 @@ module supra_framework::automation_registry {
 
     #[event]
     /// Event emitted during epoch transition when refunds to be paid is not possible due to insufficient resource account balance.
-    /// Type of the refund can be releated either to the deposit paid during registration (0), or to epoch-fee caused by
+    /// Type of the refund can be related either to the deposit paid during registration (0), or to epoch-fee caused by
     /// the shortening of the epoch (1)
     struct ErrorInsufficientBalanceToRefund has drop, store {
         refund_type: u8,
@@ -389,7 +387,7 @@ module supra_framework::automation_registry {
     }
 
     /// Represents intermediate state of the registry on epoch change.
-    /// Deprectead in production, substituted with IntermediateStateWithRemovedTasks.
+    /// Deprecated in production, substituted with `IntermediateStateOfEpochChange`.
     /// Kept for backward compatible framework upgrade.
     struct IntermediateState has drop {
         active_task_ids: vector<u64>,
@@ -576,7 +574,7 @@ module supra_framework::automation_registry {
         let total_committed_max_gas = committed_occupancy + task_occupancy;
 
         // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
             &active_config.main_config,
             (total_committed_max_gas as u256),
             active_config.next_epoch_registry_max_gas_cap);
@@ -700,7 +698,7 @@ module supra_framework::automation_registry {
         ).main_config;
 
         let current_time = timestamp::now_seconds();
-        let intermedate_state = update_state_for_new_epoch(
+        let intermediate_state = update_state_for_new_epoch(
             automation_registry,
             refund_bookkeeping,
             &automation_registry_config,
@@ -720,7 +718,7 @@ module supra_framework::automation_registry {
                 automation_epoch_info,
                 refund_bookkeeping,
                 current_time,
-                intermedate_state);
+                intermediate_state);
             return
         };
 
@@ -730,10 +728,10 @@ module supra_framework::automation_registry {
             &automation_registry_config,
             automation_epoch_info.epoch_interval,
             current_time,
-            &mut intermedate_state,
+            &mut intermediate_state,
         );
 
-        finalize_epoch_change(automation_registry, automation_epoch_info, current_time, intermedate_state);
+        finalize_epoch_change(automation_registry, automation_epoch_info, current_time, intermediate_state);
     }
 
     fun finalize_epoch_change(
@@ -820,7 +818,7 @@ module supra_framework::automation_registry {
             let previous_tcmg = automation_registry.gas_committed_for_this_epoch;
             refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
             // Compute the automation fee multiplier for ended epoch
-            refund_automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(arc, previous_tcmg, arc.registry_max_gas_cap);
+            refund_automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(arc, previous_tcmg, arc.registry_max_gas_cap);
         };
 
         if (refund_automation_fee_per_sec != 0) {
@@ -836,8 +834,8 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Refunds active tasks of the previeous epoch, cleans up expired and canclelled tasks and activates the pending tasks.
-    /// Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+    /// Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks and activates the pending tasks.
+    /// Also calculates and returns the total committed max gas for the new epoch along with the task indexes
     /// that have been removed from the registry.
     fun refund_cleanup_and_activate_tasks(
         automation_registry: &mut AutomationRegistry,
@@ -900,8 +898,8 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Cleans up expired and canclelled tasks and activates the pending tasks.
-    /// Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+    /// Cleans up expired and cancelled tasks and activates the pending tasks.
+    /// Also calculates and returns the total committed max gas for the new epoch along with the task indexes
     /// that have been removed from the registry.
     fun cleanup_and_activate_tasks(
         automation_registry: &mut AutomationRegistry,
@@ -967,20 +965,20 @@ module supra_framework::automation_registry {
         });
     }
 
-    /// Refunds specified ammount of deposit to the task ower and unlocks full deposit from registry resource account.
+    /// Refunds specified amount of deposit to the task owner and unlocks full deposit from registry resource account.
     /// Error events are emitted
     ///   - if the registry resource account does not have enough balance for refund.
     ///   - if the full deposit can not be unlocked.
     fun safe_deposit_refund(
         rb: &mut AutomationRefundBookkeeping,
         resource_signer: &signer,
-        resouce_address: address,
+        resource_address: address,
         task_index: u64,
         task_owner: address,
         refundable_deposit: u64,
         locked_deposit: u64
     ):  bool {
-        // This check will make sure that no more than totally locked deposited will be refunced.
+        // This check will make sure that no more than totally locked deposited will be refunded.
         // If there is an attempt then it means implementation bug.
         let result = safe_unlock_locked_deposit(rb, locked_deposit, task_index);
         if (!result) {
@@ -989,7 +987,7 @@ module supra_framework::automation_registry {
 
         let result = safe_refund(
             resource_signer,
-            resouce_address,
+            resource_address,
             task_index,
             task_owner,
             refundable_deposit,
@@ -1003,8 +1001,8 @@ module supra_framework::automation_registry {
         result
     }
 
-    /// Unlocks the deposit paied by the task from internal deposit refund bookkeeping state.
-    /// Error event is emitted if the deposit refund bookkeeping state is inconsistent with the requested unlock ammount.
+    /// Unlocks the deposit paid by the task from internal deposit refund bookkeeping state.
+    /// Error event is emitted if the deposit refund bookkeeping state is inconsistent with the requested unlock amount.
     fun safe_unlock_locked_deposit(
         rb: &mut AutomationRefundBookkeeping,
         locked_deposit: u64,
@@ -1022,7 +1020,7 @@ module supra_framework::automation_registry {
     }
 
     /// Unlocks the locked fee paid by the task for epoch.
-    /// Error event is emitted if the epoch locked fee amount is inconsistent with the requested unlock ammount.
+    /// Error event is emitted if the epoch locked fee amount is inconsistent with the requested unlock amount.
     fun safe_unlock_locked_epoch_fee(
         epoch_locked_fees: u64,
         refundable_fee: u64,
@@ -1042,13 +1040,13 @@ module supra_framework::automation_registry {
         (has_locked_fee, epoch_locked_fees)
     }
 
-    /// Refunds fee paied by the task for the epoch to the task owner.
+    /// Refunds fee paid by the task for the epoch to the task owner.
     /// Note that here we do not unlock the fee, as on epoch change locked epoch-fees for the ended epoch are
     /// automatically unlocked.
     fun safe_fee_refund(
         epoch_locked_fees: u64,
         resource_signer: &signer,
-        resouce_address: address,
+        resource_address: address,
         task_index: u64,
         task_owner: address,
         refundable_fee: u64
@@ -1059,7 +1057,7 @@ module supra_framework::automation_registry {
         };
         let result = safe_refund(
             resource_signer,
-            resouce_address,
+            resource_address,
             task_index,
             task_owner,
             refundable_fee,
@@ -1073,7 +1071,7 @@ module supra_framework::automation_registry {
     }
 
     /// Refunds specified amount to the task owner.
-    /// Error event is emitted if the resource account does not have enough balace.
+    /// Error event is emitted if the resource account does not have enough balance.
     fun safe_refund(
         resource_signer: &signer,
         resource_address: address,
@@ -1135,7 +1133,7 @@ module supra_framework::automation_registry {
     }
 
     /// Calculate automation fee multiplier for epoch. It is measured in quants/sec.
-    fun calculate_automation_fee_multipler_for_epoch(
+    fun calculate_automation_fee_multiplier_for_epoch(
         arc: &AutomationRegistryConfig,
         tcmg: u256,
         registry_max_gas_cap: u64
@@ -1226,7 +1224,7 @@ module supra_framework::automation_registry {
         intermediate_state: &mut IntermediateStateOfEpochChange,
     ) {
         // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
             arc,
             intermediate_state.gas_committed_for_new_epoch,
             arc.registry_max_gas_cap);
@@ -1237,7 +1235,7 @@ module supra_framework::automation_registry {
         );
         let current_epoch_end_time = current_time + epoch_interval;
 
-        // Sort task indexes to charge autoamtion fees in the tasks chronological order
+        // Sort task indexes to charge automation fees in the tasks chronological order
         sort_vector(&mut task_ids);
 
         // Process each active task and calculate fee for the epoch for the tasks
@@ -1626,7 +1624,7 @@ module supra_framework::automation_registry {
         let tcmg = automation_registry.gas_committed_for_this_epoch;
 
         // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(&arc, tcmg, arc.registry_max_gas_cap);
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(&arc, tcmg, arc.registry_max_gas_cap);
 
         let stopped_task_details = vector[];
         let total_refund_fee = 0;
@@ -1985,7 +1983,7 @@ module supra_framework::automation_registry {
         let task_with_fees = vector[];
 
         // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(arc, tcmg, arc.registry_max_gas_cap);
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(arc, tcmg, arc.registry_max_gas_cap);
 
         enumerable_map::for_each_value_ref(&automation_registry.tasks, |task| {
             let task: &AutomationTaskMetaData = task;

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -88,7 +88,8 @@ module supra_framework::automation_registry {
     /// Max U64 value
     const MAX_U64: u128 = 18446744073709551615;
     /// Decimal place to make
-    const DECIMAL: u256 = 100_000_000; // 10^8 Power
+    // 10^8 Power
+    const DECIMAL: u256 = 100_000_000;
     /// 100 Percentage
     const MAX_PERCENTAGE: u8 = 100;
     const REFUND_FRACTION: u64 = 2;
@@ -234,6 +235,15 @@ module supra_framework::automation_registry {
     }
 
     #[event]
+    /// Event emitted when an automation fee is refunded for an automation task at the end of the epoch for excessive
+    /// duration paid at the beginning of the epoch due to epoch-duration reduction by governance.
+    struct TaskDepositFeeRefund has drop, store {
+        task_index: u64,
+        owner: address,
+        amount: u64,
+    }
+
+    #[event]
     /// Event emitted on automation task cancellation by owner.
     struct TaskCancelled has drop, store {
         task_index: u64,
@@ -297,6 +307,17 @@ module supra_framework::automation_registry {
         task_index: u64,
         owner: address,
         fee: u64,
+    }
+
+    /// Represents the fee charged for an automation task execution and some additional information.
+    struct AutomationTaskFeeMeta has drop {
+        task_index: u64,
+        owner: address,
+        fee: u64,
+        automation_fee_cap: u64,
+        expiry_time: u64,
+        max_gas_amount: u64,
+        locked_fee_for_next_epoch: u64
     }
 
     /// Represents intermediate state of the registry on epoch change.
@@ -441,7 +462,12 @@ module supra_framework::automation_registry {
     ): u64 acquires AutomationEpochInfo, ActiveAutomationRegistryConfig {
         let epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
         let config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
-        estimate_automation_fee_with_committed_occupancy_internal(task_occupancy, committed_occupancy, epoch_info, config)
+        estimate_automation_fee_with_committed_occupancy_internal(
+            task_occupancy,
+            committed_occupancy,
+            epoch_info,
+            config
+        )
     }
 
     #[view]
@@ -486,7 +512,7 @@ module supra_framework::automation_registry {
         registry_max_gas_cap: u64,
         congestion_threshold_percentage: u8,
         congestion_exponent: u8,
-    ){
+    ) {
         assert!(congestion_threshold_percentage <= MAX_PERCENTAGE, EMAX_CONGESTION_THRESHOLD);
         assert!(congestion_exponent > 0, ECONGESTION_EXP_NON_ZERO);
         assert!(task_duration_cap_in_secs > epoch_interval_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
@@ -523,7 +549,9 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_exponent);
 
-        let (registry_fee_resource_signer, registry_fee_address_signer_cap) = create_registry_resource_account(supra_framework);
+        let (registry_fee_resource_signer, registry_fee_address_signer_cap) = create_registry_resource_account(
+            supra_framework
+        );
 
         move_to(supra_framework, AutomationRegistry {
             tasks: enumerable_map::new_map(),
@@ -558,7 +586,6 @@ module supra_framework::automation_registry {
         });
     }
 
-
     /// On new epoch this function will be triggered and update the automation registry state
     public(friend) fun on_new_epoch() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
         // Unless registry in initialized, registry will not be updated on new epoch.
@@ -592,7 +619,6 @@ module supra_framework::automation_registry {
 
         // If feature is not enabled then we are not charging and tasks are cleared.
         if (!features::supra_native_automation_enabled()) {
-
             automation_registry.gas_committed_for_next_epoch = 0;
             automation_registry.epoch_locked_fees = 0;
             automation_registry.gas_committed_for_this_epoch = 0;
@@ -627,7 +653,7 @@ module supra_framework::automation_registry {
         automation_registry.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
         automation_registry.epoch_locked_fees = intermediate_state.epoch_locked_fees;
         automation_registry.gas_committed_for_this_epoch = tcmg;
-        automation_registry.epoch_active_task_ids = active_task_ids(intermediate_state);
+        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;
         automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
@@ -687,6 +713,9 @@ module supra_framework::automation_registry {
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let tcmg = 0;
 
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
         // Perform clean up and updation of state (we can't use enumerable_map::for_each, as actually we need value as mutable ref)
         vector::for_each(ids, |task_index| {
             if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
@@ -696,6 +725,151 @@ module supra_framework::automation_registry {
 
                 // Drop or activate task for this current epoch.
                 if (task.expiry_time <= current_time || task.state == CANCELLED) {
+                    coin::transfer<SupraCoin>(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+                    event::emit(
+                        TaskFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+                    );
+                    enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+                } else {
+                    task.state = ACTIVE;
+                    tcmg = tcmg + (task.max_gas_amount as u256);
+                }
+            }
+        });
+        tcmg
+    }
+
+    /// On new epoch this function will be triggered and update the automation registry state
+    public(friend) fun on_new_epoch_2(
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        // Unless registry in initialized, registry will not be updated on new epoch.
+        // Here we need to be careful as well. If the feature is disabled for the current epoch then
+        //  - refund for the previous epoch should be done if any charges has been done.
+        //  - all tasks should be removed from registry state
+        // Note that with the current setup feature::on_new_epoch is called before automation_registry::on_new_epoch
+        if (!is_initialized()) {
+            return
+        };
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let automation_epoch_info = borrow_global_mut<AutomationEpochInfo>(@supra_framework);
+
+        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(
+            @supra_framework
+        ).main_config;
+
+        let current_time = timestamp::now_seconds();
+        let new_epoch_tcmg = update_state_for_new_epoch(automation_registry,
+            &automation_registry_config,
+            automation_epoch_info,
+            current_time
+        );
+
+
+        // Apply the latest configuration if any parameter has been updated
+        // only after refund has been done for previous epoch.
+        update_config_from_buffer();
+
+        // If feature is not enabled then we are not charging and tasks are cleared.
+        if (!features::supra_native_automation_enabled()) {
+            automation_registry.gas_committed_for_next_epoch = 0;
+            automation_registry.epoch_locked_fees = 0;
+            automation_registry.gas_committed_for_this_epoch = 0;
+            automation_registry.epoch_active_task_ids = vector[];
+            // TODO before cleaning refund locked automation fee deposit
+            enumerable_map::clear(&mut automation_registry.tasks);
+
+            automation_epoch_info.start_time = current_time;
+            automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+            return
+        };
+
+
+        let intermediate_state = try_withdraw_task_automation_fees_2(
+            automation_registry,
+            &automation_registry_config,
+            automation_epoch_info.epoch_interval,
+            current_time,
+            new_epoch_tcmg,
+        );
+
+        automation_registry.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
+        automation_registry.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+        automation_registry.gas_committed_for_this_epoch = new_epoch_tcmg;
+        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
+
+        automation_epoch_info.start_time = current_time;
+        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+    }
+
+    /// Checks all tasks for refunds, cancellation and expirations.
+    /// Cleans the stale tasks and calculates gas-committed for the new epoch.
+    fun update_state_for_new_epoch(
+        automation_registry: &mut AutomationRegistry,
+        arc: &AutomationRegistryConfig,
+        aei: &AutomationEpochInfo,
+        current_time: u64
+    ): u256 {
+        let previous_epoch_duration = current_time - aei.start_time;
+        let refund_interval = 0;
+        let refund_automation_fee_per_sec = 0;
+
+        // If epoch actual duration is greater or equal to expected epoch-duration then there is nothing to refund.
+        if (automation_registry.epoch_locked_fees != 0 && previous_epoch_duration < aei.expected_epoch_duration) {
+            let previous_tcmg = automation_registry.gas_committed_for_this_epoch;
+            refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
+            let acf = calculate_automation_congestion_fee(arc, previous_tcmg, arc.registry_max_gas_cap);
+            refund_automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
+        };
+
+        let new_epoch_tcmg = if (refund_automation_fee_per_sec != 0) {
+            refund_cleanup_and_activate_tasks(
+                automation_registry,
+                current_time,
+                arc,
+                refund_automation_fee_per_sec,
+                refund_interval)
+        } else {
+            cleanup_and_activate_tasks(automation_registry, current_time)
+        };
+
+        new_epoch_tcmg
+    }
+
+
+    /// Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
+    fun refund_cleanup_and_activate_tasks(
+        automation_registry: &mut AutomationRegistry,
+        current_time: u64,
+        arc: &AutomationRegistryConfig,
+        refund_automation_fee_per_sec: u256,
+        refund_interval: u64,
+    ): u256 {
+        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+        let tcmg = 0;
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+
+        vector::for_each(ids, |task_index| {
+            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                event::emit(ErrorTaskDoesNotExist { task_index })
+            } else {
+                let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+                if (task.state != PENDING) {
+                    let refund = calculate_task_fee(arc, task,
+                        refund_interval, current_time, refund_automation_fee_per_sec);
+                    coin::transfer<SupraCoin>(&resource_signer, task.owner, refund);
+                    event::emit(TaskFeeRefund { task_index: task.task_index, owner: task.owner, amount: refund });
+                };
+
+                // Drop or activate task for this current epoch.
+                if (task.state == CANCELLED || task.expiry_time <= current_time) {
+                    // Refund deposited epoch-fee for cancelled and expired tasks.
+                    coin::transfer<SupraCoin>(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+                    event::emit(
+                        TaskDepositFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+                    );
                     enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
                 } else {
                     task.state = ACTIVE;
@@ -871,9 +1045,15 @@ module supra_framework::automation_registry {
         vector::for_each(tasks_automation_fees, |task| {
             let task: AutomationTaskFee = task;
             if (!enumerable_map::contains(&automation_registry.tasks, task.task_index)) {
-                event::emit(ErrorTaskDoesNotExistForWithdrawal {task_index: task.task_index})
+                event::emit(ErrorTaskDoesNotExistForWithdrawal { task_index: task.task_index })
             } else {
-                try_withdraw_task_automation_fee(automation_registry, task, current_time, epoch_interval, &mut intermediate_state);
+                try_withdraw_task_automation_fee(
+                    automation_registry,
+                    task,
+                    current_time,
+                    epoch_interval,
+                    &mut intermediate_state
+                );
             };
         });
         intermediate_state
@@ -885,11 +1065,17 @@ module supra_framework::automation_registry {
         current_time: u64,
         epoch_interval: u64,
         intermediate_state: &mut IntermediateState) {
-
         let task_metadata = enumerable_map::get_value(&automation_registry.tasks, task.task_index);
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
 
         // Remove the automation task if the epoch fee cap is exceeded
         if (task.fee > task_metadata.automation_fee_cap_for_epoch) {
+            coin::transfer<SupraCoin>(&resource_signer, task.owner, task_metadata.locked_fee_for_next_epoch);
+            event::emit(
+                TaskDepositFeeRefund { task_index: task.task_index, owner: task.owner, amount: task_metadata.locked_fee_for_next_epoch }
+            );
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
             event::emit(TaskCancelledCapacitySurpassed {
                 task_index: task.task_index,
@@ -897,38 +1083,151 @@ module supra_framework::automation_registry {
                 fee: task.fee,
                 automation_fee_cap: task_metadata.automation_fee_cap_for_epoch,
             });
-        } else {
-            let user_balance = coin::balance<SupraCoin>(task_metadata.owner);
-            if (user_balance < task.fee) {
-                // If the user does not have enough balance, remove the task and emit an event
-                enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
-                event::emit(TaskCancelledInsufficentBalance {
-                    task_index: task.task_index,
-                    owner: task_metadata.owner,
-                    fee: task.fee,
-                });
-            } else {
-                // Charge the fee and emit a success event
-                coin::transfer<SupraCoin>(
-                    &create_signer(task_metadata.owner),
-                    automation_registry.registry_fee_address,
-                    task.fee
-                );
-                event::emit(TaskEpochFeeWithdraw {
-                    task_index: task.task_index,
-                    owner: task_metadata.owner,
-                    fee: task.fee,
-                });
-                // Total task fees deducted from the user's account
-                intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
-                vector::push_back(&mut intermediate_state.active_task_ids, task.task_index);
+            return
+        };
+        let user_balance = coin::balance<SupraCoin>(task_metadata.owner);
+        if (user_balance < task.fee) {
+            // If the user does not have enough balance, remove the task and emit an event
+            enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            event::emit(TaskCancelledInsufficentBalance {
+                task_index: task.task_index,
+                owner: task_metadata.owner,
+                fee: task.fee,
+            });
+            return
+        };
+        if (task.fee != 0) {
+            // Charge the fee and emit a success event
+            coin::transfer<SupraCoin>(
+                &create_signer(task_metadata.owner),
+                automation_registry.registry_fee_address,
+                task.fee
+            );
+        };
+        event::emit(TaskEpochFeeWithdraw {
+            task_index: task.task_index,
+            owner: task_metadata.owner,
+            fee: task.fee,
+        });
+        // Total task fees deducted from the user's account
+        intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
 
-                // Calculate gas commitment for the next epoch only for valid active tasks
-                if (task_metadata.expiry_time > (current_time + epoch_interval)) {
-                    intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
+        // Calculate gas commitment for the next epoch only for valid active tasks
+        if (task_metadata.expiry_time > (current_time + epoch_interval)) {
+            intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
+        };
+    }
+
+    /// Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
+    /// - If the user has sufficient balance, deducts the fee and emits a success event.
+    /// - If the balance is insufficient, removes the task and emits a cancellation event.
+    /// - If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
+    /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
+    fun try_withdraw_task_automation_fees_2(
+        automation_registry: &mut AutomationRegistry,
+        arc: &AutomationRegistryConfig,
+        epoch_interval: u64,
+        current_time: u64,
+        tcmg: u256,
+    ): IntermediateState {
+        let intermediate_state = IntermediateState {
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: 0,
+            active_task_ids: vector[]
+        };
+        // Compute the automation congestion fee (acf) for the epoch
+        let acf = calculate_automation_congestion_fee(arc, tcmg, arc.registry_max_gas_cap);
+        let automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
+        let task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
+
+        // Sort task indexes to charge autoamtion fees in the tasks chronological order
+        sort(&mut task_ids);
+
+        // Process each active task and calculate fee for the epoch for the tasks
+        vector::for_each(task_ids, |task_index| {
+            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                event::emit(ErrorTaskDoesNotExistForWithdrawal { task_index })
+            } else {
+                let task_meta = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
+                let task = AutomationTaskFeeMeta {
+                    task_index,
+                    owner: task_meta.owner,
+                    fee: 0,
+                    expiry_time: task_meta.expiry_time,
+                    automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                    max_gas_amount: task_meta.max_gas_amount,
+                    locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
                 };
+                if (automation_fee_per_sec != 0) {
+                    task.fee = calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+                };
+                try_withdraw_task_automation_fee_2(
+                    automation_registry,
+                    task,
+                    current_time,
+                    epoch_interval,
+                    &mut intermediate_state
+                );
             };
-        }
+        });
+        intermediate_state
+    }
+
+    fun try_withdraw_task_automation_fee_2(
+        automation_registry: &mut AutomationRegistry,
+        task: AutomationTaskFeeMeta,
+        current_time: u64,
+        epoch_interval: u64,
+        intermediate_state: &mut IntermediateState) {
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        // Remove the automation task if the epoch fee cap is exceeded
+        if (task.fee > task.automation_fee_cap) {
+            coin::transfer<SupraCoin>(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
+            event::emit(
+                TaskDepositFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+            );
+            enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            event::emit(TaskCancelledCapacitySurpassed {
+                task_index: task.task_index,
+                owner: task.owner,
+                fee: task.fee,
+                automation_fee_cap: task.automation_fee_cap,
+            });
+            return
+        };
+        let user_balance = coin::balance<SupraCoin>(task.owner);
+        if (user_balance < task.fee) {
+            // If the user does not have enough balance, remove the task and emit an event
+            enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            event::emit(TaskCancelledInsufficentBalance {
+                task_index: task.task_index,
+                owner: task.owner,
+                fee: task.fee,
+            });
+            return
+        };
+        if (task.fee != 0) {
+            // Charge the fee and emit a success event
+            coin::transfer<SupraCoin>(
+                &create_signer(task.owner),
+                automation_registry.registry_fee_address,
+                task.fee
+            );
+        };
+        event::emit(TaskEpochFeeWithdraw {
+            task_index: task.task_index,
+            owner: task.owner,
+            fee: task.fee,
+        });
+        // Total task fees deducted from the user's account
+        intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
+
+        // Calculate gas commitment for the next epoch only for valid active tasks
+        if (task.expiry_time > (current_time + epoch_interval)) {
+            intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task.max_gas_amount;
+        };
     }
 
     /// The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
@@ -1314,6 +1613,22 @@ module supra_framework::automation_registry {
         };
     }
 
+    /// Sorting vector implementation
+    public fun sort(input: &mut vector<u64>) {
+        let len = vector::length(input);
+        let i = 0;
+        while (i < len) {
+            let j = i + 1;
+            while (j < len) {
+                if (*vector::borrow(input, i) > *vector::borrow(input, j)) {
+                    vector::swap(input, i, j)
+                };
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+    }
+
     fun upscale_from_u8(value: u8): u256 { (value as u256) * DECIMAL }
 
     fun upscale_from_u64(value: u64): u256 { (value as u256) * DECIMAL }
@@ -1339,7 +1654,7 @@ module supra_framework::automation_registry {
     #[test_only]
     const CONGESTION_EXPONENT_TEST: u8 = 6;
     #[test_only]
-    const TASK_CAPACITY_TEST: u16 = 50;
+    const TASK_CAPACITY_TEST: u16 = 500;
     #[test_only]
     /// Value defined in microsecond
     const EPOCH_INTERVAL_FOR_TEST_IN_SECS: u64 = 7200;
@@ -1500,7 +1815,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EUNACCEPTABLE_TASK_DURATION_CAP, location = Self)]
     fun test_initialization_with_invalid_task_duration(
         supra_framework: &signer,
-    )  {
+    ) {
         initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -1519,7 +1834,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EREGISTRY_MAX_GAS_CAP_NON_ZERO, location = Self)]
     fun test_initialization_with_invalid_registry_max_gas_cap(
         supra_framework: &signer,
-    )  {
+    ) {
         initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -1538,7 +1853,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = ECONGESTION_EXP_NON_ZERO, location = Self)]
     fun test_initialization_with_invalid_congestion_exponent(
         supra_framework: &signer,
-    )  {
+    ) {
         initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -1557,7 +1872,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EMAX_CONGESTION_THRESHOLD, location = Self)]
     fun test_initialization_with_invalid_threshold_percentage(
         supra_framework: &signer,
-    )  {
+    ) {
         initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2657,10 +2972,10 @@ module supra_framework::automation_registry {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
             let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
             let results = calculate_tasks_automation_fees(ar, arc,
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
-            0,
-            tcmg,
-            true);
+                EPOCH_INTERVAL_FOR_TEST_IN_SECS,
+                0,
+                tcmg,
+                true);
             assert!(vector::length(&results) == 2, 10);
 
             let expected_fee = expected_congestion_fee_per_task;
@@ -2756,7 +3071,6 @@ module supra_framework::automation_registry {
                 true);
             assert!(vector::length(&results) == 0, 13);
         }
-
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3265,4 +3579,115 @@ module supra_framework::automation_registry {
             REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_automation_fee - refund_automation_fee
         );
     }
+
+    // Register 500 tasks to measure registration time/used-gas
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+        fun check_task_registration_performance(
+            framework: &signer,
+            user: &signer
+        ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        let count = 0;
+        while (count < 500) {
+            register(user,
+                PAYLOAD,
+                86400,
+                10000,
+                20,
+                1000000,
+                PARENT_HASH,
+                AUX_DATA
+            );
+            count = count + 1;
+        };
+
+        // No active task and committed gas for the next epoch is total of the all registered tasks
+        assert!(500 * 10000 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        assert!(active_task_ids == vector[], 1);
+    }
+
+    // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
+    // And run 3 epochs to check gas-used when
+    //  - full epoch passed
+    //  - 1/3 of epoch passed to simulate refund, but tasks are still active
+    //  - last epoch identifies all tasks are expired
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_task_activation_on_new_epoch_performance(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        let count = 0;
+        let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        while (count < 500) {
+            register(user,
+                PAYLOAD,
+                exp_time,
+                10000,
+                20,
+                1000000,
+                PARENT_HASH,
+                AUX_DATA
+            );
+            count = count + 1;
+        };
+
+        // No active task and committed gas for the next epoch is total of the all registered tasks
+        assert!(10000 * 500 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        assert!(active_task_ids == vector[], 1);
+
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        on_new_epoch();
+        timestamp::update_global_time_for_test_secs(
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3
+        );
+        on_new_epoch();
+        timestamp::update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        on_new_epoch();
+    }
+
+    // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
+    // And run 3 epochs to check gas-used when
+    //  - full epoch passed
+    //  - 1/3 of epoch passed to simulate refund, but tasks are still active
+    //  - last epoch identifies all tasks are expired
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_task_activation_on_new_epoch_2_performance(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        let count = 0;
+        let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        while (count < 500) {
+            register(user,
+                PAYLOAD,
+                exp_time,
+                10000,
+                20,
+                1000000,
+                PARENT_HASH,
+                AUX_DATA
+            );
+            count = count + 1;
+        };
+
+        // No active task and committed gas for the next epoch is total of the all registered tasks
+        assert!(10000 * 500 == get_gas_committed_for_next_epoch(), 1);
+        let active_task_ids = get_active_task_ids();
+        assert!(active_task_ids == vector[], 1);
+
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        on_new_epoch_2();
+        timestamp::update_global_time_for_test_secs(
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3
+        );
+        on_new_epoch_2();
+        timestamp::update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        on_new_epoch_2();
+    }
 }
+
+

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1042,7 +1042,7 @@ module supra_framework::automation_registry {
     }
 
     fun safe_unlock_locked_deposit(rb: &mut AutomationRefundBookkeeping, locked_deposit: u64, task_index: u64) {
-        if (rb.total_deposited_automation_fee > locked_deposit) {
+        if (rb.total_deposited_automation_fee >= locked_deposit) {
             rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
         } else {
             event::emit(
@@ -1737,7 +1737,7 @@ module supra_framework::automation_registry {
     public entry fun stop_tasks(
         owner_signer: &signer,
         task_indexes: vector<u64>
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo, AutomationRefundBookkeeping {
         // Ensure that task indexes are provided
         assert!(!vector::is_empty(&task_indexes), EEMPTY_TASK_INDEXES);
 
@@ -1745,6 +1745,7 @@ module supra_framework::automation_registry {
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let arc = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).main_config;
         let epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
 
         let tcmg = automation_registry.gas_committed_for_this_epoch;
 
@@ -1808,6 +1809,7 @@ module supra_framework::automation_registry {
                 } else {
                     (0, (task.locked_fee_for_next_epoch / REFUND_FRACTION))
                 };
+                safe_unlock_locked_deposit(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
 
                 total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
 
@@ -3576,7 +3578,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_stopped(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3734,7 +3736,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_stopped_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3759,7 +3761,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig , AutomationRefundBookkeeping{
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -79,6 +79,10 @@ module supra_framework::automation_registry {
     const EEMPTY_TASK_INDEXES: u64 = 25;
     /// Resource Account does not have sufficient balance to process the refund for the specified task.
     const EINSUFFICIENT_BALANCE_FOR_REFUND: u64 = 26;
+    /// Failed to refund deposit for the task. For more deatils see the emitted events
+    const EDEPOSIT_REFUND: u64 = 27;
+    /// Failed to refund deposit for the task. For more deatils see the emitted events
+    const EEPOCH_FEE_REFUND: u64 = 28;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -183,7 +187,7 @@ module supra_framework::automation_registry {
     /// Automation Deposited fee bookkeeping configs
     struct AutomationRefundBookkeeping has key, copy {
         /// Total deposited fee so far which is locked in resource account unless refund of it (fully or partially) is done.
-        /// Independent of refund amount the actual deposited amount is deduced to unlock it from resource account.
+        /// Regardless of the refunded amount the actual deposited amount is deduced to unlock it from the resource account.
         total_deposited_automation_fee: u64
         // TODO here we can have also configuration parameter like REFUND_FACTOR
     }
@@ -215,10 +219,10 @@ module supra_framework::automation_registry {
         registration_time: u64,
         /// Flag indicating whether the task is active, cancelled or pending.
         state: u8,
-        /// Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for the task.
+        /// Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for it.
         /// It will be refunded fully when active task is expired or cancelled by user
-        /// and partially if a pending task is cancelled by user or by the system due to insufficient balance to
-        /// pay the automation fee for the epoch
+        /// and partially if a pending task is cancelled by user or an active taks is cancelled by the system due to
+        /// insufficient balance to  pay the automation fee for the epoch
         locked_fee_for_next_epoch: u64,
     }
 
@@ -273,12 +277,21 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted when an automation fee is refunded but inner state bookkeeping total locked deposits is less than
-    /// potential locked deposit which is being refunded fully or partially
+    /// Event emitted when an automation fee is being refunded but inner state bookkeeping total locked deposits is less than
+    /// potential locked deposit for the task.
     struct ErrorUnlockTaskDepositFee has drop, store {
         task_index: u64,
         total_registered_deposit: u64,
         locked_deposit: u64
+    }
+
+    #[event]
+    /// Event emitted when an task epoch fee is being refunded but locked epoch fees is less than
+    /// potential requested refund.
+    struct ErrorUnlockTaskEpochFee has drop, store {
+        task_index: u64,
+        locked_epoch_fees: u64,
+        refund: u64
     }
 
     #[event]
@@ -358,13 +371,6 @@ module supra_framework::automation_registry {
     struct DisabledRegistrationEvent has drop, store {}
 
     /// Represents the fee charged for an automation task execution and some additional information.
-    struct AutomationTaskFee has drop {
-        task_index: u64,
-        owner: address,
-        fee: u64,
-    }
-
-    /// Represents the fee charged for an automation task execution and some additional information.
     struct AutomationTaskFeeMeta has drop {
         task_index: u64,
         owner: address,
@@ -376,7 +382,7 @@ module supra_framework::automation_registry {
     }
 
     /// Represents intermediate state of the registry on epoch change.
-    struct IntermediateStateWithCoins {
+    struct IntermediateState {
         removed_task_ids: vector<u64>,
         gas_committed_for_next_epoch: u64,
         epoch_locked_fees: Coin<SupraCoin>,
@@ -552,13 +558,11 @@ module supra_framework::automation_registry {
     ): u64 {
         let total_committed_max_gas = committed_occupancy + task_occupancy;
 
-        let congestion_base_fee_per_sec = calculate_automation_congestion_fee(
+        // Compute the automation fee multiplier for epoch
+        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(
             &active_config.main_config,
             (total_committed_max_gas as u256),
             active_config.next_epoch_registry_max_gas_cap);
-
-        let automation_fee_per_sec = (active_config.main_config.automation_base_fee_in_quants_per_sec as u256) +
-            congestion_base_fee_per_sec;
 
         if (automation_fee_per_sec == 0) {
             return 0
@@ -699,9 +703,8 @@ module supra_framework::automation_registry {
             automation_registry.gas_committed_for_this_epoch = 0;
             automation_registry.epoch_active_task_ids = vector[];
             safe_deposit_refund_all(automation_registry, refund_bookkeeping);
-            event::emit(RemovedTasks {
-                task_indexes: enumerable_map::get_map_list(&automation_registry.tasks)
-            });
+            vector::append(&mut removed_tasks, enumerable_map::get_map_list(&automation_registry.tasks));
+            event::emit(RemovedTasks { task_indexes:  removed_tasks });
             enumerable_map::clear(&mut automation_registry.tasks);
 
             automation_epoch_info.start_time = current_time;
@@ -710,7 +713,7 @@ module supra_framework::automation_registry {
         };
 
 
-        let IntermediateStateWithCoins {
+        let IntermediateState {
             gas_committed_for_next_epoch,
             epoch_locked_fees,
             removed_task_ids,
@@ -725,7 +728,6 @@ module supra_framework::automation_registry {
         );
 
         let epoch_locked_fees_value = coin::value(&epoch_locked_fees);
-
         coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
 
         automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
@@ -737,56 +739,6 @@ module supra_framework::automation_registry {
         automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
         event::emit(RemovedTasks {
             task_indexes: removed_task_ids
-        });
-    }
-
-
-    /// Adjusts task fees and processes refunds when there's a change in epoch duration.
-    fun adjust_tasks_epoch_fee_refund(
-        automation_registry: &AutomationRegistry,
-        arc: &AutomationRegistryConfig,
-        aei: &AutomationEpochInfo,
-        current_time: u64
-    ) {
-        // If no funds were locked for the previous epoch then there is nothing to refund.
-        // This may happen when feature was disabled, and no automation task was registered and charged for the next epoch.
-        if (automation_registry.epoch_locked_fees == 0) {
-            return
-        };
-
-        // If epoch actual duration is greater or equal to expected epoch-duration then there is nothing to refund.
-        let epoch_duration = current_time - aei.start_time;
-        if (aei.expected_epoch_duration <= epoch_duration) {
-            return
-        };
-
-        let residual_time = aei.expected_epoch_duration - epoch_duration;
-        let tcmg = automation_registry.gas_committed_for_this_epoch;
-        let registry_fee_address_signer_cap = &automation_registry.registry_fee_address_signer_cap;
-        let tasks_automation_refund_fees = calculate_tasks_automation_fees(
-            automation_registry,
-            arc,
-            residual_time,
-            current_time,
-            tcmg,
-            true
-        );
-        refund_tasks_fee(registry_fee_address_signer_cap, tasks_automation_refund_fees);
-    }
-
-    /// Processes refunds for automation task fees.
-    fun refund_tasks_fee(
-        resource_signer_cap: &SignerCapability,
-        tasks_automation_refund_fees: vector<AutomationTaskFee>
-    ) {
-        let resource_signer = account::create_signer_with_capability(resource_signer_cap);
-        let resource_adderss= signer::address_of(&resource_signer);
-
-        vector::for_each(tasks_automation_refund_fees, |task| {
-            let task: AutomationTaskFee = task;
-            if (task.fee != 0) {
-                safe_fee_refund(&resource_signer, resource_adderss, task.task_index, task.owner, task.fee);
-            }
         });
     }
 
@@ -807,8 +759,8 @@ module supra_framework::automation_registry {
         if (automation_registry.epoch_locked_fees != 0 && previous_epoch_duration < aei.expected_epoch_duration) {
             let previous_tcmg = automation_registry.gas_committed_for_this_epoch;
             refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
-            let acf = calculate_automation_congestion_fee(arc, previous_tcmg, arc.registry_max_gas_cap);
-            refund_automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
+            // Compute the automation fee multiplier for ended epoch
+            refund_automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(arc, previous_tcmg, arc.registry_max_gas_cap);
         };
 
         if (refund_automation_fee_per_sec != 0) {
@@ -824,7 +776,9 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
+    /// Refunds active tasks of the previeous epoch, cleans up expired and canclelled tasks and activates the pending tasks.
+    /// Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+    /// that have been removed from the registry.
     fun refund_cleanup_and_activate_tasks(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
@@ -840,6 +794,7 @@ module supra_framework::automation_registry {
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
         );
+        let epoch_locked_fees = automation_registry.epoch_locked_fees;
 
         vector::for_each(ids, |task_index| {
             let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
@@ -850,12 +805,14 @@ module supra_framework::automation_registry {
                     refund_interval,
                     current_time,
                     refund_automation_fee_per_sec);
-                safe_fee_refund(
+                let (_, remaining_epoch_locked_fees) = safe_fee_refund(
+                    epoch_locked_fees,
                     &resource_signer,
                     automation_registry.registry_fee_address,
                     task.task_index,
                     task.owner,
                     refund);
+                epoch_locked_fees = remaining_epoch_locked_fees;
             };
 
             // Drop or activate task for this current epoch.
@@ -878,7 +835,9 @@ module supra_framework::automation_registry {
         (tcmg, removed_tasks)
     }
 
-    /// Cleanup and activate the automation task also it's calculate and return total committed max gas
+    /// Cleans up expired and canclelled tasks and activates the pending tasks.
+    /// Also alculates and returns the total committed max gas for the new epoch along with the task indexes
+    /// that have been removed from the registry.
     fun cleanup_and_activate_tasks(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
@@ -893,31 +852,157 @@ module supra_framework::automation_registry {
         );
         // Perform clean up and updation of state (we can't use enumerable_map::for_each, as actually we need value as mutable ref)
         vector::for_each(ids, |task_index| {
-            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                event::emit(ErrorTaskDoesNotExist { task_index })
+            let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+            // Drop or activate task for this current epoch.
+            if (task.expiry_time <= current_time || task.state == CANCELLED) {
+                safe_deposit_refund(
+                    refund_bookkeeping,
+                    &resource_signer,
+                    automation_registry.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    task.locked_fee_for_next_epoch,
+                    task.locked_fee_for_next_epoch);
+                enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+                vector::push_back(&mut removed_tasks, task_index);
             } else {
-                let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
-                // Drop or activate task for this current epoch.
-                if (task.expiry_time <= current_time || task.state == CANCELLED) {
-                    safe_deposit_refund(
-                        refund_bookkeeping,
-                        &resource_signer,
-                        automation_registry.registry_fee_address,
-                        task.task_index,
-                        task.owner,
-                        task.locked_fee_for_next_epoch,
-                        task.locked_fee_for_next_epoch);
-                    enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-                    vector::push_back(&mut removed_tasks, task_index);
-                } else {
-                    task.state = ACTIVE;
-                    tcmg = tcmg + (task.max_gas_amount as u256);
-                }
+                task.state = ACTIVE;
+                tcmg = tcmg + (task.max_gas_amount as u256);
             }
         });
         (tcmg, removed_tasks)
     }
 
+    /// Traverses through all existing tasks and refunds deposited fee upon registration fully.
+    fun safe_deposit_refund_all(
+        automation_registry: &AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping) {
+        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        vector::for_each(ids, |task_index| {
+            let task = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
+
+            safe_deposit_refund(
+                refund_bookkeeping,
+                &resource_signer,
+                automation_registry.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch);
+        });
+    }
+
+    /// Refunds specified ammount of deposit to the task ower and unlocks full deposit from registry resource account.
+    /// Error events are emitted
+    ///   - if the registry resource account does not have enough balance for refund.
+    ///   - if the full deposit can not be unlocked.
+    fun safe_deposit_refund(
+        rb: &mut AutomationRefundBookkeeping,
+        resource_signer: &signer,
+        resouce_address: address,
+        task_index: u64,
+        task_owner: address,
+        refundable_deposit: u64,
+        locked_deposit: u64
+    ):  bool {
+        // This check will make sure that no more than totally locked deposited will be refunced.
+        // If there is an attempt then it means implementation bug.
+        let result = safe_unlock_locked_deposit(rb, locked_deposit, task_index);
+        if (!result) {
+            return result
+        };
+
+        let result = safe_refund(
+            resource_signer,
+            resouce_address,
+            task_index,
+            task_owner,
+            refundable_deposit,
+            DEPOSIT_EPOCH_FEE);
+
+        if (result) {
+            event::emit(
+                TaskDepositFeeRefund { task_index, owner: task_owner, amount: refundable_deposit }
+            );
+        };
+        result
+    }
+
+    /// Unlocks the deposit paied by the task from internal deposit refund bookkeeping state.
+    /// Error event is emitted if the deposit refund bookkeeping state is inconsistent with the requested unlock ammount.
+    fun safe_unlock_locked_deposit(
+        rb: &mut AutomationRefundBookkeeping,
+        locked_deposit: u64,
+        task_index: u64
+    ): bool {
+        let has_locked_deposit = rb.total_deposited_automation_fee >= locked_deposit;
+        if (has_locked_deposit) {
+            rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
+        } else {
+            event::emit(
+                ErrorUnlockTaskDepositFee { total_registered_deposit: rb.total_deposited_automation_fee, locked_deposit, task_index }
+            );
+        };
+        has_locked_deposit
+    }
+
+    /// Unlocks the locked fee paid by the task for epoch.
+    /// Error event is emitted if the epoch locked fee amount is inconsistent with the requested unlock ammount.
+    fun safe_unlock_locked_epoch_fee(
+        epoch_locked_fees: u64,
+        refundable_fee: u64,
+        task_index: u64
+    ): (bool, u64) {
+        // This check makes sure that more than locked amount of the fees will be not be refunded.
+        // Any attempt means internal bug.
+        let has_locked_fee = epoch_locked_fees >= refundable_fee;
+        if (has_locked_fee) {
+            // unlock the refunded amount
+            epoch_locked_fees = epoch_locked_fees - refundable_fee;
+        } else {
+            event::emit(
+                ErrorUnlockTaskEpochFee { locked_epoch_fees: epoch_locked_fees, task_index, refund: refundable_fee}
+            );
+        };
+        (has_locked_fee, epoch_locked_fees)
+    }
+
+    /// Refunds fee paied by the task for the epoch to the task owner.
+    /// Note that here we do not unlock the fee, as on epoch change locked epoch-fees for the ended epoch are
+    /// automatically unlocked.
+    fun safe_fee_refund(
+        epoch_locked_fees: u64,
+        resource_signer: &signer,
+        resouce_address: address,
+        task_index: u64,
+        task_owner: address,
+        refundable_fee: u64
+    ):  (bool, u64) {
+        let (result, remaining_locked_fees) = safe_unlock_locked_epoch_fee(epoch_locked_fees, refundable_fee, task_index);
+        if (!result) {
+            return (result, remaining_locked_fees)
+        };
+        let result = safe_refund(
+            resource_signer,
+            resouce_address,
+            task_index,
+            task_owner,
+            refundable_fee,
+            EPOCH_FEE);
+        if (result) {
+            event::emit(
+                TaskFeeRefund { task_index, owner: task_owner, amount: refundable_fee }
+            );
+        };
+        (result, remaining_locked_fees)
+    }
+
+    /// Refunds specified amount to the task owner.
+    /// Error event is emitted if the resource account does not have enough balace.
     fun safe_refund(
         resource_signer: &signer,
         resource_address: address,
@@ -938,126 +1023,6 @@ module supra_framework::automation_registry {
         return true
     }
 
-    fun safe_deposit_refund(
-        rb: &mut AutomationRefundBookkeeping,
-        resource_signer: &signer,
-        resouce_address: address,
-        task_index: u64,
-        task_owner: address,
-        refundable_deposit: u64,
-        locked_deposit: u64
-    ):  bool {
-        let result = safe_refund(
-            resource_signer,
-            resouce_address,
-            task_index,
-            task_owner,
-            refundable_deposit,
-            DEPOSIT_EPOCH_FEE);
-        if (result) {
-            event::emit(
-                TaskDepositFeeRefund { task_index, owner: task_owner, amount: refundable_deposit }
-            );
-            safe_unlock_locked_deposit(rb, locked_deposit, task_index)
-        };
-        result
-    }
-
-    fun safe_unlock_locked_deposit(
-        rb: &mut AutomationRefundBookkeeping,
-        locked_deposit: u64,
-        task_index: u64
-    ) {
-        if (rb.total_deposited_automation_fee >= locked_deposit) {
-            rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
-        } else {
-            event::emit(
-                ErrorUnlockTaskDepositFee { total_registered_deposit: rb.total_deposited_automation_fee, locked_deposit, task_index }
-            );
-        }
-
-    }
-
-    fun safe_fee_refund(
-        resource_signer: &signer,
-        resouce_address: address,
-        task_index: u64,
-        task_owner: address,
-        refundable_fee: u64
-    ):  bool {
-        let result = safe_refund(
-            resource_signer,
-            resouce_address,
-            task_index,
-            task_owner,
-            refundable_fee,
-            EPOCH_FEE);
-        if (result) {
-            event::emit(
-                TaskFeeRefund { task_index, owner: task_owner, amount: refundable_fee }
-            );
-        };
-        result
-    }
-
-    fun safe_deposit_refund_all(
-        automation_registry: &AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping) {
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-        vector::for_each(ids, |task_index| {
-            let task = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
-
-            safe_deposit_refund(
-                refund_bookkeeping,
-                &resource_signer,
-                automation_registry.registry_fee_address,
-                task.task_index,
-                task.owner,
-                task.locked_fee_for_next_epoch,
-            task.locked_fee_for_next_epoch);
-        });
-    }
-
-    /// Calculates automation task fees for the active tasks for the provided interval with provided tcmg occupancy.
-    /// The CANCELLED tasks are also taken into account if include_cancelled_task is true.
-    fun calculate_tasks_automation_fees(
-        automation_registry: &AutomationRegistry,
-        arc: &AutomationRegistryConfig,
-        interval: u64,
-        current_time: u64,
-        tcmg: u256,
-        include_cancelled_task: bool
-    ): vector<AutomationTaskFee> {
-        // Compute the automation congestion fee (acf) for the epoch
-        let acf = calculate_automation_congestion_fee(arc, tcmg, arc.registry_max_gas_cap);
-        let task_with_fees = vector[];
-        // Automation fee per second is the sum of the automation base fee per second and congeation fee per second
-        // calculated based on the current registry occupancy.
-        let automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
-
-        // Return early if automation fee per second is 0
-        if (automation_fee_per_sec == 0) {
-            return task_with_fees
-        };
-
-        // Process each active task and calculate fee for the epoch for the tasks
-        enumerable_map::for_each_value_ref(&automation_registry.tasks, |task| {
-            let task: &AutomationTaskMetaData = task;
-            if (task.state == ACTIVE || (include_cancelled_task && task.state == CANCELLED)) {
-                let task_fee = calculate_task_fee(arc, task, interval, current_time, automation_fee_per_sec);
-                vector::push_back(&mut task_with_fees, AutomationTaskFee {
-                    task_index: task.task_index,
-                    owner: task.owner,
-                    fee: task_fee,
-                });
-            }
-        });
-        task_with_fees
-    }
 
     /// Calculates automation task fees for a single task at the time of new epoch.
     /// This is supposed to be called only after removing expired task and must not be called for expired task.
@@ -1069,6 +1034,7 @@ module supra_framework::automation_registry {
         current_time: u64,
         automation_fee_per_sec: u256
     ): u64 {
+        if (automation_fee_per_sec == 0) { return 0 };
         if (task.expiry_time <= current_time) { return 0 };
         // Subtraction is safe here, as we already excluded expired tasks
         let remaining_time = task.expiry_time - current_time;
@@ -1095,6 +1061,16 @@ module supra_framework::automation_registry {
         let automation_fee_for_interval = automation_fee_per_sec * task_occupancy_ratio_by_duration;
 
         downscale_to_u64(automation_fee_for_interval)
+    }
+
+    /// Calculate automation fee multiplier for epoch. It is measured in quants/sec.
+    fun calculate_automation_fee_multipler_for_epoch(
+        arc: &AutomationRegistryConfig,
+        tcmg: u256,
+        registry_max_gas_cap: u64
+    ): u256 {
+        let acf = calculate_automation_congestion_fee(arc, tcmg, registry_max_gas_cap);
+        acf + (arc.automation_base_fee_in_quants_per_sec as u256)
     }
 
     /// Calculate automation congestion fee for the epoch
@@ -1178,15 +1154,15 @@ module supra_framework::automation_registry {
         current_time: u64,
         tcmg: u256,
         removed_tasks: vector<u64>
-    ): IntermediateStateWithCoins {
-        let intermediate_state_with_coins = IntermediateStateWithCoins {
+    ): IntermediateState {
+        let intermediate_state = IntermediateState {
             gas_committed_for_next_epoch: 0,
             epoch_locked_fees: coin::zero<SupraCoin>(),
             removed_task_ids: removed_tasks,
         };
-        // Compute the automation congestion fee (acf) for the epoch
-        let acf = calculate_automation_congestion_fee(arc, tcmg, arc.registry_max_gas_cap);
-        let automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
+        // Compute the automation fee multiplier for epoch
+        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(arc, tcmg, arc.registry_max_gas_cap);
+
         let task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
@@ -1202,14 +1178,11 @@ module supra_framework::automation_registry {
             let task = AutomationTaskFeeMeta {
                 task_index,
                 owner: task_meta.owner,
-                fee: 0,
+                fee: calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec),
                 expiry_time: task_meta.expiry_time,
                 automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
                 max_gas_amount: task_meta.max_gas_amount,
                 locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
-            };
-            if (automation_fee_per_sec != 0) {
-                task.fee = calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
             };
             try_withdraw_task_automation_fee(
                 automation_registry,
@@ -1217,10 +1190,10 @@ module supra_framework::automation_registry {
                 &resource_signer,
                 task,
                 current_epoch_end_time,
-                &mut intermediate_state_with_coins
+                &mut intermediate_state
             );
         });
-        intermediate_state_with_coins
+        intermediate_state
     }
 
     fun try_withdraw_task_automation_fee(
@@ -1229,7 +1202,7 @@ module supra_framework::automation_registry {
         resource_signer: &signer,
         task: AutomationTaskFeeMeta,
         current_epoch_end_time: u64,
-        intermediate_state: &mut IntermediateStateWithCoins) {
+        intermediate_state: &mut IntermediateState) {
         // Remove the automation task if the epoch fee cap is exceeded
         if (task.fee > task.automation_fee_cap) {
             safe_deposit_refund(
@@ -1253,7 +1226,8 @@ module supra_framework::automation_registry {
         };
         let user_balance = coin::balance<SupraCoin>(task.owner);
         if (user_balance < task.fee) {
-            // If the user does not have enough balance, remove the task, refund the locked deposit and emit an event
+            // If the user does not have enough balance, remove the task, DON'T refund the locked deposit, but simply unlock it
+            // and emit an event
             safe_unlock_locked_deposit(refund_bookkeeping, task.locked_deposit_fee, task.task_index);
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
             vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
@@ -1322,9 +1296,9 @@ module supra_framework::automation_registry {
 
         assert!(resource_balance >= amount, EINSUFFICIENT_BALANCE);
 
-        assert!((resource_balance - amount) >=
-            automation_registry.epoch_locked_fees +
-                refund_bookkeeping.total_deposited_automation_fee, EREQUEST_EXCEEDS_LOCKED_BALANCE);
+        assert!((resource_balance - amount)
+            >= automation_registry.epoch_locked_fees + refund_bookkeeping.total_deposited_automation_fee,
+            EREQUEST_EXCEEDS_LOCKED_BALANCE);
 
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
@@ -1530,7 +1504,7 @@ module supra_framework::automation_registry {
                 &automation_registry.registry_fee_address_signer_cap
             );
             // When Pending tasks are cancelled, refund of the deposit fee is done with penalty
-            safe_deposit_refund(
+            let result = safe_deposit_refund(
                 refund_bookkeeping,
                 &resource_signer,
                 automation_registry.registry_fee_address,
@@ -1538,9 +1512,10 @@ module supra_framework::automation_registry {
                 owner,
                 automation_task_metadata.locked_fee_for_next_epoch / REFUND_FACTOR,
             automation_task_metadata.locked_fee_for_next_epoch);
+            assert!(result, EDEPOSIT_REFUND);
             enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-        } else { // it is safe not to check the state as above the already cancelled task's cancellation is rejected.
-            // Active tasks will be refunded at the end of the epoch
+        } else { // it is safe not to check the state as above, the cancelled tasks are already rejected.
+            // Active tasks will be refunded the deposited amount fully at the end of the epoch
             let automation_task_metadata_mut = enumerable_map::get_value_mut(
                 &mut automation_registry.tasks,
                 task_index
@@ -1583,18 +1558,12 @@ module supra_framework::automation_registry {
 
         let tcmg = automation_registry.gas_committed_for_this_epoch;
 
-        // Calculate the automation congestion fee
-        let acf = calculate_automation_congestion_fee(
-            &arc,
-            tcmg,
-            arc.registry_max_gas_cap
-        );
-
-        // Total fee per second (base + congestion fee)
-        let automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
+        // Compute the automation fee multiplier for epoch
+        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(&arc, tcmg, arc.registry_max_gas_cap);
 
         let stopped_task_details = vector[];
         let total_refund_fee = 0;
+        let epoch_locked_fees = automation_registry.epoch_locked_fees;
 
         // Calculate refundable fee for this remaining time task in current epoch
         let current_time = timestamp::now_seconds();
@@ -1604,6 +1573,7 @@ module supra_framework::automation_registry {
         } else {
             epoch_end_time - current_time
         };
+
 
         // Loop through each task index to validate and stop the task
         vector::for_each(task_indexes, |task_index| {
@@ -1643,7 +1613,17 @@ module supra_framework::automation_registry {
                 } else {
                     (0, (task.locked_fee_for_next_epoch / REFUND_FRACTION))
                 };
-                safe_unlock_locked_deposit(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
+                let result = safe_unlock_locked_deposit(
+                    refund_bookkeeping,
+                    task.locked_fee_for_next_epoch,
+                    task.task_index);
+                assert!(result, EDEPOSIT_REFUND);
+                let (result, remaining_epoch_locked_fees) = safe_unlock_locked_epoch_fee(
+                    epoch_locked_fees,
+                    epoch_fee_refund,
+                    task.task_index);
+                assert!(result, EEPOCH_FEE_REFUND);
+                epoch_locked_fees = remaining_epoch_locked_fees;
 
                 total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
 
@@ -1681,7 +1661,7 @@ module supra_framework::automation_registry {
     }
 
     /// Insertion sort implementation for vector
-    public fun sort_vector(input: &mut vector<u64>) {
+    fun sort_vector(input: &mut vector<u64>) {
         let len = vector::length(input);
         let i = 1;
         while (i < len) {
@@ -1733,7 +1713,7 @@ module supra_framework::automation_registry {
     #[test_only]
     const ACCOUNT_BALANCE: u64 = 10_000_000_000;
     #[test_only]
-    const REGISTRY_DEFAULT_BALANCE: u64 = 200_000_000_000;
+    const REGISTRY_DEFAULT_BALANCE: u64 = 100_000_000_000;
 
 
     #[test_only]
@@ -1902,6 +1882,42 @@ module supra_framework::automation_registry {
         let current_balance = coin::balance<SupraCoin>(account);
         assert!(current_balance == expected_balance, current_balance);
     }
+
+
+    #[test_only]
+    /// Represents the fee charged for an automation task execution and some additional information.
+    struct AutomationTaskFee has drop {
+        task_index: u64,
+        owner: address,
+        fee: u64,
+    }
+
+    #[test_only]
+    /// Calculates automation task fees for the active tasks for the provided interval with provided tcmg occupancy.
+    fun calculate_tasks_automation_fees(
+        automation_registry: &AutomationRegistry,
+        arc: &AutomationRegistryConfig,
+        interval: u64,
+        current_time: u64,
+        tcmg: u256,
+    ): vector<AutomationTaskFee> {
+        let task_with_fees = vector[];
+
+        // Compute the automation fee multiplier for epoch
+        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(arc, tcmg, arc.registry_max_gas_cap);
+
+        enumerable_map::for_each_value_ref(&automation_registry.tasks, |task| {
+            let task: &AutomationTaskMetaData = task;
+                let task_fee = calculate_task_fee(arc, task, interval, current_time, automation_fee_per_sec);
+                vector::push_back(&mut task_with_fees, AutomationTaskFee {
+                    task_index: task.task_index,
+                    owner: task.owner,
+                    fee: task_fee,
+                });
+        });
+        task_with_fees
+    }
+
 
     #[test(supra_framework = @supra_framework)]
     #[expected_failure(abort_code = EUNACCEPTABLE_TASK_DURATION_CAP, location = Self)]
@@ -3000,8 +3016,8 @@ module supra_framework::automation_registry {
         let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
         let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
 
-        let balance = coin::balance<SupraCoin>(signer::address_of(user));
-        assert!(balance == expected_user_current_balance, 11);
+        let user_address = signer::address_of(user);
+        check_account_balance(user_address, expected_user_current_balance);
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
@@ -3012,10 +3028,10 @@ module supra_framework::automation_registry {
         // Refund is expected
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
         on_new_epoch();
-        let balance = coin::balance<SupraCoin>(signer::address_of(user));
         // as account have 2 active tasks with same automation and congestion fees then refund is double + deposit refund for all 3 tasks.
         let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task + 3 * automation_fee_cap;
-        assert!(balance == expected_user_current_balance + expected_refund, 12);
+
+        check_account_balance(user_address, expected_user_current_balance + expected_refund);
         // Checke registry balance
         check_account_balance(get_registry_fee_address(), expected_registry_current_balance - expected_refund);
 
@@ -3047,7 +3063,6 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
-        let t3_max_gas = 11_000_000;
 
         register_with_state(
             framework,
@@ -3060,13 +3075,7 @@ module supra_framework::automation_registry {
             user,
             t1_t2_max_gas,
             100_000_000,
-            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, CANCELLED);
-        register_with_state(
-            framework,
-            user,
-            t3_max_gas,
-            100_000_000,
-            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, PENDING);
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
@@ -3087,9 +3096,7 @@ module supra_framework::automation_registry {
             arc,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             0,
-            tcmg,
-            true);
-        // Pending task is ignored
+            tcmg);
         assert!(vector::length(&results) == 2, 2);
 
         let expected_fee = expected_automation_fee_per_task + expected_congestion_fee_per_task;
@@ -3099,7 +3106,7 @@ module supra_framework::automation_registry {
         assert!(r2.fee == expected_fee, 4);
 
         // Take into account CANCELLED tasks as well
-        // Tasks are still valid but for the half of the epoch, as current time is 3600
+        // Tasks are still valid but for the half of the epoch, current_time - task.expiry time == epoch_duration / 2
         let current_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
         let results = calculate_tasks_automation_fees(
             ar,
@@ -3107,7 +3114,6 @@ module supra_framework::automation_registry {
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             current_time,
             tcmg,
-            true
         );
         // Pending task is ignored
         assert!(vector::length(&results) == 2, 2);
@@ -3118,8 +3124,7 @@ module supra_framework::automation_registry {
         assert!(r1.fee == expected_fee, 3);
         assert!(r2.fee == expected_fee, 4);
 
-        // Take into account CANCELLED tasks as well
-        // Tasks are considered as expired
+        // Tasks are considered as expired even if they are part of the registry due to some bug, they will not be charged.
         let current_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
         let results = calculate_tasks_automation_fees(
             ar,
@@ -3127,7 +3132,6 @@ module supra_framework::automation_registry {
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             current_time,
             tcmg,
-            true
         );
         // Pending task is ignored
         assert!(vector::length(&results) == 2, 2);
@@ -3136,22 +3140,6 @@ module supra_framework::automation_registry {
         let r2 = vector::borrow(&results, 1);
         assert!(r1.fee == 0, 5);
         assert!(r2.fee == 0, 6);
-
-        // Take into account only ACTIVE tasks
-        // Tasks are considered as expired
-        let results = calculate_tasks_automation_fees(
-            ar,
-            arc,
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
-            0,
-            tcmg,
-            false);
-        // Pending task is ignored
-        assert!(vector::length(&results) == 1, 2);
-
-        let expected_fee = (expected_automation_fee_per_task + expected_congestion_fee_per_task);
-        let r1 = vector::borrow(&results, 0);
-        assert!(r1.fee == expected_fee, 7);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3161,7 +3149,6 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
-        let t3_max_gas = 11_000_000;
 
         register_with_state(
             framework,
@@ -3174,13 +3161,7 @@ module supra_framework::automation_registry {
             user,
             t1_t2_max_gas,
             100_000_000,
-            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, CANCELLED);
-        register_with_state(
-            framework,
-            user,
-            t3_max_gas,
-            100_000_000,
-            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, PENDING);
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
@@ -3209,8 +3190,7 @@ module supra_framework::automation_registry {
             let results = calculate_tasks_automation_fees(ar, arc,
                 EPOCH_INTERVAL_FOR_TEST_IN_SECS,
                 0,
-                tcmg,
-                true);
+                tcmg);
             assert!(vector::length(&results) == 2, 10);
 
             let expected_fee = expected_congestion_fee_per_task;
@@ -3240,8 +3220,7 @@ module supra_framework::automation_registry {
             let results = calculate_tasks_automation_fees(ar, arc,
                 EPOCH_INTERVAL_FOR_TEST_IN_SECS,
                 0,
-                tcmg,
-                true);
+                tcmg);
             assert!(vector::length(&results) == 2, 11);
 
             let expected_fee = expected_automation_fee_per_task;
@@ -3271,8 +3250,7 @@ module supra_framework::automation_registry {
             let results = calculate_tasks_automation_fees(ar, arc,
                 EPOCH_INTERVAL_FOR_TEST_IN_SECS,
                 0,
-                tcmg,
-                true);
+                tcmg);
             assert!(vector::length(&results) == 2, 12);
 
             let expected_fee = expected_automation_fee_per_task;
@@ -3281,31 +3259,6 @@ module supra_framework::automation_registry {
             assert!(r1.fee == expected_fee, 3);
             assert!(r2.fee == expected_fee, 4);
         };
-
-        // Update config with 0 congestion  and automation base fee, no fee calculation is expected at all
-        update_config_for_tests(framework,
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
-            AUTOMATION_MAX_GAS_TEST,
-            0,
-            FLAT_REGISTRATION_FEE_TEST,
-            CONGESTION_THRESHOLD_TEST,
-            0,
-            CONGESTION_EXPONENT_TEST,
-            TASK_CAPACITY_TEST,
-        );
-
-        let tcmg = ((2 * t1_t2_max_gas) as u256);
-
-        {
-            let ar = borrow_global<AutomationRegistry>(fwk_address);
-            let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-            let results = calculate_tasks_automation_fees(ar, arc,
-                EPOCH_INTERVAL_FOR_TEST_IN_SECS,
-                0,
-                tcmg,
-                true);
-            assert!(vector::length(&results) == 0, 13);
-        }
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3711,7 +3664,7 @@ module supra_framework::automation_registry {
         stop_tasks(user, vector[0]);
         assert!(!has_task_with_id(0), 1);
 
-        stop_tasks(user, vector[0]);
+        // stop_tasks(user, vector[0]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
@@ -3777,6 +3730,172 @@ module supra_framework::automation_registry {
         check_account_balance( user_address, expected_current_balance + refund_automation_fee );
         check_account_balance( registry_fee_address, expected_registry_balance - refund_automation_fee );
     }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_bookkeeping_refunds_and_unlocks(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let automation_fee_cap = 1000;
+
+        let user_address = address_of(user);
+        let fwk_address = address_of(framework);
+
+
+        register(user,
+            PAYLOAD,
+            86400,
+            2000,
+            200,
+            automation_fee_cap,
+            PARENT_HASH,
+            AUX_DATA
+        );
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
+
+        let expected_user_balance = ACCOUNT_BALANCE - automation_fee_cap - FLAT_REGISTRATION_FEE_TEST;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE + automation_fee_cap + FLAT_REGISTRATION_FEE_TEST;
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+
+        let automation_registry = borrow_global<AutomationRegistry>(fwk_address);
+        let resource_address = automation_registry.registry_fee_address;
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        let expected_total_locked = automation_fee_cap;
+
+        assert!(refund_bookkeeping.total_deposited_automation_fee == expected_total_locked, 2);
+        // refund only 10 % and unlock half of the initial deposit;
+        let refund = automation_fee_cap / 10;
+        let unlock = automation_fee_cap / 2;
+        let result = safe_deposit_refund(
+            refund_bookkeeping,
+            &resource_signer,
+            resource_address,
+            0,
+            user_address,
+            refund,
+            unlock);
+        assert!(result, 1);
+
+        expected_user_balance = expected_user_balance + refund;
+        expected_registry_balance = expected_registry_balance - refund;
+        expected_total_locked = expected_total_locked - unlock;
+
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+        assert!(refund_bookkeeping.total_deposited_automation_fee == expected_total_locked, 2);
+
+        // try to refund availbale amount but unlock more than is locked balance
+        // Niether unlock nor refund should succeed.
+        let result = safe_deposit_refund(
+            refund_bookkeeping,
+            &resource_signer,
+            resource_address,
+            0,
+            user_address,
+            refund,
+            automation_fee_cap);
+        assert!(!result, 3);
+
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+        assert!(refund_bookkeeping.total_deposited_automation_fee == expected_total_locked, 4);
+
+        // try to refund more then registry account has but unlock acceptable amount of deposit.
+        // Unlock will succeed but not refund.
+        let result = safe_deposit_refund(
+            refund_bookkeeping,
+            &resource_signer,
+            resource_address,
+            0,
+            user_address,
+            expected_registry_balance + automation_fee_cap,
+            unlock);
+        assert!(!result, 4);
+
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+        assert!(refund_bookkeeping.total_deposited_automation_fee == 0, 5);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_epoch_fee_refunds_and_unlocks(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry {
+        initialize_registry_test(framework, user);
+        let locked_epoch_fee = 1000;
+
+        let user_address = address_of(user);
+        let fwk_address = address_of(framework);
+
+        let automation_registry = borrow_global_mut<AutomationRegistry>(fwk_address);
+        automation_registry.epoch_locked_fees = locked_epoch_fee;
+
+        let expected_user_balance = ACCOUNT_BALANCE;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE;
+
+        let resource_address = automation_registry.registry_fee_address;
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        // refund only 10 % and unlock half of the initial deposit;
+        let refund = locked_epoch_fee / 10;
+        let (result, remaining_epoch_locked_fees) = safe_fee_refund(
+            automation_registry.epoch_locked_fees,
+            &resource_signer,
+            resource_address,
+            0,
+            user_address,
+            refund, );
+        assert!(result, 1);
+
+        expected_user_balance = expected_user_balance + refund;
+        expected_registry_balance = expected_registry_balance - refund;
+        let expected_total_locked = locked_epoch_fee - refund;
+
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+        assert!(remaining_epoch_locked_fees == expected_total_locked, 2);
+
+        // try to refund more than locked
+        // Niether unlock nor refund should succeed.
+        let (result, remaining_epoch_locked_fees) = safe_fee_refund(
+            remaining_epoch_locked_fees,
+            &resource_signer,
+            resource_address,
+            0,
+            user_address,
+            locked_epoch_fee,
+            );
+        assert!(!result, 3);
+
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+        assert!(remaining_epoch_locked_fees == expected_total_locked, 4);
+
+        // Assume there is no enough balance to refund the epoch fee in regiatry account.
+        // No refund but fee is unlocked.
+        let epoch_locked_fees = REGISTRY_DEFAULT_BALANCE;
+
+        let (result, remaining_epoch_locked_fees) = safe_fee_refund(
+            epoch_locked_fees,
+            &resource_signer,
+            resource_address,
+            0,
+            user_address,
+            expected_registry_balance + 1,
+        );
+        assert!(!result, 3);
+
+        check_account_balance(user_address, expected_user_balance);
+        check_account_balance(get_registry_fee_address(), expected_registry_balance);
+        assert!(remaining_epoch_locked_fees == epoch_locked_fees - expected_registry_balance - 1, 4);
+    }
+
 
     // Register 500 tasks to measure registration time/used-gas
     #[test_only]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -108,7 +108,8 @@ module supra_framework::automation_registry {
     const DEPOSIT_EPOCH_FEE: u8 = 0;
     const EPOCH_FEE: u8 = 1;
 
-    /// Defines refund factor for refunds of deposit fees with penalty
+    /// Defines divisor for refunds of deposit fees with penalty
+    /// Factor of `2` suggests that `1/2` of the deposit will be refunded.
     const REFUND_FACTOR: u64 = 2;
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -398,7 +399,7 @@ module supra_framework::automation_registry {
     /// Represents intermediate state of the registry on epoch change.
     struct IntermediateStateOfEpochChange {
         removed_tasks: vector<u64>,
-        gas_committed_for_new_epoch: u256,
+        gas_committed_for_new_epoch: u64,
         gas_committed_for_next_epoch: u64,
         epoch_locked_fees: Coin<SupraCoin>,
     }
@@ -673,6 +674,7 @@ module supra_framework::automation_registry {
     }
 
     public fun initialize_refund_bookkeeping_resource(supra_framework: &signer) {
+        system_addresses::assert_supra_framework(supra_framework);
         move_to(supra_framework, AutomationRefundBookkeeping {
             total_deposited_automation_fee: 0
         });
@@ -752,7 +754,7 @@ module supra_framework::automation_registry {
 
         automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
         automation_registry.epoch_locked_fees = epoch_locked_fees_value;
-        automation_registry.gas_committed_for_this_epoch = gas_committed_for_new_epoch;
+        automation_registry.gas_committed_for_this_epoch = (gas_committed_for_new_epoch as u256);
         automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;
@@ -887,7 +889,7 @@ module supra_framework::automation_registry {
                 vector::push_back(&mut removed_tasks, task_index);
             } else {
                 task.state = ACTIVE;
-                tcmg = tcmg + (task.max_gas_amount as u256);
+                tcmg = tcmg + task.max_gas_amount;
             }
         });
         IntermediateStateOfEpochChange {
@@ -930,7 +932,7 @@ module supra_framework::automation_registry {
                 vector::push_back(&mut removed_tasks, task_index);
             } else {
                 task.state = ACTIVE;
-                tcmg = tcmg + (task.max_gas_amount as u256);
+                tcmg = tcmg + task.max_gas_amount;
             }
         });
 
@@ -1226,7 +1228,7 @@ module supra_framework::automation_registry {
         // Compute the automation fee multiplier for epoch
         let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
             arc,
-            intermediate_state.gas_committed_for_new_epoch,
+            (intermediate_state.gas_committed_for_new_epoch as u256),
             arc.registry_max_gas_cap);
 
         let task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
@@ -3961,7 +3963,7 @@ module supra_framework::automation_registry {
         check_account_balance(get_registry_fee_address(), expected_registry_balance);
         assert!(remaining_epoch_locked_fees == expected_total_locked, 4);
 
-        // Assume there is no enough balance to refund the epoch fee in regiatry account.
+        // Assume there is no enough balance to refund the epoch fee in registry account.
         // No refund but fee is unlocked.
         let epoch_locked_fees = REGISTRY_DEFAULT_BALANCE;
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -189,11 +189,6 @@ module supra_framework::automation_registry {
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
-    struct ToggleNewEpoch has key, copy {
-        optimized: bool
-    }
-
-    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     #[event]
     /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
     struct AutomationTaskMetaData has key, copy, store, drop {
@@ -220,7 +215,10 @@ module supra_framework::automation_registry {
         registration_time: u64,
         /// Flag indicating whether the task is active, cancelled or pending.
         state: u8,
-        /// Fee locked for the task estimated for the next epoch at the start of the current epoch.
+        /// Deposit fee locked for the task equal to the automation-fee-cap for epoch specified for the task.
+        /// It will be refunded fully when active task is expired or cancelled by user
+        /// and partially if a pending task is cancelled by user or by the system due to insufficient balance to
+        /// pay the automation fee for the epoch
         locked_fee_for_next_epoch: u64,
     }
 
@@ -238,7 +236,7 @@ module supra_framework::automation_registry {
         task_index: u64,
         owner: address,
         registration_fee: u64,
-        deposit_epoch_fee: u64,
+        locked_deposit_fee: u64,
     }
 
     #[event]
@@ -321,7 +319,7 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted when an automation task is cancelled due to automation fee capacity surpass.
+    /// Event emitted on epoch transition containing removed task indexes.
     struct RemovedTasks has drop, store {
         task_indexes: vector<u64>
     }
@@ -341,8 +339,9 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted when on new epoch refunds to be paid is not possible due to insufficient resource account balance.
-    /// Type of the refund can be either deposit paid during registration (0), or caused by the shortening of the epoch (1)
+    /// Event emitted during epoch transition when refunds to be paid is not possible due to insufficient resource account balance.
+    /// Type of the refund can be releated either to the deposit paid during registration (0), or to epoch-fee caused by
+    /// the shortening of the epoch (1)
     struct ErrorInsufficientBalanceToRefund has drop, store {
         refund_type: u8,
         task_index: u64,
@@ -373,14 +372,7 @@ module supra_framework::automation_registry {
         automation_fee_cap: u64,
         expiry_time: u64,
         max_gas_amount: u64,
-        locked_fee_for_next_epoch: u64
-    }
-
-    /// Represents intermediate state of the registry on epoch change.
-    struct IntermediateState has drop {
-        removed_task_ids: vector<u64>,
-        gas_committed_for_next_epoch: u64,
-        epoch_locked_fees: u64,
+        locked_deposit_fee: u64
     }
 
     /// Represents intermediate state of the registry on epoch change.
@@ -390,16 +382,6 @@ module supra_framework::automation_registry {
         epoch_locked_fees: Coin<SupraCoin>,
     }
 
-    fun deposit_epoch_fee_to_registry_fee_address(automation_registry: &AutomationRegistry, value: IntermediateStateWithCoins) {
-        let IntermediateStateWithCoins {
-            removed_task_ids: _,
-            gas_committed_for_next_epoch: _,
-            epoch_locked_fees,
-
-        } = value;
-        coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
-    }
-
     #[view]
     /// Checks whether all required resources are created.
     public fun is_initialized(): bool {
@@ -407,7 +389,6 @@ module supra_framework::automation_registry {
             && exists<AutomationEpochInfo>(@supra_framework)
             && exists<ActiveAutomationRegistryConfig>(@supra_framework)
             && exists<AutomationRefundBookkeeping>(@supra_framework)
-        && exists<ToggleNewEpoch>(@supra_framework)
     }
 
     #[view]
@@ -668,9 +649,6 @@ module supra_framework::automation_registry {
             epoch_interval: epoch_interval_secs,
             start_time: 0,
         });
-        move_to(supra_framework, ToggleNewEpoch {
-            optimized: false,
-        });
 
         initialize_refund_bookkeeping_resource(supra_framework)
     }
@@ -681,17 +659,9 @@ module supra_framework::automation_registry {
         });
     }
 
-    public(friend) fun on_new_epoch() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping , ToggleNewEpoch{
-        let toggle_epoch_change = borrow_global<ToggleNewEpoch>(@supra_framework);
-        if (toggle_epoch_change.optimized) {
-            on_new_epoch_2()
-        } else {
-            on_new_epoch_old()
-        }
-
-    }
     /// On new epoch this function will be triggered and update the automation registry state
-    public(friend) fun on_new_epoch_old() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    public(friend) fun on_new_epoch(
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Unless registry in initialized, registry will not be updated on new epoch.
         // Here we need to be careful as well. If the feature is disabled for the current epoch then
         //  - refund for the previous epoch should be done if any charges has been done.
@@ -709,14 +679,14 @@ module supra_framework::automation_registry {
         ).main_config;
 
         let current_time = timestamp::now_seconds();
-
-        // Refund the task if the epoch was shorter than expected.
-        adjust_tasks_epoch_fee_refund(
+        let (new_epoch_tcmg, removed_tasks) = update_state_for_new_epoch(
             automation_registry,
+            refund_bookkeeping,
             &automation_registry_config,
             automation_epoch_info,
             current_time
         );
+
 
         // Apply the latest configuration if any parameter has been updated
         // only after refund has been done for previous epoch.
@@ -739,40 +709,28 @@ module supra_framework::automation_registry {
             return
         };
 
-        // Accumulated maximum gas amount of the registered tasks for the current epoch
-        let (tcmg, removed_tasks) = cleanup_and_activate_tasks(automation_registry, refund_bookkeeping, current_time);
 
-
-        let tasks_automation_fees = calculate_tasks_automation_fees(
-            automation_registry,
-            &automation_registry_config,
-            automation_epoch_info.epoch_interval,
-            current_time,
-            tcmg,
-            false
-        );
-
-        let intermediate_state = IntermediateState {
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: 0,
-            removed_task_ids: removed_tasks,
-        };
-        let IntermediateState {
+        let IntermediateStateWithCoins {
             gas_committed_for_next_epoch,
             epoch_locked_fees,
-            removed_task_ids
+            removed_task_ids,
         } = try_withdraw_task_automation_fees(
             automation_registry,
             refund_bookkeeping,
-            tasks_automation_fees,
-            current_time,
+            &automation_registry_config,
             automation_epoch_info.epoch_interval,
-            intermediate_state
+            current_time,
+            new_epoch_tcmg,
+            removed_tasks,
         );
 
+        let epoch_locked_fees_value = coin::value(&epoch_locked_fees);
+
+        coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
+
         automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
-        automation_registry.epoch_locked_fees = epoch_locked_fees;
-        automation_registry.gas_committed_for_this_epoch = tcmg;
+        automation_registry.epoch_locked_fees = epoch_locked_fees_value;
+        automation_registry.gas_committed_for_this_epoch = new_epoch_tcmg;
         automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;
@@ -781,6 +739,7 @@ module supra_framework::automation_registry {
             task_indexes: removed_task_ids
         });
     }
+
 
     /// Adjusts task fees and processes refunds when there's a change in epoch duration.
     fun adjust_tasks_epoch_fee_refund(
@@ -831,125 +790,6 @@ module supra_framework::automation_registry {
         });
     }
 
-    /// Cleanup and activate the automation task also it's calculate and return total committed max gas
-    fun cleanup_and_activate_tasks(automation_registry: &mut AutomationRegistry, refund_bookkeeping: &mut AutomationRefundBookkeeping, current_time: u64): (u256, vector<u64>) {
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-        let tcmg = 0;
-        let removed_tasks = vector[];
-
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-        // Perform clean up and updation of state (we can't use enumerable_map::for_each, as actually we need value as mutable ref)
-        vector::for_each(ids, |task_index| {
-            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                event::emit(ErrorTaskDoesNotExist { task_index })
-            } else {
-                let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
-
-                // Drop or activate task for this current epoch.
-                if (task.expiry_time <= current_time || task.state == CANCELLED) {
-                    safe_deposit_refund(
-                        refund_bookkeeping,
-                        &resource_signer,
-                        automation_registry.registry_fee_address,
-                        task.task_index,
-                        task.owner,
-                        task.locked_fee_for_next_epoch,
-                    task.locked_fee_for_next_epoch);
-                    enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-                    vector::push_back(&mut removed_tasks, task_index);
-                } else {
-                    task.state = ACTIVE;
-                    tcmg = tcmg + (task.max_gas_amount as u256);
-                }
-            }
-        });
-        (tcmg, removed_tasks)
-    }
-
-    /// On new epoch this function will be triggered and update the automation registry state
-    public(friend) fun on_new_epoch_2(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        // Unless registry in initialized, registry will not be updated on new epoch.
-        // Here we need to be careful as well. If the feature is disabled for the current epoch then
-        //  - refund for the previous epoch should be done if any charges has been done.
-        //  - all tasks should be removed from registry state
-        // Note that with the current setup feature::on_new_epoch is called before automation_registry::on_new_epoch
-        if (!is_initialized()) {
-            return
-        };
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_epoch_info = borrow_global_mut<AutomationEpochInfo>(@supra_framework);
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-
-        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(
-            @supra_framework
-        ).main_config;
-
-        let current_time = timestamp::now_seconds();
-        let (new_epoch_tcmg, removed_tasks) = update_state_for_new_epoch(
-            automation_registry,
-            refund_bookkeeping,
-            &automation_registry_config,
-            automation_epoch_info,
-            current_time
-        );
-
-
-        // Apply the latest configuration if any parameter has been updated
-        // only after refund has been done for previous epoch.
-        update_config_from_buffer();
-
-        // If feature is not enabled then we are not charging and tasks are cleared.
-        if (!features::supra_native_automation_enabled()) {
-            automation_registry.gas_committed_for_next_epoch = 0;
-            automation_registry.epoch_locked_fees = 0;
-            automation_registry.gas_committed_for_this_epoch = 0;
-            automation_registry.epoch_active_task_ids = vector[];
-            safe_deposit_refund_all(automation_registry, refund_bookkeeping);
-            event::emit(RemovedTasks {
-                task_indexes: enumerable_map::get_map_list(&automation_registry.tasks)
-            });
-            enumerable_map::clear(&mut automation_registry.tasks);
-
-            automation_epoch_info.start_time = current_time;
-            automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-            return
-        };
-
-        let intermediate_state_with_coins = IntermediateStateWithCoins {
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: coin::zero<SupraCoin>(),
-            removed_task_ids: removed_tasks,
-        };
-
-        let IntermediateState {
-            gas_committed_for_next_epoch,
-            epoch_locked_fees,
-            removed_task_ids
-        } = try_withdraw_task_automation_fees_2(
-            automation_registry,
-            refund_bookkeeping,
-            &automation_registry_config,
-            automation_epoch_info.epoch_interval,
-            current_time,
-            new_epoch_tcmg,
-            intermediate_state_with_coins
-        );
-
-        automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
-        automation_registry.epoch_locked_fees = epoch_locked_fees;
-        automation_registry.gas_committed_for_this_epoch = new_epoch_tcmg;
-        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        automation_epoch_info.start_time = current_time;
-        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-        event::emit(RemovedTasks {
-            task_indexes: removed_task_ids
-        });
-    }
-
     /// Checks all tasks for refunds, cancellation and expirations.
     /// Cleans the stale tasks and calculates gas-committed for the new epoch.
     fun update_state_for_new_epoch(
@@ -984,7 +824,6 @@ module supra_framework::automation_registry {
         }
     }
 
-
     /// Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
     fun refund_cleanup_and_activate_tasks(
         automation_registry: &mut AutomationRegistry,
@@ -1005,8 +844,12 @@ module supra_framework::automation_registry {
         vector::for_each(ids, |task_index| {
             let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
             if (task.state != PENDING) {
-                let refund = calculate_task_fee(arc, task,
-                    refund_interval, current_time, refund_automation_fee_per_sec);
+                let refund = calculate_task_fee(
+                    arc,
+                    task,
+                    refund_interval,
+                    current_time,
+                    refund_automation_fee_per_sec);
                 safe_fee_refund(
                     &resource_signer,
                     automation_registry.registry_fee_address,
@@ -1016,8 +859,7 @@ module supra_framework::automation_registry {
             };
 
             // Drop or activate task for this current epoch.
-            if (task.state == CANCELLED || task.expiry_time <= current_time) {
-                // Refund deposited epoch-fee for cancelled and expired tasks.
+            if (task.expiry_time <= current_time || task.state == CANCELLED) {
                 safe_deposit_refund(
                     refund_bookkeeping,
                     &resource_signer,
@@ -1036,7 +878,54 @@ module supra_framework::automation_registry {
         (tcmg, removed_tasks)
     }
 
-    fun safe_refund(resource_signer: &signer, resource_address: address, task_index: u64, task_owner: address, refundable_amount: u64, refund_type: u8):  bool {
+    /// Cleanup and activate the automation task also it's calculate and return total committed max gas
+    fun cleanup_and_activate_tasks(
+        automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        current_time: u64
+    ): (u256, vector<u64>) {
+        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+        let tcmg = 0;
+        let removed_tasks = vector[];
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        // Perform clean up and updation of state (we can't use enumerable_map::for_each, as actually we need value as mutable ref)
+        vector::for_each(ids, |task_index| {
+            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                event::emit(ErrorTaskDoesNotExist { task_index })
+            } else {
+                let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+                // Drop or activate task for this current epoch.
+                if (task.expiry_time <= current_time || task.state == CANCELLED) {
+                    safe_deposit_refund(
+                        refund_bookkeeping,
+                        &resource_signer,
+                        automation_registry.registry_fee_address,
+                        task.task_index,
+                        task.owner,
+                        task.locked_fee_for_next_epoch,
+                        task.locked_fee_for_next_epoch);
+                    enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+                    vector::push_back(&mut removed_tasks, task_index);
+                } else {
+                    task.state = ACTIVE;
+                    tcmg = tcmg + (task.max_gas_amount as u256);
+                }
+            }
+        });
+        (tcmg, removed_tasks)
+    }
+
+    fun safe_refund(
+        resource_signer: &signer,
+        resource_address: address,
+        task_index: u64,
+        task_owner: address,
+        refundable_amount: u64,
+        refund_type: u8
+    ):  bool {
         let balance = coin::balance<SupraCoin>(resource_address);
         if (balance < refundable_amount) {
             event::emit(
@@ -1049,8 +938,22 @@ module supra_framework::automation_registry {
         return true
     }
 
-    fun safe_deposit_refund(rb: &mut AutomationRefundBookkeeping, resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_deposit: u64, locked_deposit: u64):  bool {
-        let result = safe_refund(resource_signer, resouce_address, task_index, task_owner, refundable_deposit, DEPOSIT_EPOCH_FEE);
+    fun safe_deposit_refund(
+        rb: &mut AutomationRefundBookkeeping,
+        resource_signer: &signer,
+        resouce_address: address,
+        task_index: u64,
+        task_owner: address,
+        refundable_deposit: u64,
+        locked_deposit: u64
+    ):  bool {
+        let result = safe_refund(
+            resource_signer,
+            resouce_address,
+            task_index,
+            task_owner,
+            refundable_deposit,
+            DEPOSIT_EPOCH_FEE);
         if (result) {
             event::emit(
                 TaskDepositFeeRefund { task_index, owner: task_owner, amount: refundable_deposit }
@@ -1060,7 +963,11 @@ module supra_framework::automation_registry {
         result
     }
 
-    fun safe_unlock_locked_deposit(rb: &mut AutomationRefundBookkeeping, locked_deposit: u64, task_index: u64) {
+    fun safe_unlock_locked_deposit(
+        rb: &mut AutomationRefundBookkeeping,
+        locked_deposit: u64,
+        task_index: u64
+    ) {
         if (rb.total_deposited_automation_fee >= locked_deposit) {
             rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
         } else {
@@ -1071,8 +978,20 @@ module supra_framework::automation_registry {
 
     }
 
-    fun safe_fee_refund(resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_fee: u64):  bool {
-        let result = safe_refund(resource_signer, resouce_address, task_index, task_owner, refundable_fee, EPOCH_FEE);
+    fun safe_fee_refund(
+        resource_signer: &signer,
+        resouce_address: address,
+        task_index: u64,
+        task_owner: address,
+        refundable_fee: u64
+    ):  bool {
+        let result = safe_refund(
+            resource_signer,
+            resouce_address,
+            task_index,
+            task_owner,
+            refundable_fee,
+            EPOCH_FEE);
         if (result) {
             event::emit(
                 TaskFeeRefund { task_index, owner: task_owner, amount: refundable_fee }
@@ -1081,7 +1000,9 @@ module supra_framework::automation_registry {
         result
     }
 
-    fun safe_deposit_refund_all(automation_registry: &AutomationRegistry, refund_bookkeeping: &mut AutomationRefundBookkeeping) {
+    fun safe_deposit_refund_all(
+        automation_registry: &AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping) {
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         let resource_signer = account::create_signer_with_capability(
@@ -1252,114 +1173,17 @@ module supra_framework::automation_registry {
     fun try_withdraw_task_automation_fees(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        tasks_automation_fees: vector<AutomationTaskFee>,
-        current_time: u64,
-        epoch_interval: u64,
-        intermediate_state: IntermediateState,
-    ): IntermediateState {
-
-        sort_by_task_index(&mut tasks_automation_fees);
-
-        vector::for_each(tasks_automation_fees, |task| {
-            let task: AutomationTaskFee = task;
-            if (!enumerable_map::contains(&automation_registry.tasks, task.task_index)) {
-                event::emit(ErrorTaskDoesNotExistForWithdrawal { task_index: task.task_index })
-            } else {
-                try_withdraw_task_automation_fee(
-                    automation_registry,
-                    refund_bookkeeping,
-                    task,
-                    current_time,
-                    epoch_interval,
-                    &mut intermediate_state
-                );
-            };
-        });
-        intermediate_state
-    }
-
-    fun try_withdraw_task_automation_fee(
-        automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        task: AutomationTaskFee,
-        current_time: u64,
-        epoch_interval: u64,
-        intermediate_state: &mut IntermediateState) {
-        let task_metadata = enumerable_map::get_value(&automation_registry.tasks, task.task_index);
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-
-        // Remove the automation task if the epoch fee cap is exceeded
-        if (task.fee > task_metadata.automation_fee_cap_for_epoch) {
-            safe_deposit_refund(
-                refund_bookkeeping,
-                &resource_signer,
-                automation_registry.registry_fee_address,
-                task.task_index,
-                task.owner,
-                task_metadata.locked_fee_for_next_epoch,
-                task_metadata.locked_fee_for_next_epoch
-            );
-            enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
-            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
-            event::emit(TaskCancelledCapacitySurpassed {
-                task_index: task.task_index,
-                owner: task_metadata.owner,
-                fee: task.fee,
-                automation_fee_cap: task_metadata.automation_fee_cap_for_epoch,
-            });
-            return
-        };
-        let user_balance = coin::balance<SupraCoin>(task_metadata.owner);
-        if (user_balance < task.fee) {
-            // If the user does not have enough balance, remove the task and emit an event
-            enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
-            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
-            event::emit(TaskCancelledInsufficentBalance {
-                task_index: task.task_index,
-                owner: task_metadata.owner,
-                fee: task.fee,
-            });
-            safe_unlock_locked_deposit(refund_bookkeeping, task_metadata.locked_fee_for_next_epoch, task.task_index);
-            return
-        };
-        if (task.fee != 0) {
-            // Charge the fee and emit a success event
-            coin::transfer<SupraCoin>(
-                &create_signer(task_metadata.owner),
-                automation_registry.registry_fee_address,
-                task.fee
-            );
-        };
-        event::emit(TaskEpochFeeWithdraw {
-            task_index: task.task_index,
-            owner: task_metadata.owner,
-            fee: task.fee,
-        });
-        // Total task fees deducted from the user's account
-        intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
-
-        // Calculate gas commitment for the next epoch only for valid active tasks
-        if (task_metadata.expiry_time > (current_time + epoch_interval)) {
-            intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task_metadata.max_gas_amount;
-        };
-    }
-
-    /// Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-    /// - If the user has sufficient balance, deducts the fee and emits a success event.
-    /// - If the balance is insufficient, removes the task and emits a cancellation event.
-    /// - If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-    /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-    fun try_withdraw_task_automation_fees_2(
-        automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         arc: &AutomationRegistryConfig,
         epoch_interval: u64,
         current_time: u64,
         tcmg: u256,
-        intermediate_state_with_coins: IntermediateStateWithCoins
-    ): IntermediateState {
+        removed_tasks: vector<u64>
+    ): IntermediateStateWithCoins {
+        let intermediate_state_with_coins = IntermediateStateWithCoins {
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: coin::zero<SupraCoin>(),
+            removed_task_ids: removed_tasks,
+        };
         // Compute the automation congestion fee (acf) for the epoch
         let acf = calculate_automation_congestion_fee(arc, tcmg, arc.registry_max_gas_cap);
         let automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
@@ -1367,9 +1191,10 @@ module supra_framework::automation_registry {
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
         );
+        let current_epoch_end_time = current_time + epoch_interval;
 
         // Sort task indexes to charge autoamtion fees in the tasks chronological order
-        sort(&mut task_ids);
+        sort_vector(&mut task_ids);
 
         // Process each active task and calculate fee for the epoch for the tasks
         vector::for_each(task_ids, |task_index| {
@@ -1381,38 +1206,29 @@ module supra_framework::automation_registry {
                 expiry_time: task_meta.expiry_time,
                 automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
                 max_gas_amount: task_meta.max_gas_amount,
-                locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
+                locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
             };
             if (automation_fee_per_sec != 0) {
                 task.fee = calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
             };
-            try_withdraw_task_automation_fee_2(
+            try_withdraw_task_automation_fee(
                 automation_registry,
                 refund_bookkeeping,
                 &resource_signer,
                 task,
-                current_time,
-                epoch_interval,
+                current_epoch_end_time,
                 &mut intermediate_state_with_coins
             );
         });
-        let intermediate_state = IntermediateState {
-            gas_committed_for_next_epoch: intermediate_state_with_coins.gas_committed_for_next_epoch,
-            epoch_locked_fees: coin::value(&intermediate_state_with_coins.epoch_locked_fees),
-            removed_task_ids: intermediate_state_with_coins.removed_task_ids
-        };
-
-        deposit_epoch_fee_to_registry_fee_address(automation_registry, intermediate_state_with_coins);
-        intermediate_state
+        intermediate_state_with_coins
     }
 
-    fun try_withdraw_task_automation_fee_2(
+    fun try_withdraw_task_automation_fee(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         resource_signer: &signer,
         task: AutomationTaskFeeMeta,
-        current_time: u64,
-        epoch_interval: u64,
+        current_epoch_end_time: u64,
         intermediate_state: &mut IntermediateStateWithCoins) {
         // Remove the automation task if the epoch fee cap is exceeded
         if (task.fee > task.automation_fee_cap) {
@@ -1422,8 +1238,8 @@ module supra_framework::automation_registry {
                 automation_registry.registry_fee_address,
                 task.task_index,
                 task.owner,
-                task.locked_fee_for_next_epoch,
-                task.locked_fee_for_next_epoch
+                task.locked_deposit_fee,
+                task.locked_deposit_fee
             );
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
             vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
@@ -1437,7 +1253,8 @@ module supra_framework::automation_registry {
         };
         let user_balance = coin::balance<SupraCoin>(task.owner);
         if (user_balance < task.fee) {
-            // If the user does not have enough balance, remove the task and emit an event
+            // If the user does not have enough balance, remove the task, refund the locked deposit and emit an event
+            safe_unlock_locked_deposit(refund_bookkeeping, task.locked_deposit_fee, task.task_index);
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
             vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
             event::emit(TaskCancelledInsufficentBalance {
@@ -1445,7 +1262,6 @@ module supra_framework::automation_registry {
                 owner: task.owner,
                 fee: task.fee,
             });
-            safe_unlock_locked_deposit(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
             return
         };
         if (task.fee != 0) {
@@ -1464,7 +1280,7 @@ module supra_framework::automation_registry {
         });
 
         // Calculate gas commitment for the next epoch only for valid active tasks
-        if (task.expiry_time > (current_time + epoch_interval)) {
+        if (task.expiry_time > current_epoch_end_time) {
             intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task.max_gas_amount;
         };
     }
@@ -1565,13 +1381,6 @@ module supra_framework::automation_registry {
     }
 
     /// Enables the registration process in the automation registry.
-    public fun toggle_new_epoch(supra_framework: &signer, flag: bool) acquires ToggleNewEpoch {
-        system_addresses::assert_supra_framework(supra_framework);
-        let toggle_new_epoch = borrow_global_mut<ToggleNewEpoch>(@supra_framework);
-        toggle_new_epoch.optimized = flag;
-    }
-
-    /// Enables the registration process in the automation registry.
     public fun enable_registration(supra_framework: &signer) acquires ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
@@ -1645,7 +1454,6 @@ module supra_framework::automation_registry {
         automation_registry.gas_committed_for_next_epoch = committed_gas;
         let task_index = automation_registry.current_index;
 
-        let deposit_automation_fee = automation_fee_cap_for_epoch;
         let automation_task_metadata = AutomationTaskMetaData {
             task_index,
             owner,
@@ -1658,17 +1466,17 @@ module supra_framework::automation_registry {
             state: PENDING,
             registration_time,
             tx_hash,
-            locked_fee_for_next_epoch: deposit_automation_fee
+            locked_fee_for_next_epoch: automation_fee_cap_for_epoch
         };
 
         enumerable_map::add_value(&mut automation_registry.tasks, task_index, automation_task_metadata);
         automation_registry.current_index = automation_registry.current_index + 1;
 
         // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
-        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + deposit_automation_fee;
+        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + automation_fee_cap_for_epoch;
 
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + deposit_automation_fee;
+        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + automation_fee_cap_for_epoch;
 
         coin::transfer<SupraCoin>(owner_signer, automation_registry.registry_fee_address, fee);
 
@@ -1676,7 +1484,7 @@ module supra_framework::automation_registry {
             task_index,
             owner,
             registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
-            deposit_epoch_fee: deposit_automation_fee
+            locked_deposit_fee: automation_fee_cap_for_epoch
         });
         event::emit(automation_task_metadata);
     }
@@ -1731,7 +1539,7 @@ module supra_framework::automation_registry {
                 automation_task_metadata.locked_fee_for_next_epoch / REFUND_FACTOR,
             automation_task_metadata.locked_fee_for_next_epoch);
             enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-        } else if (automation_task_metadata.state == ACTIVE) {
+        } else { // it is safe not to check the state as above the already cancelled task's cancellation is rejected.
             // Active tasks will be refunded at the end of the epoch
             let automation_task_metadata_mut = enumerable_map::get_value_mut(
                 &mut automation_registry.tasks,
@@ -1872,23 +1680,8 @@ module supra_framework::automation_registry {
         };
     }
 
-    /// Sorting vector implementation
-    fun sort_by_task_index(v: &mut vector<AutomationTaskFee>) {
-        let len = vector::length(v);
-        let i = 1;
-        while (i < len) {
-            let j = i;
-            let to_be_sorted = vector::borrow(v, j).task_index;
-            while (j > 0 && to_be_sorted < vector::borrow(v, j - 1).task_index) {
-                vector::swap(v, j, j - 1);
-                j = j - 1;
-            };
-            i = i + 1;
-        };
-    }
-
-    /// Sorting vector implementation
-    public fun sort(input: &mut vector<u64>) {
+    /// Insertion sort implementation for vector
+    public fun sort_vector(input: &mut vector<u64>) {
         let len = vector::length(input);
         let i = 1;
         while (i < len) {
@@ -1940,7 +1733,7 @@ module supra_framework::automation_registry {
     #[test_only]
     const ACCOUNT_BALANCE: u64 = 10_000_000_000;
     #[test_only]
-    const REGISTRY_DEFAULT_BALANCE: u64 = 100_000_000_000;
+    const REGISTRY_DEFAULT_BALANCE: u64 = 200_000_000_000;
 
 
     #[test_only]
@@ -2067,6 +1860,32 @@ module supra_framework::automation_registry {
     }
 
     #[test_only]
+    /// Registers a task with specified state and returns the task index
+    fun update_task_state(
+        automation_registry: &mut AutomationRegistry,
+        task_index: u64,
+        state: u8,
+    ) {
+        let task_details = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+        task_details.state = state;
+    }
+
+    #[test_only]
+    /// Registers a task with specified state and returns the task index
+    fun check_task_state(
+        automation_registry: &AutomationRegistry,
+        task_index: u64,
+        exists: bool,
+        state: u8,
+    ) {
+        assert!(enumerable_map::contains(&automation_registry.tasks, task_index) == exists, 98);
+        if (exists) {
+            let task_details = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
+            assert!(task_details.state == state, 99);
+        }
+    }
+
+    #[test_only]
     fun set_locked_fee(
         framework: &signer,
         locked_fee: u64,
@@ -2174,7 +1993,7 @@ module supra_framework::automation_registry {
 
     #[test]
     fun test_on_new_epoch_without_initialization(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Nothing will be attempted if the registry is not initialized.
         on_new_epoch()
     }
@@ -2195,7 +2014,7 @@ module supra_framework::automation_registry {
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_update_config_success_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2615,7 +2434,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2674,7 +2493,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_cancellation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2761,6 +2580,39 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_pending_task_cancellation_refunds(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let automation_fee_cap = 1000;
+
+        register(user,
+            PAYLOAD,
+            86400,
+            10,
+            20,
+            automation_fee_cap,
+            PARENT_HASH,
+            AUX_DATA
+        );
+        // check user balance after registered new task
+        let registry_fee_address = get_registry_fee_address();
+        let user_address = address_of(user);
+        let registration_charges = FLAT_REGISTRATION_FEE_TEST + automation_fee_cap;
+        let expected_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
+        check_account_balance(user_address, expected_current_balance);
+        check_account_balance(registry_fee_address, expected_registry_balance);
+
+        cancel_task(user, 0);
+        // Pending task upon cancellation refunded only with half of the deposit;
+        let expected_refund = automation_fee_cap / REFUND_FACTOR;
+        check_account_balance(user_address, expected_current_balance + expected_refund);
+        check_account_balance(registry_fee_address, expected_registry_balance - expected_refund);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
     #[expected_failure(abort_code = EAUTOMATION_TASK_NOT_FOUND, location = Self)]
     fun check_cancellation_of_non_existing_task(
         framework: &signer,
@@ -2797,7 +2649,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2820,12 +2672,13 @@ module supra_framework::automation_registry {
     fun check_normal_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
+        let automation_fee_cap = 100_000;
 
         register(user,
             PAYLOAD,
-            86400,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             1_000_000, // normal gas amount
             20,
             100_000,
@@ -2835,10 +2688,12 @@ module supra_framework::automation_registry {
 
         // check user balance after registered new task
         let registry_fee_address = get_registry_fee_address();
-        let user_account = address_of(user);
-        let expected_current_balance = ACCOUNT_BALANCE - FLAT_REGISTRATION_FEE_TEST;
-        check_account_balance(user_account, expected_current_balance);
-        check_account_balance(registry_fee_address, REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST);
+        let user_address = address_of(user);
+        let registration_charges = FLAT_REGISTRATION_FEE_TEST + automation_fee_cap;
+        let expected_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
+        check_account_balance(user_address, expected_current_balance);
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         timestamp::update_global_time_for_test_secs(50);
         on_new_epoch();
@@ -2846,25 +2701,26 @@ module supra_framework::automation_registry {
         // 10 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
         // check user balance after on new epoch fee applied
-        check_account_balance(user_account, expected_current_balance - expected_automation_fee);
+        check_account_balance(user_address, expected_current_balance - expected_automation_fee);
         check_account_balance(
             registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_automation_fee);
+            expected_registry_balance + expected_automation_fee);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_congestion_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
+        let automation_fee_cap = 10_000_000;
 
         register(user,
             PAYLOAD,
-            86400,
+            3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             85_000_000, // congestion threshold reached
             20,
-            10_000_000,
+            automation_fee_cap,
             PARENT_HASH,
             AUX_DATA
         );
@@ -2872,12 +2728,15 @@ module supra_framework::automation_registry {
         // check user balance after registered new task
         let registry_fee_address = get_registry_fee_address();
         let user_address = address_of(user);
-        let expected_current_balance = ACCOUNT_BALANCE - FLAT_REGISTRATION_FEE_TEST;
+        let registration_charges = FLAT_REGISTRATION_FEE_TEST + automation_fee_cap;
+        let expected_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
         check_account_balance(user_address, expected_current_balance);
-        check_account_balance(registry_fee_address, REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST);
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         timestamp::update_global_time_for_test_secs(50);
         on_new_epoch();
+        has_task_with_id(0);
 
         // 85/100 * 1000 = 850 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 850;
@@ -2888,59 +2747,67 @@ module supra_framework::automation_registry {
         check_account_balance(user_address, expected_current_balance - expected_epoch_fee);
         check_account_balance(
             registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_epoch_fee);
+            expected_registry_balance + expected_epoch_fee);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_automation_task_fee_refund(
+    fun check_update_state_for_new_epoch(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let exists = true;
 
-        register_with_state(
+        let task1 = register_with_state(
             framework,
             user,
             44_000_000,
-            100_000_000,
+            automation_fee_cap,
             task_exipry_time,
             ACTIVE);
-        register_with_state(
+        let task2 = register_with_state(
             framework,
             user,
             44_000_000,
-            100_000_000,
+            automation_fee_cap,
             task_exipry_time,
-            CANCELLED);
-        register_with_state(
+            ACTIVE);
+        let task3 = register_with_state(
             framework,
             user,
             11_000_000,
-            100_000_000,
+            automation_fee_cap,
             task_exipry_time,
             PENDING);
-        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * FLAT_REGISTRATION_FEE_TEST;
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * FLAT_REGISTRATION_FEE_TEST;
+        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
 
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
         // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
         let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
         let fwk_address = address_of(framework);
         let user_address = address_of(user);
 
         // No refund when there is no locked fee.
         set_locked_fee(framework, 0);
         {
-            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+            let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
             let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
             let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-            adjust_tasks_epoch_fee_refund(ar, arc, aei, 3600);
+            update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
             // If there is no locked fee, nothing to refund;
+            // tasks only will be charged for the next epoch.
             check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+            check_task_state(ar, task3, exists, ACTIVE);
+            // reset the state
+            update_task_state(ar, task3, PENDING);
         };
 
         // Set some locked fee which is enough to pay refund if necessary
@@ -2948,28 +2815,104 @@ module supra_framework::automation_registry {
 
         {
             // if epoch length matches or greater the expected epoch interval then no refund is expected
-            // event if there is a locked fee.
-            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            // even if there is a locked fee.
+            let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+            let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
             let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
             let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-            adjust_tasks_epoch_fee_refund(ar, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-            check_account_balance(user_address, expected_user_current_balance);
-            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
 
-            adjust_tasks_epoch_fee_refund(ar, arc, aei, task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+            update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
             check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+            check_task_state(ar, task1, exists, ACTIVE);
+            check_task_state(ar, task2, exists, ACTIVE);
+            check_task_state(ar, task3, exists, ACTIVE);
 
             // Refund is expected only for ACTIVE AND CANCELLED TASK BUT NOT FOR PENDING
-            adjust_tasks_epoch_fee_refund(ar, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
-            // as account have 2 tasks with same automation and congestion fees then refund is double
-            let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task;
+            update_task_state(ar, task3, PENDING);
+            update_task_state(ar, task2, CANCELLED);
+            update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+            // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
+            let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task
+                + automation_fee_cap; // refund of the depodit for cancelled task
             expected_user_current_balance = expected_user_current_balance + expected_refund;
             expected_registry_current_balance = expected_registry_current_balance - expected_refund;
+
             check_account_balance(user_address, expected_user_current_balance);
-            // Check registry balance
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+            check_task_state(ar, task1, exists, ACTIVE);
+            check_task_state(ar, task2, !exists, CANCELLED);
+            check_task_state(ar, task3, exists, ACTIVE);
+
+            // Now we have only task1 as Active and task 3 as pending.
+            // If epoch duration surpasses tasks expiration time, then they are refunded on  locked deposit, and removed from registry.
+            // even pending task.
+            update_task_state(ar, task3, PENDING);
+            update_state_for_new_epoch(
+                ar,
+                refund_bookkeeping,
+                arc,
+                aei,
+                task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS
+            );
+            let expected_refund = 2 * automation_fee_cap; // refund of the depodit for both available tasks
+
+            expected_user_current_balance = expected_user_current_balance + expected_refund;
+            expected_registry_current_balance = expected_registry_current_balance - expected_refund;
+
+            check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
         };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_update_state_for_new_epoch_with_remaining_time_refund(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let exists = true;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task3 = register_with_state(
+            framework,
+            user,
+            11_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let registration_charges = 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
+
+
+        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+
+        // Set some locked fee which is enough to pay refund if necessary
+        set_locked_fee(framework, 100_000_000);
 
         // Refund is expected only for the remaing time till the task expiry time for both cancelled and active tasks
         // Task was expiring in the middle of the 3rd epoch, but epoch duration was cat short by 3/4
@@ -2980,46 +2923,62 @@ module supra_framework::automation_registry {
             aei.start_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
         };
 
-        let ar = borrow_global<AutomationRegistry>(fwk_address);
+        let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
         let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
         let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-        adjust_tasks_epoch_fee_refund(ar, arc, aei, current_time);
+
+        check_account_balance(user_address, expected_user_current_balance);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+        update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, current_time);
         // It is expected that the tasks will be chared only for 1/2 epoch fee, so if the epoch lenght is 1/4,
-        // then refund should be 1/4 and as long as we have 2 tasks for the account the sum will be 1/2
-        // as account have 2 tasks with same automation and congestion fees then refund is double
-        let expected_refund = (expected_congestion_fee_per_task + expected_automation_fee_per_task) / 2;
-        check_account_balance(user_address, expected_user_current_balance + expected_refund);
+        // then refund should be 1/4.
+        // as account has 2 tasks with same automation and congestion fees then refund is double
+        // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
+        let expected_refund = (expected_congestion_fee_per_task + expected_automation_fee_per_task) / 2
+                + automation_fee_cap; // refund of the depodit for cancelled task
+
+        expected_user_current_balance = expected_user_current_balance + expected_refund;
+        expected_registry_current_balance = expected_registry_current_balance - expected_refund;
+
+        check_task_state(ar, task1, exists, ACTIVE);
+        check_task_state(ar, task2, !exists, CANCELLED);
+        check_task_state(ar, task3, exists, ACTIVE);
+
+        check_account_balance(user_address, expected_user_current_balance);
         // // Check registry balance
-        check_account_balance(ar.registry_fee_address, expected_registry_current_balance - expected_refund);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafb)]
     fun check_automation_task_fee_refund_is_done_with_old_config(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         config_buffer::initialize(framework);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 11_000_000;
+        let automation_fee_cap = 100_000_000;
 
         let t1 = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
-            100_000_000,
+            automation_fee_cap,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
         let t2 = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
-            100_000_000,
+            automation_fee_cap,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, CANCELLED);
         let t3 = register_with_state(
             framework,
             user,
             t3_max_gas,
-            100_000_000,
+            automation_fee_cap,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, PENDING);
         // Set some locked fee which is enough to pay refund if necessary
         set_locked_fee(framework, 100_000_000);
@@ -3037,8 +2996,9 @@ module supra_framework::automation_registry {
         toggle_feature_flag(framework, false);
 
         // 3 task has been registered
-        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * FLAT_REGISTRATION_FEE_TEST;
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * FLAT_REGISTRATION_FEE_TEST;
+        let registration_charges = 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
 
         let balance = coin::balance<SupraCoin>(signer::address_of(user));
         assert!(balance == expected_user_current_balance, 11);
@@ -3050,11 +3010,11 @@ module supra_framework::automation_registry {
         // Epoch cut short 2 times
 
         // Refund is expected
-        timestamp::update_global_time_for_test_secs(3600);
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
         on_new_epoch();
         let balance = coin::balance<SupraCoin>(signer::address_of(user));
-        // as account have 2 tasks with same automation and congestion fees then refund is double
-        let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task;
+        // as account have 2 active tasks with same automation and congestion fees then refund is double + deposit refund for all 3 tasks.
+        let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task + 3 * automation_fee_cap;
         assert!(balance == expected_user_current_balance + expected_refund, 12);
         // Checke registry balance
         check_account_balance(get_registry_fee_address(), expected_registry_current_balance - expected_refund);
@@ -3352,10 +3312,12 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_withdrawal_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 10_000_000;
+        let automation_fee_cap_t1 = 10_000_000;
+        let automation_fee_cap_t2_t3 = 100_000_000;
 
         // Automation fee cap overflow
         let t1 = register_with_state(
@@ -3399,8 +3361,9 @@ module supra_framework::automation_registry {
         let expected_epoch_fee_for_t1_2 = expected_automation_fee_for_t1_2 + expected_congestion_fee_for_t1_2;
 
         // 3 tasks have been registered
-        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * FLAT_REGISTRATION_FEE_TEST;
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * FLAT_REGISTRATION_FEE_TEST;
+        let registration_charges = 3 * FLAT_REGISTRATION_FEE_TEST + automation_fee_cap_t1 + 2 * automation_fee_cap_t2_t3;
+        let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
         // Make sure that user account has only enough balance for task 2 automation fee
         let withdraw_amount = expected_user_current_balance - expected_epoch_fee_for_t1_2;
         coin::transfer<SupraCoin>(
@@ -3416,16 +3379,18 @@ module supra_framework::automation_registry {
         let user_address = address_of(user);
         let fwk_address = address_of(framework);
 
-        // TASK 1 and 3 are removed/cancelled.
+        // TASK 1 cancelled due-to automation fee cap surrpass and task 3 is cancelled due to insufficient balance.
+        // So for task 1 full deposit refund is expected and for task 3 no refund is expected.
         assert!(!has_task_with_id(t1), 1);
         assert!(!has_task_with_id(t3), 2);
         assert!(has_sender_active_task_with_id(user_address, t2), 3);
         // only one task is charged as the other 2 are cancelled/removed.
+        // and uppon cancellation no deposit is refunded.
+        check_account_balance(user_address, automation_fee_cap_t1);
         check_account_balance(
             get_registry_fee_address(),
-            expected_registry_current_balance + expected_epoch_fee_for_t1_2
+            expected_registry_current_balance + expected_epoch_fee_for_t1_2 - automation_fee_cap_t1
         );
-        check_account_balance(address_of(user), 0);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         assert!(ar.gas_committed_for_this_epoch == tcmg, 4);
@@ -3516,38 +3481,13 @@ module supra_framework::automation_registry {
     }
 
     #[test]
-    fun check_sort_by_task_index() {
-        let t1 = AutomationTaskFee {
-            task_index: 1,
-            owner: @0x0123456,
-            fee: 10,
-        };
-        let t2 = AutomationTaskFee {
-            task_index: 2,
-            owner: @0x0123456,
-            fee: 5,
-        };
-        let t3 = AutomationTaskFee {
-            task_index: 3,
-            owner: @0x0123456,
-            fee: 30,
-        };
-        let t4 = AutomationTaskFee {
-            task_index: 4,
-            owner: @0x0123456,
-            fee: 10,
-        };
-        let t5 = AutomationTaskFee {
-            task_index: 5,
-            owner: @0x0123456,
-            fee: 1,
-        };
-        let task_fee_vec = vector[t5, t3, t1, t4, t2];
-        sort_by_task_index(&mut task_fee_vec);
+    fun check_sort_vector() {
+        let task_fee_vec = vector[5, 3, 1, 4, 2];
+        sort_vector(&mut task_fee_vec);
         let i = 0;
         while (i < 5) {
             let item = vector::borrow(&task_fee_vec, i);
-            assert!(i + 1 == item.task_index, i);
+            assert!(i + 1 == *item, i);
             i = i + 1;
         };
     }
@@ -3604,15 +3544,16 @@ module supra_framework::automation_registry {
     fun check_task_successful_stopped(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
+        let automation_fee_cap = 1000;
 
         register(user,
             PAYLOAD,
             86400,
             200,
             200,
-            1000,
+            automation_fee_cap,
             PARENT_HASH,
             AUX_DATA
         );
@@ -3621,7 +3562,7 @@ module supra_framework::automation_registry {
             86400,
             200,
             200,
-            1000,
+            automation_fee_cap,
             PARENT_HASH,
             AUX_DATA
         );
@@ -3630,7 +3571,7 @@ module supra_framework::automation_registry {
             86400,
             200,
             200,
-            1000,
+            automation_fee_cap,
             PARENT_HASH,
             AUX_DATA
         );
@@ -3639,7 +3580,7 @@ module supra_framework::automation_registry {
             86400,
             200,
             200,
-            1000,
+            automation_fee_cap,
             PARENT_HASH,
             AUX_DATA
         );
@@ -3647,9 +3588,11 @@ module supra_framework::automation_registry {
         // check user balance after registered new task
         let registry_fee_address = get_registry_fee_address();
         let user_account = address_of(user);
-        let expected_current_balance = ACCOUNT_BALANCE - (4 * FLAT_REGISTRATION_FEE_TEST);
+        let registration_charges = 4 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
         check_account_balance(user_account, expected_current_balance);
-        check_account_balance(registry_fee_address, REGISTRY_DEFAULT_BALANCE + (4 * FLAT_REGISTRATION_FEE_TEST));
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         on_new_epoch();
@@ -3662,11 +3605,10 @@ module supra_framework::automation_registry {
 
         // 0.002 (*4) - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 4 * (200 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000);
-        check_account_balance(user_account, expected_current_balance - expected_automation_fee);
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + (4 * FLAT_REGISTRATION_FEE_TEST) + expected_automation_fee
-        );
+        expected_current_balance = expected_current_balance - expected_automation_fee;
+        expected_registry_balance = expected_registry_balance + expected_automation_fee;
+        check_account_balance(user_account, expected_current_balance );
+        check_account_balance( registry_fee_address, expected_registry_balance );
 
         timestamp::update_global_time_for_test_secs(
             EPOCH_INTERVAL_FOR_TEST_IN_SECS + (EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2)
@@ -3684,16 +3626,12 @@ module supra_framework::automation_registry {
         assert!(600 == get_gas_committed_for_next_epoch(), 1);
 
         // Because the on of the task stopped halfway, the user gets a 50% refund for the unused time.
-        // which is equivalent to a 25% refund of the full epoch for single task.
-        let refund_automation_fee = (200 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4;
-        check_account_balance(
-            user_account,
-            (expected_current_balance - expected_automation_fee + refund_automation_fee)
-        );
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + (4 * FLAT_REGISTRATION_FEE_TEST) + expected_automation_fee - refund_automation_fee
-        );
+        // which is equivalent to a 25% refund of the full epoch for single task and deposited fee upon registration
+        let expected_refund = (200 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4 + automation_fee_cap;
+        expected_current_balance = expected_current_balance + expected_refund;
+        expected_registry_balance = expected_registry_balance - expected_refund;
+        check_account_balance(user_account, expected_current_balance);
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         // Add and stop the task in the same epoch. Task index will be 4
         assert!(get_next_task_index() == 4, 1);
@@ -3707,14 +3645,11 @@ module supra_framework::automation_registry {
             AUX_DATA
         );
 
-        check_account_balance(
-            user_account,
-            (expected_current_balance - expected_automation_fee + refund_automation_fee - FLAT_REGISTRATION_FEE_TEST)
-        );
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + (4 * FLAT_REGISTRATION_FEE_TEST) + expected_automation_fee - refund_automation_fee + FLAT_REGISTRATION_FEE_TEST
-        );
+        registration_charges = FLAT_REGISTRATION_FEE_TEST + automation_fee_cap;
+        expected_current_balance = expected_current_balance - registration_charges;
+        expected_registry_balance = expected_registry_balance + registration_charges;
+        check_account_balance(user_account, expected_current_balance);
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         stop_tasks(user, vector[4]);
         let active_task_ids = get_active_task_ids();
@@ -3727,14 +3662,10 @@ module supra_framework::automation_registry {
         assert!(get_next_task_index() == 5, 1);
         assert!(600 == get_gas_committed_for_next_epoch(), 1);
 
-        check_account_balance(
-            user_account,
-            (expected_current_balance - expected_automation_fee + refund_automation_fee - FLAT_REGISTRATION_FEE_TEST)
-        );
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + (4 * FLAT_REGISTRATION_FEE_TEST) + expected_automation_fee - refund_automation_fee + FLAT_REGISTRATION_FEE_TEST
-        );
+        // Expected refund for the stopping pending task is only the half of the deposited fee
+        expected_refund = automation_fee_cap / REFUND_FACTOR;
+        check_account_balance(user_account, expected_current_balance + expected_refund);
+        check_account_balance(registry_fee_address, expected_registry_balance - expected_refund);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe, user2 = @0x1cafa)]
@@ -3762,7 +3693,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_stopped_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3787,8 +3718,9 @@ module supra_framework::automation_registry {
     fun check_stopping_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
+        let automation_fee_cap = 1000;
 
         register(user,
             PAYLOAD,
@@ -3803,10 +3735,12 @@ module supra_framework::automation_registry {
 
         // check user balance after registered new task
         let registry_fee_address = get_registry_fee_address();
-        let user_account = address_of(user);
-        let expected_current_balance = ACCOUNT_BALANCE - FLAT_REGISTRATION_FEE_TEST;
-        check_account_balance(user_account, expected_current_balance);
-        check_account_balance(registry_fee_address, REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST);
+        let user_address = address_of(user);
+        let registration_charges = FLAT_REGISTRATION_FEE_TEST + automation_fee_cap;
+        let expected_current_balance = ACCOUNT_BALANCE - registration_charges;
+        let expected_registry_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
+        check_account_balance(user_address, expected_current_balance);
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         // Start new epoch
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
@@ -3814,11 +3748,10 @@ module supra_framework::automation_registry {
 
         // 0.002 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000;
-        check_account_balance(user_account, expected_current_balance - expected_automation_fee);
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_automation_fee
-        );
+        expected_current_balance = expected_current_balance - expected_automation_fee;
+        expected_registry_balance = expected_registry_balance + expected_automation_fee;
+        check_account_balance(user_address, expected_current_balance);
+        check_account_balance( registry_fee_address, expected_registry_balance );
 
         // Task is active state and after cancelling it, status will be update to cancelled
         cancel_task(user, 0);
@@ -3826,12 +3759,8 @@ module supra_framework::automation_registry {
         assert!(0 == get_gas_committed_for_next_epoch(), 1);
 
         // balance is keep remain same
-        let expected_automation_fee = 2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000;
-        check_account_balance(user_account, expected_current_balance - expected_automation_fee);
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_automation_fee
-        );
+        check_account_balance(user_address, expected_current_balance);
+        check_account_balance(registry_fee_address, expected_registry_balance);
 
         // After cancelling the task, the user stops it after 50% of the next epoch has passed.
         timestamp::update_global_time_for_test_secs(
@@ -3843,16 +3772,10 @@ module supra_framework::automation_registry {
         assert!(0 == get_gas_committed_for_next_epoch(), 1);
 
         // Because the on of the task stopped after 50% epoch time passed, the user gets a 50% refund for the unused time.
-        // which is equivalent to a 25% refund of the full epoch for single task.
-        let refund_automation_fee = (2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4;
-        check_account_balance(
-            user_account,
-            (expected_current_balance - expected_automation_fee + refund_automation_fee)
-        );
-        check_account_balance(
-            registry_fee_address,
-            REGISTRY_DEFAULT_BALANCE + FLAT_REGISTRATION_FEE_TEST + expected_automation_fee - refund_automation_fee
-        );
+        // which is equivalent to a 25% refund of the full epoch for single task + refund of deposited amount upon registration
+        let refund_automation_fee = (2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4 + automation_fee_cap;
+        check_account_balance( user_address, expected_current_balance + refund_automation_fee );
+        check_account_balance( registry_fee_address, expected_registry_balance - refund_automation_fee );
     }
 
     // Register 500 tasks to measure registration time/used-gas
@@ -3901,40 +3824,19 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
-        task_registration_performance(framework, user);
-
-        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
-        timestamp::update_global_time_for_test_secs(
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3
-        );
-        on_new_epoch();
-        timestamp::update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
-    }
-
-    // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
-    // And run 3 epochs to check gas-used when
-    //  - full epoch passed
-    //  - 1/3 of epoch passed to simulate refund, but tasks are still active
-    //  - last epoch identifies all tasks are expired
-    #[test(framework = @supra_framework, user = @0x1cafe)]
-    fun check_task_activation_on_new_epoch_2_performance(
-        framework: &signer,
-        user: &signer
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch_2();
+        on_new_epoch();
         timestamp::update_global_time_for_test_secs(
             EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3
         );
-        on_new_epoch_2();
+        on_new_epoch();
         timestamp::update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch_2();
+        on_new_epoch();
     }
+
 }
 
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -338,6 +338,13 @@ module supra_framework::automation_registry {
     }
 
     #[event]
+    /// Event emitted on epoch transition containing active task indexes for the new epoch.
+    struct ActiveTasks has drop, store {
+        task_indexes: vector<u64>
+    }
+
+
+    #[event]
     /// Event emitted when on new epoch a task is accessed with index of the task for the expected list
     /// but value does not exist in the map
     struct ErrorTaskDoesNotExist has drop, store {
@@ -755,6 +762,9 @@ module supra_framework::automation_registry {
         event::emit(RemovedTasks {
             task_indexes: removed_tasks
         });
+        event::emit(ActiveTasks {
+            task_indexes: automation_registry.epoch_active_task_ids
+        });
     }
 
     fun finalize_epoch_change_for_feature_disabled_state(
@@ -783,6 +793,9 @@ module supra_framework::automation_registry {
             &mut removed_tasks,
             enumerable_map::get_map_list(&automation_registry.tasks));
         event::emit(RemovedTasks { task_indexes: removed_tasks });
+        event::emit(ActiveTasks {
+            task_indexes: vector[]
+        });
         enumerable_map::clear(&mut automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1159,7 +1159,7 @@ module supra_framework::automation_registry {
 
         // Calculate congestion threshold surplus for the current epoch
         let threshold_usage = upscale_from_u256(tcmg) * 100 / max_gas_cap;
-        if (threshold_usage < threshold_percentage) 0
+        if (threshold_usage <= threshold_percentage) 0
         else {
             let threshold_surplus_normalized = (threshold_usage - threshold_percentage) / 100;
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -7,7 +7,7 @@ module supra_framework::automation_registry {
     use std::signer;
     use std::vector;
     use aptos_std::math64;
-    use supra_framework::coin::Coin;
+    use supra_framework::coin::{Coin, destroy_zero};
 
     use supra_std::enumerable_map::{Self, EnumerableMap};
 
@@ -382,8 +382,18 @@ module supra_framework::automation_registry {
     }
 
     /// Represents intermediate state of the registry on epoch change.
-    struct IntermediateState {
-        removed_task_ids: vector<u64>,
+    /// Deprectead in production, substituted with IntermediateStateWithRemovedTasks.
+    /// Kept for backward compatible framework upgrade.
+    struct IntermediateState has drop {
+        active_task_ids: vector<u64>,
+        gas_committed_for_next_epoch: u64,
+        epoch_locked_fees: u64,
+    }
+
+    /// Represents intermediate state of the registry on epoch change.
+    struct IntermediateStateOfEpochChange {
+        removed_tasks: vector<u64>,
+        gas_committed_for_new_epoch: u256,
         gas_committed_for_next_epoch: u64,
         epoch_locked_fees: Coin<SupraCoin>,
     }
@@ -683,7 +693,7 @@ module supra_framework::automation_registry {
         ).main_config;
 
         let current_time = timestamp::now_seconds();
-        let (new_epoch_tcmg, removed_tasks) = update_state_for_new_epoch(
+        let intermedate_state = update_state_for_new_epoch(
             automation_registry,
             refund_bookkeeping,
             &automation_registry_config,
@@ -698,48 +708,85 @@ module supra_framework::automation_registry {
 
         // If feature is not enabled then we are not charging and tasks are cleared.
         if (!features::supra_native_automation_enabled()) {
-            automation_registry.gas_committed_for_next_epoch = 0;
-            automation_registry.epoch_locked_fees = 0;
-            automation_registry.gas_committed_for_this_epoch = 0;
-            automation_registry.epoch_active_task_ids = vector[];
-            safe_deposit_refund_all(automation_registry, refund_bookkeeping);
-            vector::append(&mut removed_tasks, enumerable_map::get_map_list(&automation_registry.tasks));
-            event::emit(RemovedTasks { task_indexes:  removed_tasks });
-            enumerable_map::clear(&mut automation_registry.tasks);
-
-            automation_epoch_info.start_time = current_time;
-            automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+            finalize_epoch_change_for_feature_disabled_state(
+                automation_registry,
+                automation_epoch_info,
+                refund_bookkeeping,
+                current_time,
+                intermedate_state);
             return
         };
 
-
-        let IntermediateState {
-            gas_committed_for_next_epoch,
-            epoch_locked_fees,
-            removed_task_ids,
-        } = try_withdraw_task_automation_fees(
+        try_withdraw_task_automation_fees(
             automation_registry,
             refund_bookkeeping,
             &automation_registry_config,
             automation_epoch_info.epoch_interval,
             current_time,
-            new_epoch_tcmg,
-            removed_tasks,
+            &mut intermedate_state,
         );
+
+        finalize_epoch_change(automation_registry, automation_epoch_info, current_time, intermedate_state);
+    }
+
+    fun finalize_epoch_change(
+        automation_registry: &mut AutomationRegistry,
+        automation_epoch_info: &mut AutomationEpochInfo,
+        current_time: u64,
+        intermediate_state: IntermediateStateOfEpochChange
+    ) {
+        let IntermediateStateOfEpochChange {
+            gas_committed_for_new_epoch,
+            gas_committed_for_next_epoch,
+            epoch_locked_fees,
+            removed_tasks,
+        } = intermediate_state;
 
         let epoch_locked_fees_value = coin::value(&epoch_locked_fees);
         coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
 
         automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
         automation_registry.epoch_locked_fees = epoch_locked_fees_value;
-        automation_registry.gas_committed_for_this_epoch = new_epoch_tcmg;
+        automation_registry.gas_committed_for_this_epoch = gas_committed_for_new_epoch;
         automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;
         automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
         event::emit(RemovedTasks {
-            task_indexes: removed_task_ids
+            task_indexes: removed_tasks
         });
+    }
+
+    fun finalize_epoch_change_for_feature_disabled_state(
+        automation_registry: &mut AutomationRegistry,
+        automation_epoch_info: &mut AutomationEpochInfo,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        current_time: u64,
+        intermediate_state: IntermediateStateOfEpochChange
+    ) {
+        let IntermediateStateOfEpochChange {
+            gas_committed_for_new_epoch: _,
+            gas_committed_for_next_epoch: _,
+            epoch_locked_fees,
+            removed_tasks,
+        } = intermediate_state;
+
+        destroy_zero(epoch_locked_fees);
+
+        automation_registry.gas_committed_for_next_epoch = 0;
+        automation_registry.epoch_locked_fees = 0;
+        automation_registry.gas_committed_for_this_epoch = 0;
+        automation_registry.epoch_active_task_ids = vector[];
+
+        safe_deposit_refund_all(automation_registry, refund_bookkeeping);
+        vector::append(
+            &mut removed_tasks,
+            enumerable_map::get_map_list(&automation_registry.tasks));
+        event::emit(RemovedTasks { task_indexes: removed_tasks });
+        enumerable_map::clear(&mut automation_registry.tasks);
+
+        automation_epoch_info.start_time = current_time;
+        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
     }
 
     /// Checks all tasks for refunds, cancellation and expirations.
@@ -750,7 +797,7 @@ module supra_framework::automation_registry {
         arc: &AutomationRegistryConfig,
         aei: &AutomationEpochInfo,
         current_time: u64
-    ): (u256, vector<u64>) {
+    ): IntermediateStateOfEpochChange {
         let previous_epoch_duration = current_time - aei.start_time;
         let refund_interval = 0;
         let refund_automation_fee_per_sec = 0;
@@ -786,7 +833,7 @@ module supra_framework::automation_registry {
         arc: &AutomationRegistryConfig,
         refund_automation_fee_per_sec: u256,
         refund_interval: u64,
-    ): (u256, vector<u64>) {
+    ): IntermediateStateOfEpochChange {
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let tcmg = 0;
         let removed_tasks = vector[];
@@ -832,7 +879,12 @@ module supra_framework::automation_registry {
                 tcmg = tcmg + (task.max_gas_amount as u256);
             }
         });
-        (tcmg, removed_tasks)
+        IntermediateStateOfEpochChange {
+            removed_tasks,
+            gas_committed_for_new_epoch: tcmg,
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: coin::zero(),
+        }
     }
 
     /// Cleans up expired and canclelled tasks and activates the pending tasks.
@@ -842,7 +894,7 @@ module supra_framework::automation_registry {
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         current_time: u64
-    ): (u256, vector<u64>) {
+    ): IntermediateStateOfEpochChange {
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let tcmg = 0;
         let removed_tasks = vector[];
@@ -870,7 +922,13 @@ module supra_framework::automation_registry {
                 tcmg = tcmg + (task.max_gas_amount as u256);
             }
         });
-        (tcmg, removed_tasks)
+
+        IntermediateStateOfEpochChange {
+            removed_tasks,
+            gas_committed_for_new_epoch: tcmg,
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: coin::zero(),
+        }
     }
 
     /// Traverses through all existing tasks and refunds deposited fee upon registration fully.
@@ -1152,16 +1210,13 @@ module supra_framework::automation_registry {
         arc: &AutomationRegistryConfig,
         epoch_interval: u64,
         current_time: u64,
-        tcmg: u256,
-        removed_tasks: vector<u64>
-    ): IntermediateState {
-        let intermediate_state = IntermediateState {
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: coin::zero<SupraCoin>(),
-            removed_task_ids: removed_tasks,
-        };
+        intermediate_state: &mut IntermediateStateOfEpochChange,
+    ) {
         // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(arc, tcmg, arc.registry_max_gas_cap);
+        let automation_fee_per_sec = calculate_automation_fee_multipler_for_epoch(
+            arc,
+            intermediate_state.gas_committed_for_new_epoch,
+            arc.registry_max_gas_cap);
 
         let task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let resource_signer = account::create_signer_with_capability(
@@ -1190,10 +1245,9 @@ module supra_framework::automation_registry {
                 &resource_signer,
                 task,
                 current_epoch_end_time,
-                &mut intermediate_state
+                intermediate_state
             );
         });
-        intermediate_state
     }
 
     fun try_withdraw_task_automation_fee(
@@ -1202,7 +1256,7 @@ module supra_framework::automation_registry {
         resource_signer: &signer,
         task: AutomationTaskFeeMeta,
         current_epoch_end_time: u64,
-        intermediate_state: &mut IntermediateState) {
+        intermediate_state: &mut IntermediateStateOfEpochChange) {
         // Remove the automation task if the epoch fee cap is exceeded
         if (task.fee > task.automation_fee_cap) {
             safe_deposit_refund(
@@ -1215,7 +1269,7 @@ module supra_framework::automation_registry {
                 task.locked_deposit_fee
             );
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
-            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
+            vector::push_back(&mut intermediate_state.removed_tasks, task.task_index);
             event::emit(TaskCancelledCapacitySurpassed {
                 task_index: task.task_index,
                 owner: task.owner,
@@ -1230,7 +1284,7 @@ module supra_framework::automation_registry {
             // and emit an event
             safe_unlock_locked_deposit(refund_bookkeeping, task.locked_deposit_fee, task.task_index);
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
-            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
+            vector::push_back(&mut intermediate_state.removed_tasks, task.task_index);
             event::emit(TaskCancelledInsufficentBalance {
                 task_index: task.task_index,
                 owner: task.owner,
@@ -1883,9 +1937,23 @@ module supra_framework::automation_registry {
         assert!(current_balance == expected_balance, current_balance);
     }
 
-
     #[test_only]
+    fun consume_intermediate_state(
+        intermediate_state: IntermediateStateOfEpochChange,
+    ) {
+        let IntermediateStateOfEpochChange {
+            gas_committed_for_new_epoch: _,
+            gas_committed_for_next_epoch: _,
+            epoch_locked_fees,
+            removed_tasks: _,
+        } = intermediate_state;
+
+        destroy_zero(epoch_locked_fees);
+    }
+
     /// Represents the fee charged for an automation task execution and some additional information.
+    /// Used only in tests, substituted with AutomationTaskFeeMeta in production code.
+    /// Kept for backward compatible framework upgrade.
     struct AutomationTaskFee has drop {
         task_index: u64,
         owner: address,
@@ -2816,7 +2884,8 @@ module supra_framework::automation_registry {
             let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
             let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
             let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-            update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+            let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+            consume_intermediate_state(result);
             // If there is no locked fee, nothing to refund;
             // tasks only will be charged for the next epoch.
             check_account_balance(user_address, expected_user_current_balance);
@@ -2837,7 +2906,8 @@ module supra_framework::automation_registry {
             let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
             let aei = borrow_global<AutomationEpochInfo>(fwk_address);
 
-            update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+            let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+            consume_intermediate_state(result);
 
             check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
@@ -2848,7 +2918,8 @@ module supra_framework::automation_registry {
             // Refund is expected only for ACTIVE AND CANCELLED TASK BUT NOT FOR PENDING
             update_task_state(ar, task3, PENDING);
             update_task_state(ar, task2, CANCELLED);
-            update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+            let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+            consume_intermediate_state(result);
             // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
             let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task
                 + automation_fee_cap; // refund of the depodit for cancelled task
@@ -2865,13 +2936,14 @@ module supra_framework::automation_registry {
             // If epoch duration surpasses tasks expiration time, then they are refunded on  locked deposit, and removed from registry.
             // even pending task.
             update_task_state(ar, task3, PENDING);
-            update_state_for_new_epoch(
+            let result = update_state_for_new_epoch(
                 ar,
                 refund_bookkeeping,
                 arc,
                 aei,
                 task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS
             );
+            consume_intermediate_state(result);
             let expected_refund = 2 * automation_fee_cap; // refund of the depodit for both available tasks
 
             expected_user_current_balance = expected_user_current_balance + expected_refund;
@@ -2947,7 +3019,8 @@ module supra_framework::automation_registry {
         check_account_balance(user_address, expected_user_current_balance);
         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
 
-        update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, current_time);
+        let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, current_time);
+        consume_intermediate_state(result);
         // It is expected that the tasks will be chared only for 1/2 epoch fee, so if the epoch lenght is 1/4,
         // then refund should be 1/4.
         // as account has 2 tasks with same automation and congestion fees then refund is double

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -7,6 +7,7 @@ module supra_framework::automation_registry {
     use std::signer;
     use std::vector;
     use aptos_std::math64;
+    use supra_framework::coin::Coin;
 
     use supra_std::enumerable_map::{Self, EnumerableMap};
 
@@ -99,6 +100,13 @@ module supra_framework::automation_registry {
     const ACTIVE: u8 = 1;
     const CANCELLED: u8 = 2;
 
+    /// Constants describing REFUND TYPE
+    const DEPOSIT_EPOCH_FEE: u8 = 0;
+    const EPOCH_FEE: u8 = 1;
+
+    /// Defines refund factor for refunds of deposit fees with penalty
+    const REFUND_FACTOR: u64 = 2;
+
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     struct ActiveAutomationRegistryConfig has key {
         main_config: AutomationRegistryConfig,
@@ -172,6 +180,15 @@ module supra_framework::automation_registry {
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
+    /// Automation Deposited fee bookkeeping configs
+    struct AutomationRefundBookkeeping has key, copy {
+        /// Total deposited fee so far which is locked in resource account unless refund of it (fully or partially) is done.
+        /// Independent of refund amount the actual deposited amount is deduced to unlock it from resource account.
+        total_deposited_automation_fee: u64
+        // TODO here we can have also configuration parameter like REFUND_FACTOR
+    }
+
+    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     #[event]
     /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
     struct AutomationTaskMetaData has key, copy, store, drop {
@@ -211,6 +228,15 @@ module supra_framework::automation_registry {
     }
 
     #[event]
+    /// Event on task registration fee withdrawal from owner account upon registration.
+    struct TaskRegistrationDepositFeeWithdraw has drop, store {
+        task_index: u64,
+        owner: address,
+        registration_fee: u64,
+        deposit_epoch_fee: u64,
+    }
+
+    #[event]
     /// Emitted on withdrawal of specified amount from automation registry fee address to the specified address.
     struct RegistryFeeWithdraw has drop, store {
         to: address,
@@ -241,6 +267,15 @@ module supra_framework::automation_registry {
         task_index: u64,
         owner: address,
         amount: u64,
+    }
+
+    #[event]
+    /// Event emitted when an automation fee is refunded but inner state bookkeeping total locked deposits is less than
+    /// potential locked deposit which is being refunded fully or partially
+    struct ErrorUnlockTaskDepositFee has drop, store {
+        task_index: u64,
+        total_registered_deposit: u64,
+        potential_locked_deposit: u64
     }
 
     #[event]
@@ -281,6 +316,12 @@ module supra_framework::automation_registry {
     }
 
     #[event]
+    /// Event emitted when an automation task is cancelled due to automation fee capacity surpass.
+    struct RemovedTasks has drop, store {
+        task_indexes: vector<u64>
+    }
+
+    #[event]
     /// Event emitted when on new epoch a task is accessed with index of the task for the expected list
     /// but value does not exist in the map
     struct ErrorTaskDoesNotExist has drop, store {
@@ -292,6 +333,16 @@ module supra_framework::automation_registry {
     /// but it does not exist in the list.
     struct ErrorTaskDoesNotExistForWithdrawal has drop, store {
         task_index: u64,
+    }
+
+    #[event]
+    /// Event emitted when on new epoch refunds to be paied is not possible due to insufficient resource account balance.
+    /// Type of the refund can be either depoit payed during registration (0), or caused by the shortenting of the epoch (1)
+    struct ErrorInsufficientBalanceToRefund has drop, store {
+        refund_type: u8,
+        task_index: u64,
+        owner: address,
+        amount: u64,
     }
 
     #[event]
@@ -322,13 +373,27 @@ module supra_framework::automation_registry {
 
     /// Represents intermediate state of the registry on epoch change.
     struct IntermediateState has drop {
-        active_task_ids: vector<u64>,
+        removed_task_ids: vector<u64>,
         gas_committed_for_next_epoch: u64,
         epoch_locked_fees: u64,
     }
 
-    fun active_task_ids(intermediate_state: IntermediateState): vector<u64> {
-        intermediate_state.active_task_ids
+    /// Represents intermediate state of the registry on epoch change.
+    struct IntermediateStateWithCoins {
+        removed_task_ids: vector<u64>,
+        gas_committed_for_next_epoch: u64,
+        epoch_locked_fees: Coin<SupraCoin>,
+    }
+
+    fun deposit_epoch_fee_to_registry_fee_address(automation_registry: &AutomationRegistry, value: IntermediateStateWithCoins) {
+        let IntermediateStateWithCoins {
+            removed_task_ids: _,
+            gas_committed_for_next_epoch: _,
+            epoch_locked_fees,
+
+        } = value;
+        coin::deposit(automation_registry.registry_fee_address, coin::extract_all(&mut epoch_locked_fees));
+        coin::destroy_zero(epoch_locked_fees)
     }
 
     #[view]
@@ -367,10 +432,23 @@ module supra_framework::automation_registry {
     }
 
     #[view]
-    /// Get locked balance of the resource account
+    /// Get locked balance of the resource account in terms of epoch-fees
     public fun get_epoch_locked_balance(): u64 acquires AutomationRegistry {
         let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
         automation_registry.epoch_locked_fees
+    }
+
+    #[view]
+    /// Get locked balance of the resource account in terms of deposited automation fees.
+    public fun get_locked_deposite_balance(): u64 acquires AutomationRefundBookkeeping {
+        let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(@supra_framework);
+        refund_bookkeeping.total_deposited_automation_fee
+    }
+
+    #[view]
+    /// Get total locked balance of the resource account.
+    public fun get_registry_total_locked_balance(): u64 acquires AutomationRefundBookkeeping, AutomationRegistry {
+        get_epoch_locked_balance() + get_locked_deposite_balance()
     }
 
     #[view]
@@ -584,10 +662,18 @@ module supra_framework::automation_registry {
             epoch_interval: epoch_interval_secs,
             start_time: 0,
         });
+
+        initialize_refund_bookkeeping_resource(supra_framework)
+    }
+
+    public fun initialize_refund_bookkeeping_resource(supra_framework: &signer) {
+        move_to(supra_framework, AutomationRefundBookkeeping {
+            total_deposited_automation_fee: 0
+        });
     }
 
     /// On new epoch this function will be triggered and update the automation registry state
-    public(friend) fun on_new_epoch() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    public(friend) fun on_new_epoch() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Unless registry in initialized, registry will not be updated on new epoch.
         // Here we need to be careful as well. If the feature is disabled for the current epoch then
         //  - refund for the previous epoch should be done if any charges has been done.
@@ -598,6 +684,7 @@ module supra_framework::automation_registry {
         };
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let automation_epoch_info = borrow_global_mut<AutomationEpochInfo>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
 
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(
             @supra_framework
@@ -623,6 +710,10 @@ module supra_framework::automation_registry {
             automation_registry.epoch_locked_fees = 0;
             automation_registry.gas_committed_for_this_epoch = 0;
             automation_registry.epoch_active_task_ids = vector[];
+            safe_deposit_refund_all(automation_registry, refund_bookkeeping);
+            event::emit(RemovedTasks {
+                task_indexes: enumerable_map::get_map_list(&automation_registry.tasks)
+            });
             enumerable_map::clear(&mut automation_registry.tasks);
 
             automation_epoch_info.start_time = current_time;
@@ -631,7 +722,7 @@ module supra_framework::automation_registry {
         };
 
         // Accumulated maximum gas amount of the registered tasks for the current epoch
-        let tcmg = cleanup_and_activate_tasks(automation_registry, current_time);
+        let (tcmg, removed_tasks) = cleanup_and_activate_tasks(automation_registry, refund_bookkeeping, current_time);
 
 
         let tasks_automation_fees = calculate_tasks_automation_fees(
@@ -643,20 +734,34 @@ module supra_framework::automation_registry {
             false
         );
 
-        let intermediate_state = try_withdraw_task_automation_fees(
+        let intermediate_state = IntermediateState {
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: 0,
+            removed_task_ids: removed_tasks,
+        };
+        let IntermediateState {
+            gas_committed_for_next_epoch,
+            epoch_locked_fees,
+            removed_task_ids
+        } = try_withdraw_task_automation_fees(
             automation_registry,
+            refund_bookkeeping,
             tasks_automation_fees,
             current_time,
-            automation_epoch_info.epoch_interval
+            automation_epoch_info.epoch_interval,
+            intermediate_state
         );
 
-        automation_registry.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
-        automation_registry.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+        automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
+        automation_registry.epoch_locked_fees = epoch_locked_fees;
         automation_registry.gas_committed_for_this_epoch = tcmg;
         automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;
         automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+        event::emit(RemovedTasks {
+            task_indexes: removed_task_ids
+        });
     }
 
     /// Adjusts task fees and processes refunds when there's a change in epoch duration.
@@ -698,20 +803,21 @@ module supra_framework::automation_registry {
         tasks_automation_refund_fees: vector<AutomationTaskFee>
     ) {
         let resource_signer = account::create_signer_with_capability(resource_signer_cap);
+        let resource_adderss= signer::address_of(&resource_signer);
 
         vector::for_each(tasks_automation_refund_fees, |task| {
             let task: AutomationTaskFee = task;
             if (task.fee != 0) {
-                coin::transfer<SupraCoin>(&resource_signer, task.owner, task.fee);
-                event::emit(TaskFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.fee });
+                safe_fee_refund(&resource_signer, resource_adderss, task.task_index, task.owner, task.fee);
             }
         });
     }
 
     /// Cleanup and activate the automation task also it's calculate and return total committed max gas
-    fun cleanup_and_activate_tasks(automation_registry: &mut AutomationRegistry, current_time: u64): u256 {
+    fun cleanup_and_activate_tasks(automation_registry: &mut AutomationRegistry, refund_bookkeeping: &mut AutomationRefundBookkeeping, current_time: u64): (u256, vector<u64>) {
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let tcmg = 0;
+        let removed_tasks = vector[];
 
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
@@ -725,23 +831,28 @@ module supra_framework::automation_registry {
 
                 // Drop or activate task for this current epoch.
                 if (task.expiry_time <= current_time || task.state == CANCELLED) {
-                    coin::transfer<SupraCoin>(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-                    event::emit(
-                        TaskFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
-                    );
+                    safe_deposit_refund(
+                        refund_bookkeeping,
+                        &resource_signer,
+                        automation_registry.registry_fee_address,
+                        task.task_index,
+                        task.owner,
+                        task.locked_fee_for_next_epoch,
+                    task.locked_fee_for_next_epoch);
                     enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+                    vector::push_back(&mut removed_tasks, task_index);
                 } else {
                     task.state = ACTIVE;
                     tcmg = tcmg + (task.max_gas_amount as u256);
                 }
             }
         });
-        tcmg
+        (tcmg, removed_tasks)
     }
 
     /// On new epoch this function will be triggered and update the automation registry state
     public(friend) fun on_new_epoch_2(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Unless registry in initialized, registry will not be updated on new epoch.
         // Here we need to be careful as well. If the feature is disabled for the current epoch then
         //  - refund for the previous epoch should be done if any charges has been done.
@@ -752,13 +863,16 @@ module supra_framework::automation_registry {
         };
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let automation_epoch_info = borrow_global_mut<AutomationEpochInfo>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
 
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(
             @supra_framework
         ).main_config;
 
         let current_time = timestamp::now_seconds();
-        let new_epoch_tcmg = update_state_for_new_epoch(automation_registry,
+        let (new_epoch_tcmg, removed_tasks) = update_state_for_new_epoch(
+            automation_registry,
+            refund_bookkeeping,
             &automation_registry_config,
             automation_epoch_info,
             current_time
@@ -775,7 +889,10 @@ module supra_framework::automation_registry {
             automation_registry.epoch_locked_fees = 0;
             automation_registry.gas_committed_for_this_epoch = 0;
             automation_registry.epoch_active_task_ids = vector[];
-            // TODO before cleaning refund locked automation fee deposit
+            safe_deposit_refund_all(automation_registry, refund_bookkeeping);
+            event::emit(RemovedTasks {
+                task_indexes: enumerable_map::get_map_list(&automation_registry.tasks)
+            });
             enumerable_map::clear(&mut automation_registry.tasks);
 
             automation_epoch_info.start_time = current_time;
@@ -783,32 +900,47 @@ module supra_framework::automation_registry {
             return
         };
 
+        let intermediate_state_with_coins = IntermediateStateWithCoins {
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: coin::zero<SupraCoin>(),
+            removed_task_ids: removed_tasks,
+        };
 
-        let intermediate_state = try_withdraw_task_automation_fees_2(
+        let IntermediateState {
+            gas_committed_for_next_epoch,
+            epoch_locked_fees,
+            removed_task_ids
+        } = try_withdraw_task_automation_fees_2(
             automation_registry,
+            refund_bookkeeping,
             &automation_registry_config,
             automation_epoch_info.epoch_interval,
             current_time,
             new_epoch_tcmg,
+            intermediate_state_with_coins
         );
 
-        automation_registry.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch;
-        automation_registry.epoch_locked_fees = intermediate_state.epoch_locked_fees;
+        automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
+        automation_registry.epoch_locked_fees = epoch_locked_fees;
         automation_registry.gas_committed_for_this_epoch = new_epoch_tcmg;
         automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
 
         automation_epoch_info.start_time = current_time;
         automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
+        event::emit(RemovedTasks {
+            task_indexes: removed_task_ids
+        });
     }
 
     /// Checks all tasks for refunds, cancellation and expirations.
     /// Cleans the stale tasks and calculates gas-committed for the new epoch.
     fun update_state_for_new_epoch(
         automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         arc: &AutomationRegistryConfig,
         aei: &AutomationEpochInfo,
         current_time: u64
-    ): u256 {
+    ): (u256, vector<u64>) {
         let previous_epoch_duration = current_time - aei.start_time;
         let refund_interval = 0;
         let refund_automation_fee_per_sec = 0;
@@ -821,63 +953,133 @@ module supra_framework::automation_registry {
             refund_automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
         };
 
-        let new_epoch_tcmg = if (refund_automation_fee_per_sec != 0) {
+        if (refund_automation_fee_per_sec != 0) {
             refund_cleanup_and_activate_tasks(
                 automation_registry,
+                refund_bookkeeping,
                 current_time,
                 arc,
                 refund_automation_fee_per_sec,
                 refund_interval)
         } else {
-            cleanup_and_activate_tasks(automation_registry, current_time)
-        };
-
-        new_epoch_tcmg
+            cleanup_and_activate_tasks(automation_registry, refund_bookkeeping, current_time)
+        }
     }
 
 
     /// Refund, Cleanup and activate the automation task also it's calculate and return total committed max gas
     fun refund_cleanup_and_activate_tasks(
         automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         current_time: u64,
         arc: &AutomationRegistryConfig,
         refund_automation_fee_per_sec: u256,
         refund_interval: u64,
-    ): u256 {
+    ): (u256, vector<u64>) {
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
         let tcmg = 0;
+        let removed_tasks = vector[];
 
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
         );
 
         vector::for_each(ids, |task_index| {
-            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                event::emit(ErrorTaskDoesNotExist { task_index })
-            } else {
-                let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
-                if (task.state != PENDING) {
-                    let refund = calculate_task_fee(arc, task,
-                        refund_interval, current_time, refund_automation_fee_per_sec);
-                    coin::transfer<SupraCoin>(&resource_signer, task.owner, refund);
-                    event::emit(TaskFeeRefund { task_index: task.task_index, owner: task.owner, amount: refund });
-                };
+            let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+            if (task.state != PENDING) {
+                let refund = calculate_task_fee(arc, task,
+                    refund_interval, current_time, refund_automation_fee_per_sec);
+                safe_fee_refund(
+                    &resource_signer,
+                    automation_registry.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    refund);
+            };
 
-                // Drop or activate task for this current epoch.
-                if (task.state == CANCELLED || task.expiry_time <= current_time) {
-                    // Refund deposited epoch-fee for cancelled and expired tasks.
-                    coin::transfer<SupraCoin>(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-                    event::emit(
-                        TaskDepositFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
-                    );
-                    enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-                } else {
-                    task.state = ACTIVE;
-                    tcmg = tcmg + (task.max_gas_amount as u256);
-                }
+            // Drop or activate task for this current epoch.
+            if (task.state == CANCELLED || task.expiry_time <= current_time) {
+                // Refund deposited epoch-fee for cancelled and expired tasks.
+                safe_deposit_refund(
+                    refund_bookkeeping,
+                    &resource_signer,
+                    automation_registry.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch);
+                enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+                vector::push_back(&mut removed_tasks, task_index);
+            } else {
+                task.state = ACTIVE;
+                tcmg = tcmg + (task.max_gas_amount as u256);
             }
         });
-        tcmg
+        (tcmg, removed_tasks)
+    }
+
+    fun safe_refund(resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_amount: u64, refund_type: u8):  bool {
+        let balance = coin::balance<SupraCoin>(resouce_address);
+        if (balance < refundable_amount) {
+            event::emit(
+                ErrorInsufficientBalanceToRefund { refund_type, task_index, owner: task_owner, amount: refundable_amount }
+            );
+            return false
+        };
+
+        coin::transfer<SupraCoin>(resource_signer, task_owner, refundable_amount);
+        return true
+    }
+
+    fun safe_deposit_refund(rb: &mut AutomationRefundBookkeeping, resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_deposit: u64, locked_deposit: u64):  bool {
+        let result = safe_refund(resource_signer, resouce_address, task_index, task_owner, refundable_deposit, DEPOSIT_EPOCH_FEE);
+        event::emit(
+            TaskDepositFeeRefund { task_index, owner: task_owner, amount: refundable_deposit }
+        );
+        if (result) {
+            safe_unlock_locked_deposit(rb, locked_deposit, task_index)
+        };
+        result
+    }
+
+    fun safe_unlock_locked_deposit(rb: &mut AutomationRefundBookkeeping, locked_deposit: u64, task_index: u64) {
+        if (rb.total_deposited_automation_fee > locked_deposit) {
+            rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
+        } else {
+            event::emit(
+                ErrorUnlockTaskDepositFee { total_registered_deposit: rb.total_deposited_automation_fee, potential_locked_deposit: locked_deposit, task_index }
+            );
+        }
+
+    }
+
+    fun safe_fee_refund(resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_fee: u64):  bool {
+        let result = safe_refund(resource_signer, resouce_address, task_index, task_owner, refundable_fee, EPOCH_FEE);
+        event::emit(
+            TaskFeeRefund { task_index, owner: task_owner, amount: refundable_fee }
+        );
+        result
+    }
+
+    fun safe_deposit_refund_all(automation_registry: &AutomationRegistry, refund_bookkeeping: &mut AutomationRefundBookkeeping) {
+        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        vector::for_each(ids, |task_index| {
+            let task = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
+
+            // Drop or activate task for this current epoch.
+            safe_deposit_refund(
+                refund_bookkeeping,
+                &resource_signer,
+                automation_registry.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+            task.locked_fee_for_next_epoch);
+        });
     }
 
     /// Calculates automation task fees for the active tasks for the provided interval with provided tcmg occupancy.
@@ -1030,15 +1232,12 @@ module supra_framework::automation_registry {
     /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
     fun try_withdraw_task_automation_fees(
         automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         tasks_automation_fees: vector<AutomationTaskFee>,
         current_time: u64,
         epoch_interval: u64,
+        intermediate_state: IntermediateState,
     ): IntermediateState {
-        let intermediate_state = IntermediateState {
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: 0,
-            active_task_ids: vector[]
-        };
 
         sort_by_task_index(&mut tasks_automation_fees);
 
@@ -1049,6 +1248,7 @@ module supra_framework::automation_registry {
             } else {
                 try_withdraw_task_automation_fee(
                     automation_registry,
+                    refund_bookkeeping,
                     task,
                     current_time,
                     epoch_interval,
@@ -1061,6 +1261,7 @@ module supra_framework::automation_registry {
 
     fun try_withdraw_task_automation_fee(
         automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         task: AutomationTaskFee,
         current_time: u64,
         epoch_interval: u64,
@@ -1072,11 +1273,17 @@ module supra_framework::automation_registry {
 
         // Remove the automation task if the epoch fee cap is exceeded
         if (task.fee > task_metadata.automation_fee_cap_for_epoch) {
-            coin::transfer<SupraCoin>(&resource_signer, task.owner, task_metadata.locked_fee_for_next_epoch);
-            event::emit(
-                TaskDepositFeeRefund { task_index: task.task_index, owner: task.owner, amount: task_metadata.locked_fee_for_next_epoch }
+            safe_deposit_refund(
+                refund_bookkeeping,
+                &resource_signer,
+                automation_registry.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task_metadata.locked_fee_for_next_epoch,
+                task_metadata.locked_fee_for_next_epoch
             );
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
             event::emit(TaskCancelledCapacitySurpassed {
                 task_index: task.task_index,
                 owner: task_metadata.owner,
@@ -1089,11 +1296,13 @@ module supra_framework::automation_registry {
         if (user_balance < task.fee) {
             // If the user does not have enough balance, remove the task and emit an event
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
             event::emit(TaskCancelledInsufficentBalance {
                 task_index: task.task_index,
                 owner: task_metadata.owner,
                 fee: task.fee,
             });
+            safe_unlock_locked_deposit(refund_bookkeeping, task_metadata.locked_fee_for_next_epoch, task.task_index);
             return
         };
         if (task.fee != 0) {
@@ -1125,70 +1334,80 @@ module supra_framework::automation_registry {
     /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
     fun try_withdraw_task_automation_fees_2(
         automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         arc: &AutomationRegistryConfig,
         epoch_interval: u64,
         current_time: u64,
         tcmg: u256,
+        intermediate_state_with_coins: IntermediateStateWithCoins
     ): IntermediateState {
-        let intermediate_state = IntermediateState {
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: 0,
-            active_task_ids: vector[]
-        };
         // Compute the automation congestion fee (acf) for the epoch
         let acf = calculate_automation_congestion_fee(arc, tcmg, arc.registry_max_gas_cap);
         let automation_fee_per_sec = acf + (arc.automation_base_fee_in_quants_per_sec as u256);
         let task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
 
         // Sort task indexes to charge autoamtion fees in the tasks chronological order
         sort(&mut task_ids);
 
         // Process each active task and calculate fee for the epoch for the tasks
         vector::for_each(task_ids, |task_index| {
-            if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                event::emit(ErrorTaskDoesNotExistForWithdrawal { task_index })
-            } else {
-                let task_meta = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
-                let task = AutomationTaskFeeMeta {
-                    task_index,
-                    owner: task_meta.owner,
-                    fee: 0,
-                    expiry_time: task_meta.expiry_time,
-                    automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                    max_gas_amount: task_meta.max_gas_amount,
-                    locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
-                };
-                if (automation_fee_per_sec != 0) {
-                    task.fee = calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
-                };
-                try_withdraw_task_automation_fee_2(
-                    automation_registry,
-                    task,
-                    current_time,
-                    epoch_interval,
-                    &mut intermediate_state
-                );
+            let task_meta = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
+            let task = AutomationTaskFeeMeta {
+                task_index,
+                owner: task_meta.owner,
+                fee: 0,
+                expiry_time: task_meta.expiry_time,
+                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                max_gas_amount: task_meta.max_gas_amount,
+                locked_fee_for_next_epoch: task_meta.locked_fee_for_next_epoch,
             };
+            if (automation_fee_per_sec != 0) {
+                task.fee = calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+            };
+            try_withdraw_task_automation_fee_2(
+                automation_registry,
+                refund_bookkeeping,
+                &resource_signer,
+                task,
+                current_time,
+                epoch_interval,
+                &mut intermediate_state_with_coins
+            );
         });
+        let intermediate_state = IntermediateState {
+            gas_committed_for_next_epoch: intermediate_state_with_coins.gas_committed_for_next_epoch,
+            epoch_locked_fees: coin::value(&intermediate_state_with_coins.epoch_locked_fees),
+            removed_task_ids: intermediate_state_with_coins.removed_task_ids
+        };
+
+        deposit_epoch_fee_to_registry_fee_address(automation_registry, intermediate_state_with_coins);
         intermediate_state
     }
 
     fun try_withdraw_task_automation_fee_2(
         automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        resource_signer: &signer,
         task: AutomationTaskFeeMeta,
         current_time: u64,
         epoch_interval: u64,
-        intermediate_state: &mut IntermediateState) {
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
+        intermediate_state: &mut IntermediateStateWithCoins) {
         // Remove the automation task if the epoch fee cap is exceeded
         if (task.fee > task.automation_fee_cap) {
-            coin::transfer<SupraCoin>(&resource_signer, task.owner, task.locked_fee_for_next_epoch);
-            event::emit(
-                TaskDepositFeeRefund { task_index: task.task_index, owner: task.owner, amount: task.locked_fee_for_next_epoch }
+            safe_deposit_refund(
+                refund_bookkeeping,
+                resource_signer,
+                automation_registry.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch
             );
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
             event::emit(TaskCancelledCapacitySurpassed {
                 task_index: task.task_index,
                 owner: task.owner,
@@ -1201,28 +1420,29 @@ module supra_framework::automation_registry {
         if (user_balance < task.fee) {
             // If the user does not have enough balance, remove the task and emit an event
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
+            vector::push_back(&mut intermediate_state.removed_task_ids, task.task_index);
             event::emit(TaskCancelledInsufficentBalance {
                 task_index: task.task_index,
                 owner: task.owner,
                 fee: task.fee,
             });
+            safe_unlock_locked_deposit(refund_bookkeeping, task.locked_fee_for_next_epoch, task.task_index);
             return
         };
         if (task.fee != 0) {
             // Charge the fee and emit a success event
-            coin::transfer<SupraCoin>(
+            let withdrawn_coins = coin::withdraw<SupraCoin>(
                 &create_signer(task.owner),
-                automation_registry.registry_fee_address,
                 task.fee
             );
+            // Merge to total task fees deducted from the users account
+            coin::merge(&mut intermediate_state.epoch_locked_fees, withdrawn_coins);
         };
         event::emit(TaskEpochFeeWithdraw {
             task_index: task.task_index,
             owner: task.owner,
             fee: task.fee,
         });
-        // Total task fees deducted from the user's account
-        intermediate_state.epoch_locked_fees = intermediate_state.epoch_locked_fees + task.fee;
 
         // Calculate gas commitment for the next epoch only for valid active tasks
         if (task.expiry_time > (current_time + epoch_interval)) {
@@ -1253,20 +1473,23 @@ module supra_framework::automation_registry {
         supra_framework: &signer,
         to: address,
         amount: u64
-    ) acquires AutomationRegistry {
+    ) acquires AutomationRegistry , AutomationRefundBookkeeping {
         system_addresses::assert_supra_framework(supra_framework);
         transfer_fee_to_account_internal(to, amount);
         event::emit(RegistryFeeWithdraw { to, amount });
     }
 
     /// Transfers the specified fee amount from the resource account to the target account.
-    fun transfer_fee_to_account_internal(to: address, amount: u64) acquires AutomationRegistry {
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+    fun transfer_fee_to_account_internal(to: address, amount: u64) acquires AutomationRegistry, AutomationRefundBookkeeping {
+        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
+        let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(@supra_framework);
         let resource_balance = coin::balance<SupraCoin>(automation_registry.registry_fee_address);
 
         assert!(resource_balance >= amount, EINSUFFICIENT_BALANCE);
 
-        assert!((resource_balance - amount) >= automation_registry.epoch_locked_fees, EREQUEST_EXCEEDS_LOCKED_BALANCE);
+        assert!((resource_balance - amount) >=
+            automation_registry.epoch_locked_fees +
+                refund_bookkeeping.total_deposited_automation_fee, EREQUEST_EXCEEDS_LOCKED_BALANCE);
 
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
@@ -1348,7 +1571,7 @@ module supra_framework::automation_registry {
         automation_fee_cap_for_epoch: u64,
         tx_hash: vector<u8>,
         aux_data: vector<vector<u8>>
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Guarding registration if feature is not enabled.
         assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
         assert!(vector::is_empty(&aux_data), ENO_AUX_DATA_SUPPORTED);
@@ -1396,6 +1619,7 @@ module supra_framework::automation_registry {
         automation_registry.gas_committed_for_next_epoch = committed_gas;
         let task_index = automation_registry.current_index;
 
+        let deposit_automtion_fee = automation_fee_cap_for_epoch;
         let automation_task_metadata = AutomationTaskMetaData {
             task_index,
             owner,
@@ -1408,17 +1632,26 @@ module supra_framework::automation_registry {
             state: PENDING,
             registration_time,
             tx_hash,
-            locked_fee_for_next_epoch: 0
+            locked_fee_for_next_epoch: deposit_automtion_fee
         };
 
         enumerable_map::add_value(&mut automation_registry.tasks, task_index, automation_task_metadata);
         automation_registry.current_index = automation_registry.current_index + 1;
 
-        // Charge flat registration fee from the user at the time of registration
-        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants;
+        // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
+        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + deposit_automtion_fee;
+
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + deposit_automtion_fee;
+
         coin::transfer<SupraCoin>(owner_signer, automation_registry.registry_fee_address, fee);
 
-        event::emit(TaskRegistrationFeeWithdraw { task_index, owner, fee });
+        event::emit(TaskRegistrationDepositFeeWithdraw {
+            task_index,
+            owner,
+            registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
+            deposit_epoch_fee: deposit_automtion_fee
+        });
         event::emit(automation_task_metadata);
     }
 
@@ -1449,8 +1682,9 @@ module supra_framework::automation_registry {
     public entry fun cancel_task(
         owner_signer: &signer,
         task_index: u64
-    ) acquires AutomationRegistry, AutomationEpochInfo {
+    ) acquires AutomationRegistry, AutomationEpochInfo , AutomationRefundBookkeeping{
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
         assert!(enumerable_map::contains(&automation_registry.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
 
         let automation_task_metadata = enumerable_map::get_value(&mut automation_registry.tasks, task_index);
@@ -1458,8 +1692,21 @@ module supra_framework::automation_registry {
         assert!(automation_task_metadata.owner == owner, EUNAUTHORIZED_TASK_OWNER);
         assert!(automation_task_metadata.state != CANCELLED, EALREADY_CANCELLED);
         if (automation_task_metadata.state == PENDING) {
+            let resource_signer = account::create_signer_with_capability(
+                &automation_registry.registry_fee_address_signer_cap
+            );
+            // When Pending tasks are cancelled, refund of the deposit fee is done with penalty
+            safe_deposit_refund(
+                refund_bookkeeping,
+                &resource_signer,
+                automation_registry.registry_fee_address,
+                automation_task_metadata.task_index,
+                owner,
+                automation_task_metadata.locked_fee_for_next_epoch / REFUND_FACTOR,
+            automation_task_metadata.locked_fee_for_next_epoch);
             enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
         } else if (automation_task_metadata.state == ACTIVE) {
+            // Active tasks will be refunded at the end of the epoch
             let automation_task_metadata_mut = enumerable_map::get_value_mut(
                 &mut automation_registry.tasks,
                 task_index
@@ -1600,14 +1847,13 @@ module supra_framework::automation_registry {
     /// Sorting vector implementation
     fun sort_by_task_index(v: &mut vector<AutomationTaskFee>) {
         let len = vector::length(v);
-        let i = 0;
+        let i = 1;
         while (i < len) {
-            let j = i + 1;
-            while (j < len) {
-                if (vector::borrow(v, i).task_index > vector::borrow(v, j).task_index) {
-                    vector::swap(v, i, j)
-                };
-                j = j + 1;
+            let j = i;
+            let to_be_sorted = vector::borrow(v, j).task_index;
+            while (j > 0 && to_be_sorted < vector::borrow(v, j - 1).task_index) {
+                vector::swap(v, j, j - 1);
+                j = j - 1;
             };
             i = i + 1;
         };
@@ -1616,14 +1862,13 @@ module supra_framework::automation_registry {
     /// Sorting vector implementation
     public fun sort(input: &mut vector<u64>) {
         let len = vector::length(input);
-        let i = 0;
+        let i = 1;
         while (i < len) {
-            let j = i + 1;
-            while (j < len) {
-                if (*vector::borrow(input, i) > *vector::borrow(input, j)) {
-                    vector::swap(input, i, j)
-                };
-                j = j + 1;
+            let j = i;
+            let to_be_sorted = *vector::borrow(input, j);
+            while (j > 0 && to_be_sorted < *vector::borrow(input, j - 1)) {
+                vector::swap(input, j, j - 1);
+                j = j - 1;
             };
             i = i + 1;
         };
@@ -1773,7 +2018,7 @@ module supra_framework::automation_registry {
         automation_fee_cap: u64,
         expiry_time: u64,
         state: u8,
-    ): u64 acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
+    ): u64 acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo, AutomationRefundBookkeeping {
         register(user,
             PAYLOAD,
             expiry_time,
@@ -1891,7 +2136,7 @@ module supra_framework::automation_registry {
     fun test_registry(
         supra_framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132";
@@ -1901,7 +2146,7 @@ module supra_framework::automation_registry {
 
     #[test]
     fun test_on_new_epoch_without_initialization(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Nothing will be attempted if the registry is not initialized.
         on_new_epoch()
     }
@@ -1911,7 +2156,7 @@ module supra_framework::automation_registry {
     fun test_registration_with_partial_initialization(
         supra_framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test_partially(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132";
@@ -1922,7 +2167,7 @@ module supra_framework::automation_registry {
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_update_config_success_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -1967,7 +2212,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EUNACCEPTABLE_AUTOMATION_GAS_LIMIT, location = Self)]
     fun check_automation_gas_limit_failed_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2077,7 +2322,7 @@ module supra_framework::automation_registry {
     fun check_task_registration(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2097,7 +2342,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_full_tasks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         update_config_for_tests(
             framework,
@@ -2145,7 +2390,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         timestamp::update_global_time_for_test_secs(50);
@@ -2165,7 +2410,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time_before_next_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2184,7 +2429,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time_surpassing_task_duration_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2202,7 +2447,7 @@ module supra_framework::automation_registry {
     fun check_registration_valid_expiry_time_matches_task_duration_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2221,7 +2466,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_gas_price_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2240,7 +2485,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_max_gas_amount(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2258,7 +2503,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_parent_hash(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2276,7 +2521,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_aux_data(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let new_param1 = vector[0u8, 1, 2];
         let aux_data = vector[new_param1];
@@ -2296,7 +2541,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_overflow_gas_limit(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2325,7 +2570,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_insufficient_automation_fee_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2342,7 +2587,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2401,7 +2646,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_cancellation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2492,7 +2737,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_non_existing_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo {
+    ) acquires AutomationRegistry, AutomationEpochInfo, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         cancel_task(user, 1);
@@ -2504,7 +2749,7 @@ module supra_framework::automation_registry {
         framework: &signer,
         user: &signer,
         user2: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2524,7 +2769,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2547,7 +2792,7 @@ module supra_framework::automation_registry {
     fun check_normal_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2583,7 +2828,7 @@ module supra_framework::automation_registry {
     fun check_congestion_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2622,7 +2867,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_refund(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
 
@@ -2721,10 +2966,10 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafb)]
-    fun check_automation_task_fee_refund_id_done_with_old_config(
+    fun check_automation_task_fee_refund_is_done_with_old_config(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         config_buffer::initialize(framework);
         let t1_t2_max_gas = 44_000_000;
@@ -2767,6 +3012,8 @@ module supra_framework::automation_registry {
         let expected_user_current_balance = ACCOUNT_BALANCE - 3 * FLAT_REGISTRATION_FEE_TEST;
         let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * FLAT_REGISTRATION_FEE_TEST;
 
+        let balance = coin::balance<SupraCoin>(signer::address_of(user));
+        assert!(balance == expected_user_current_balance, 11);
 
         // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
@@ -2809,7 +3056,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 11_000_000;
@@ -2923,7 +3170,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation_with_zero_multipliers(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 11_000_000;
@@ -3077,7 +3324,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_withdrawal_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 10_000_000;
@@ -3206,7 +3453,7 @@ module supra_framework::automation_registry {
     fun check_registry_fee_success_withdrawal(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry {
+    ) acquires AutomationRegistry, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         set_locked_fee(framework, 100_000_000);
         let withdraw_amount = 99_999_999;
@@ -3222,7 +3469,7 @@ module supra_framework::automation_registry {
     fun check_registry_fee_failed_withdrawal_locked_balance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry {
+    ) acquires AutomationRegistry, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         set_locked_fee(framework, 100_000_000);
         let withdraw_amount = REGISTRY_DEFAULT_BALANCE - 80_000_000;
@@ -3234,7 +3481,7 @@ module supra_framework::automation_registry {
     fun check_registry_fee_failed_withdrawal_insufficient_balance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry {
+    ) acquires AutomationRegistry, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let withdraw_amount = REGISTRY_DEFAULT_BALANCE + 1;
         withdraw_automation_task_fees(framework, address_of(user), withdraw_amount);
@@ -3308,7 +3555,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = ETASK_REGISTRATION_DISABLED, location = Self)]
     fun test_register_fails_when_registration_disabled(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         disable_registration(framework);
@@ -3325,11 +3572,11 @@ module supra_framework::automation_registry {
         );
     }
 
-    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[test(framework = @supra_framework, user = @0x1caff)]
     fun check_task_successful_stopped(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3468,7 +3715,7 @@ module supra_framework::automation_registry {
         framework: &signer,
         user: &signer,
         user2: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3487,7 +3734,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_stopped_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3512,7 +3759,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig , AutomationRefundBookkeeping{
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3581,49 +3828,18 @@ module supra_framework::automation_registry {
     }
 
     // Register 500 tasks to measure registration time/used-gas
-    #[test(framework = @supra_framework, user = @0x1cafe)]
-        fun check_task_registration_performance(
-            framework: &signer,
-            user: &signer
-        ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
-        initialize_registry_test(framework, user);
-        let count = 0;
-        while (count < 500) {
-            register(user,
-                PAYLOAD,
-                86400,
-                10000,
-                20,
-                1000000,
-                PARENT_HASH,
-                AUX_DATA
-            );
-            count = count + 1;
-        };
-
-        // No active task and committed gas for the next epoch is total of the all registered tasks
-        assert!(500 * 10000 == get_gas_committed_for_next_epoch(), 1);
-        let active_task_ids = get_active_task_ids();
-        assert!(active_task_ids == vector[], 1);
-    }
-
-    // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
-    // And run 3 epochs to check gas-used when
-    //  - full epoch passed
-    //  - 1/3 of epoch passed to simulate refund, but tasks are still active
-    //  - last epoch identifies all tasks are expired
-    #[test(framework = @supra_framework, user = @0x1cafe)]
-    fun check_task_activation_on_new_epoch_performance(
+    #[test_only]
+    fun task_registration_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let count = 0;
         let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
         while (count < 500) {
             register(user,
                 PAYLOAD,
-                exp_time,
+                exp_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS * (count / 2),
                 10000,
                 20,
                 1000000,
@@ -3637,6 +3853,28 @@ module supra_framework::automation_registry {
         assert!(10000 * 500 == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
         assert!(active_task_ids == vector[], 1);
+    }
+
+    // Register 500 tasks to measure registration time/used-gas
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_task_registration_performance(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        task_registration_performance(framework, user);
+    }
+
+    // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
+    // And run 3 epochs to check gas-used when
+    //  - full epoch passed
+    //  - 1/3 of epoch passed to simulate refund, but tasks are still active
+    //  - last epoch identifies all tasks are expired
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_task_activation_on_new_epoch_performance(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         on_new_epoch();
@@ -3657,27 +3895,8 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch_2_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
-        initialize_registry_test(framework, user);
-        let count = 0;
-        let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        while (count < 500) {
-            register(user,
-                PAYLOAD,
-                exp_time,
-                10000,
-                20,
-                1000000,
-                PARENT_HASH,
-                AUX_DATA
-            );
-            count = count + 1;
-        };
-
-        // No active task and committed gas for the next epoch is total of the all registered tasks
-        assert!(10000 * 500 == get_gas_committed_for_next_epoch(), 1);
-        let active_task_ids = get_active_task_ids();
-        assert!(active_task_ids == vector[], 1);
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         on_new_epoch_2();

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -189,6 +189,11 @@ module supra_framework::automation_registry {
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
+    struct ToggleNewEpoch has key, copy {
+        optimized: bool
+    }
+
+    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     #[event]
     /// `AutomationTaskMetaData` represents a single automation task item, containing metadata.
     struct AutomationTaskMetaData has key, copy, store, drop {
@@ -401,6 +406,8 @@ module supra_framework::automation_registry {
         exists<AutomationRegistry>(@supra_framework)
             && exists<AutomationEpochInfo>(@supra_framework)
             && exists<ActiveAutomationRegistryConfig>(@supra_framework)
+            && exists<AutomationRefundBookkeeping>(@supra_framework)
+        && exists<ToggleNewEpoch>(@supra_framework)
     }
 
     #[view]
@@ -661,6 +668,9 @@ module supra_framework::automation_registry {
             epoch_interval: epoch_interval_secs,
             start_time: 0,
         });
+        move_to(supra_framework, ToggleNewEpoch {
+            optimized: false,
+        });
 
         initialize_refund_bookkeeping_resource(supra_framework)
     }
@@ -671,8 +681,17 @@ module supra_framework::automation_registry {
         });
     }
 
+    public(friend) fun on_new_epoch() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping , ToggleNewEpoch{
+        let toggle_epoch_change = borrow_global<ToggleNewEpoch>(@supra_framework);
+        if (toggle_epoch_change.optimized) {
+            on_new_epoch_2()
+        } else {
+            on_new_epoch_old()
+        }
+
+    }
     /// On new epoch this function will be triggered and update the automation registry state
-    public(friend) fun on_new_epoch() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    public(friend) fun on_new_epoch_old() acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Unless registry in initialized, registry will not be updated on new epoch.
         // Here we need to be careful as well. If the feature is disabled for the current epoch then
         //  - refund for the previous epoch should be done if any charges has been done.
@@ -1546,6 +1565,13 @@ module supra_framework::automation_registry {
     }
 
     /// Enables the registration process in the automation registry.
+    public fun toggle_new_epoch(supra_framework: &signer, flag: bool) acquires ToggleNewEpoch {
+        system_addresses::assert_supra_framework(supra_framework);
+        let toggle_new_epoch = borrow_global_mut<ToggleNewEpoch>(@supra_framework);
+        toggle_new_epoch.optimized = flag;
+    }
+
+    /// Enables the registration process in the automation registry.
     public fun enable_registration(supra_framework: &signer) acquires ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
@@ -2148,7 +2174,7 @@ module supra_framework::automation_registry {
 
     #[test]
     fun test_on_new_epoch_without_initialization(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         // Nothing will be attempted if the registry is not initialized.
         on_new_epoch()
     }
@@ -2169,7 +2195,7 @@ module supra_framework::automation_registry {
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_update_config_success_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2589,7 +2615,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2648,7 +2674,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_cancellation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2771,7 +2797,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2794,7 +2820,7 @@ module supra_framework::automation_registry {
     fun check_normal_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2830,7 +2856,7 @@ module supra_framework::automation_registry {
     fun check_congestion_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2971,7 +2997,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_refund_is_done_with_old_config(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
         config_buffer::initialize(framework);
         let t1_t2_max_gas = 44_000_000;
@@ -3326,7 +3352,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_withdrawal_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 10_000_000;
@@ -3875,7 +3901,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, ToggleNewEpoch {
         task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -275,7 +275,7 @@ module supra_framework::automation_registry {
     struct ErrorUnlockTaskDepositFee has drop, store {
         task_index: u64,
         total_registered_deposit: u64,
-        potential_locked_deposit: u64
+        locked_deposit: u64
     }
 
     #[event]
@@ -336,8 +336,8 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted when on new epoch refunds to be paied is not possible due to insufficient resource account balance.
-    /// Type of the refund can be either depoit payed during registration (0), or caused by the shortenting of the epoch (1)
+    /// Event emitted when on new epoch refunds to be paid is not possible due to insufficient resource account balance.
+    /// Type of the refund can be either deposit paid during registration (0), or caused by the shortening of the epoch (1)
     struct ErrorInsufficientBalanceToRefund has drop, store {
         refund_type: u8,
         task_index: u64,
@@ -392,8 +392,7 @@ module supra_framework::automation_registry {
             epoch_locked_fees,
 
         } = value;
-        coin::deposit(automation_registry.registry_fee_address, coin::extract_all(&mut epoch_locked_fees));
-        coin::destroy_zero(epoch_locked_fees)
+        coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
     }
 
     #[view]
@@ -440,7 +439,7 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Get locked balance of the resource account in terms of deposited automation fees.
-    public fun get_locked_deposite_balance(): u64 acquires AutomationRefundBookkeeping {
+    public fun get_locked_deposit_balance(): u64 acquires AutomationRefundBookkeeping {
         let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(@supra_framework);
         refund_bookkeeping.total_deposited_automation_fee
     }
@@ -448,7 +447,7 @@ module supra_framework::automation_registry {
     #[view]
     /// Get total locked balance of the resource account.
     public fun get_registry_total_locked_balance(): u64 acquires AutomationRefundBookkeeping, AutomationRegistry {
-        get_epoch_locked_balance() + get_locked_deposite_balance()
+        get_epoch_locked_balance() + get_locked_deposit_balance()
     }
 
     #[view]
@@ -1018,8 +1017,8 @@ module supra_framework::automation_registry {
         (tcmg, removed_tasks)
     }
 
-    fun safe_refund(resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_amount: u64, refund_type: u8):  bool {
-        let balance = coin::balance<SupraCoin>(resouce_address);
+    fun safe_refund(resource_signer: &signer, resource_address: address, task_index: u64, task_owner: address, refundable_amount: u64, refund_type: u8):  bool {
+        let balance = coin::balance<SupraCoin>(resource_address);
         if (balance < refundable_amount) {
             event::emit(
                 ErrorInsufficientBalanceToRefund { refund_type, task_index, owner: task_owner, amount: refundable_amount }
@@ -1033,10 +1032,10 @@ module supra_framework::automation_registry {
 
     fun safe_deposit_refund(rb: &mut AutomationRefundBookkeeping, resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_deposit: u64, locked_deposit: u64):  bool {
         let result = safe_refund(resource_signer, resouce_address, task_index, task_owner, refundable_deposit, DEPOSIT_EPOCH_FEE);
-        event::emit(
-            TaskDepositFeeRefund { task_index, owner: task_owner, amount: refundable_deposit }
-        );
         if (result) {
+            event::emit(
+                TaskDepositFeeRefund { task_index, owner: task_owner, amount: refundable_deposit }
+            );
             safe_unlock_locked_deposit(rb, locked_deposit, task_index)
         };
         result
@@ -1047,7 +1046,7 @@ module supra_framework::automation_registry {
             rb.total_deposited_automation_fee = rb.total_deposited_automation_fee - locked_deposit;
         } else {
             event::emit(
-                ErrorUnlockTaskDepositFee { total_registered_deposit: rb.total_deposited_automation_fee, potential_locked_deposit: locked_deposit, task_index }
+                ErrorUnlockTaskDepositFee { total_registered_deposit: rb.total_deposited_automation_fee, locked_deposit, task_index }
             );
         }
 
@@ -1055,9 +1054,11 @@ module supra_framework::automation_registry {
 
     fun safe_fee_refund(resource_signer: &signer, resouce_address: address, task_index: u64, task_owner: address, refundable_fee: u64):  bool {
         let result = safe_refund(resource_signer, resouce_address, task_index, task_owner, refundable_fee, EPOCH_FEE);
-        event::emit(
-            TaskFeeRefund { task_index, owner: task_owner, amount: refundable_fee }
-        );
+        if (result) {
+            event::emit(
+                TaskFeeRefund { task_index, owner: task_owner, amount: refundable_fee }
+            );
+        };
         result
     }
 
@@ -1070,7 +1071,6 @@ module supra_framework::automation_registry {
         vector::for_each(ids, |task_index| {
             let task = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
 
-            // Drop or activate task for this current epoch.
             safe_deposit_refund(
                 refund_bookkeeping,
                 &resource_signer,
@@ -1619,7 +1619,7 @@ module supra_framework::automation_registry {
         automation_registry.gas_committed_for_next_epoch = committed_gas;
         let task_index = automation_registry.current_index;
 
-        let deposit_automtion_fee = automation_fee_cap_for_epoch;
+        let deposit_automation_fee = automation_fee_cap_for_epoch;
         let automation_task_metadata = AutomationTaskMetaData {
             task_index,
             owner,
@@ -1632,17 +1632,17 @@ module supra_framework::automation_registry {
             state: PENDING,
             registration_time,
             tx_hash,
-            locked_fee_for_next_epoch: deposit_automtion_fee
+            locked_fee_for_next_epoch: deposit_automation_fee
         };
 
         enumerable_map::add_value(&mut automation_registry.tasks, task_index, automation_task_metadata);
         automation_registry.current_index = automation_registry.current_index + 1;
 
         // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
-        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + deposit_automtion_fee;
+        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + deposit_automation_fee;
 
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + deposit_automtion_fee;
+        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + deposit_automation_fee;
 
         coin::transfer<SupraCoin>(owner_signer, automation_registry.registry_fee_address, fee);
 
@@ -1650,7 +1650,7 @@ module supra_framework::automation_registry {
             task_index,
             owner,
             registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
-            deposit_epoch_fee: deposit_automtion_fee
+            deposit_epoch_fee: deposit_automation_fee
         });
         event::emit(automation_task_metadata);
     }

--- a/aptos-move/framework/supra-stdlib/doc/enumerable_map.md
+++ b/aptos-move/framework/supra-stdlib/doc/enumerable_map.md
@@ -198,7 +198,7 @@ To create an empty enum map
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="enumerable_map.md#0x1_enumerable_map_new_map">new_map</a>&lt;K: <b>copy</b> + drop, V: store+drop+<b>copy</b>&gt;(): <a href="enumerable_map.md#0x1_enumerable_map_EnumerableMap">EnumerableMap</a>&lt;K, V&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="enumerable_map.md#0x1_enumerable_map_new_map">new_map</a>&lt;K: <b>copy</b> + drop, V: store + drop + <b>copy</b>&gt;(): <a href="enumerable_map.md#0x1_enumerable_map_EnumerableMap">EnumerableMap</a>&lt;K, V&gt; {
     <b>return</b> <a href="enumerable_map.md#0x1_enumerable_map_EnumerableMap">EnumerableMap</a>&lt;K, V&gt; { list: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;K&gt;(), map: <a href="../../aptos-stdlib/doc/table.md#0x1_table_new">table::new</a>&lt;K, <a href="enumerable_map.md#0x1_enumerable_map_Tuple">Tuple</a>&lt;V&gt;&gt;() }
 }
 </code></pre>

--- a/aptos-move/framework/supra-stdlib/sources/enumerable_map.move
+++ b/aptos-move/framework/supra-stdlib/sources/enumerable_map.move
@@ -35,9 +35,10 @@ module supra_std::enumerable_map {
     }
 
     /// To create an empty enum map
-    public fun new_map<K: copy + drop, V: store+drop+copy>(): EnumerableMap<K, V> {
+    public fun new_map<K: copy + drop, V: store + drop + copy>(): EnumerableMap<K, V> {
         return EnumerableMap<K, V> { list: vector::empty<K>(), map: table::new<K, Tuple<V>>() }
     }
+
 
     /// Add Single Key in the Enumerable Map
     public fun add_value<K: copy+drop, V: store+drop+copy>(map: &mut EnumerableMap<K, V>, key: K, value: V) {

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -34,7 +34,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         &pkg_path,
         build_config.clone(),
         // TODO(Gas): double check if this is correct
-        UnitTestingConfig::default_with_bound(Some(100_000)),
+        UnitTestingConfig::default_with_bound_and_statistics(Some(100_000_000)),
         aptos_test_natives(),
         aptos_test_feature_flags_genesis(),
         /* cost_table */ None,
@@ -52,7 +52,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         ok = run_move_unit_tests(
             &pkg_path,
             build_config,
-            UnitTestingConfig::default_with_bound(Some(100_000)),
+            UnitTestingConfig::default_with_bound_and_statistics(Some(100_000_000)),
             aptos_test_natives(),
             aptos_test_feature_flags_genesis(),
             /* cost_table */ None,

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -34,7 +34,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         &pkg_path,
         build_config.clone(),
         // TODO(Gas): double check if this is correct
-        UnitTestingConfig::default_with_bound_and_statistics(Some(100_000_000)),
+        UnitTestingConfig::default_with_bound(Some(100_000_000)),
         aptos_test_natives(),
         aptos_test_feature_flags_genesis(),
         /* cost_table */ None,
@@ -52,7 +52,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         ok = run_move_unit_tests(
             &pkg_path,
             build_config,
-            UnitTestingConfig::default_with_bound_and_statistics(Some(100_000_000)),
+            UnitTestingConfig::default_with_bound(Some(100_000_000)),
             aptos_test_natives(),
             aptos_test_feature_flags_genesis(),
             /* cost_table */ None,

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -595,6 +595,20 @@ pub enum StatusCode {
     RESERVED_VALIDATION_ERROR_9 = 44,
     // Failed to identify active automated task by provided index/sequence-number
     NO_ACTIVE_AUTOMATED_TASK = 45,
+    // Length of program field of automation payload in raw transaction exceeded max length
+    AUTOMATION_PAYLOAD_EXCEEDED_MAX_TRANSACTION_SIZE = 46,
+    // Max gas units submitted with for automation-task exceeds max gas units bound
+    // in VM
+    AUTOMATION_TASK_MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND = 47,
+    // Max gas units submitted for the automation-task not enough to cover the
+    // intrinsic cost of the transaction.
+    AUTOMATION_TASK_MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS = 48,
+    // Gas unit price capacity submitted for the automation-task is below minimum gas price
+    // set in the VM.
+    AUTOMATION_TASK_GAS_PRICE_CAP_BELOW_MIN_BOUND = 49,
+    // Gas unit price capacity submitted for the automation-task is above the maximum
+    // gas price set in the VM.
+    AUTOMATION_TASK_GAS_PRICE_CAP_ABOVE_MAX_BOUND = 50,
 
     // When a code module/script is published it is verified. These are the
     // possible errors that can arise from the verification process.

--- a/third_party/move/tools/move-unit-test/src/lib.rs
+++ b/third_party/move/tools/move-unit-test/src/lib.rs
@@ -145,27 +145,6 @@ impl UnitTestingConfig {
         }
     }
 
-    /// Create a unit testing config for use with `register_move_unit_tests`
-    pub fn default_with_bound_and_statistics(bound: Option<u64>) -> Self {
-        Self {
-            gas_limit: bound.or(Some(DEFAULT_EXECUTION_BOUND)),
-            filter: None,
-            num_threads: 8,
-            report_statistics: true,
-            report_storage_on_error: false,
-            report_stacktrace_on_abort: false,
-            ignore_compile_warnings: false,
-            source_files: vec![],
-            dep_files: vec![],
-            check_stackless_vm: false,
-            verbose: false,
-            list: false,
-            named_address_values: vec![],
-
-            #[cfg(feature = "evm-backend")]
-            evm: false,
-        }
-    }
     pub fn with_named_addresses(
         mut self,
         named_address_values: BTreeMap<String, NumericalAddress>,

--- a/third_party/move/tools/move-unit-test/src/lib.rs
+++ b/third_party/move/tools/move-unit-test/src/lib.rs
@@ -145,6 +145,27 @@ impl UnitTestingConfig {
         }
     }
 
+    /// Create a unit testing config for use with `register_move_unit_tests`
+    pub fn default_with_bound_and_statistics(bound: Option<u64>) -> Self {
+        Self {
+            gas_limit: bound.or(Some(DEFAULT_EXECUTION_BOUND)),
+            filter: None,
+            num_threads: 8,
+            report_statistics: true,
+            report_storage_on_error: false,
+            report_stacktrace_on_abort: false,
+            ignore_compile_warnings: false,
+            source_files: vec![],
+            dep_files: vec![],
+            check_stackless_vm: false,
+            verbose: false,
+            list: false,
+            named_address_values: vec![],
+
+            #[cfg(feature = "evm-backend")]
+            evm: false,
+        }
+    }
     pub fn with_named_addresses(
         mut self,
         named_address_values: BTreeMap<String, NumericalAddress>,

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -90,6 +90,7 @@ pub enum FeatureFlag {
     // Ends up in 11th byte, 0th bit
     SUPRA_NATIVE_AUTOMATION = 88,
     SUPRA_ETH_TRIE= 89,
+    SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK = 90,
 }
 
 impl FeatureFlag {
@@ -156,6 +157,7 @@ impl FeatureFlag {
             FeatureFlag::CONCURRENT_FUNGIBLE_BALANCE,
             FeatureFlag::LIMIT_VM_TYPE_SIZE,
             FeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH,
+            FeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK,
         ]
     }
 }


### PR DESCRIPTION
- created optimized version of on_new_epoch and try_withdraw_task_automation_fee
   - Now refund and task clean-up is done in one go if refund in applicable.
   - During epoch fee withdrawal of the tasks all the funds are collected and then deposited to registry account address in total
- Includes fix for [Automation] Potential Risk of Abusive Usage of Automation Registry Feature
[#1823](https://github.com/Entropy-Foundation/smr-moonshot/issues/1823)
    - Implemented deposit amount charge for the tasks during registration
    - Implemented deposit refund logic when tasks are cancelled, expired or stopped.
- Includes fix for [Automation] Events on task activation and removal for registry
[#1788](https://github.com/Entropy-Foundation/smr-moonshot/issues/1788)
   - Implemented events to be emitted related to active and removed tasks on epoch change
- Updated existing unit tests and added new ones to check new functionality


Latest results of the run
```
- No refund simply activating all tasks, 1 epoch
│             Test Name                                                    │ Time(secs) │ Gas Used│
│ 0x1::automation_registry::check_task_activation_on_new_epoch_performance │   0.290    │ 17267    │
│ 0x1::automation_registry::check_task_registration_performance            │   0.152    │ 9675     │


- Refund on epoch start, 2nd epoch

│ 0x1::automation_registry::check_task_activation_on_new_epoch_performance │   0.492    │ 31896    │
│ 0x1::automation_registry::check_task_registration_performance            │   0.147    │ 9675     │

- All tasks are expired, 3rd epoch
│ 0x1::automation_registry::check_task_activation_on_new_epoch_performance │   0.667    │ 47094    │
│ 0x1::automation_registry::check_task_registration_performance            │   0.142    │ 9675     │

```

With local run I have the following results:
```
- No refund simply activating all tasks, 1 epoch
│             Test Name                                                             │ Time(secs) │ Gas Used│
│ 0x1::automation_registry::check_task_activation_on_new_epoch_2_performance        │   1.216    │  80907  │                                                                                               
│ 0x1::automation_registry::check_task_activation_on_new_epoch_performance          │   0.858    │  82193  │
│ 0x1::automation_registry::check_task_registration_performance                     │   0.165    │  9382   │


- Refund on epoch start, 2nd epoch

│ 0x1::automation_registry::check_task_activation_on_new_epoch_2_performance        │   1.703    │ 156289  │
│ 0x1::automation_registry::check_task_activation_on_new_epoch_performance          │   1.817    │ 159968  │
│ 0x1::automation_registry::check_task_registration_performance                     │   0.195    │  9382   │

- All tasks are expired, 3rd epoch
│ 0x1::automation_registry::check_task_activation_on_new_epoch_2_performance        │   1.528    │ 162800  │
│ 0x1::automation_registry::check_task_activation_on_new_epoch_performance          │   1.214    │ 165396  │
│ 0x1::automation_registry::check_task_registration_performance                     │   0.143    │  9382   │

```
