### PR TITLE
normalize rocksdb deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -711,7 +711,11 @@ reqwest-middleware = "0.2.0"
 reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }
 ripemd = "0.1.1"
-rocksdb = { version = "0.22.0", features = ["lz4"] }
+######
+# Normalize rocksdb version for build
+rocksdb = { version = "0.22.0", default-features = false, features = ["lz4", "snappy"] }
+#####
+
 rsa = { version = "0.9.6" }
 rstack-self = { version = "0.3.0", features = ["dw"], default_features = false }
 rstest = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,7 +712,7 @@ reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }
 ripemd = "0.1.1"
 ######
-# Normalize rocksdb version for build
+# Normalized rocksdb version and features set with smr-moonshot
 rocksdb = { version = "0.22.0", default-features = false, features = ["lz4", "snappy"] }
 #####
 


### PR DESCRIPTION
unify rocksdb version and feature set with smr-moonshot
release branch`release/aptosvm-v1.16_supra-v1.1.x` created based on tag `aptosvm-v1.16_supra-v1.1.2` 
This pr going to create new tag `aptosvm-v1.16_supra-v1.1.3` 