### PR TITLE
[AN-Issue-1906,1907] Feature gated automation payload gas check upon registration

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -123,6 +123,7 @@ pub enum FeatureFlag {
     AbortIfMultisigPayloadMismatch,
     SupraNativeAutomation,
     SupraEthTrie,
+    SupraAutomationPayloadGasCheck
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -320,6 +321,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             },
             FeatureFlag::SupraNativeAutomation => AptosFeatureFlag::SUPRA_NATIVE_AUTOMATION,
             FeatureFlag::SupraEthTrie => AptosFeatureFlag::SUPRA_ETH_TRIE,
+            FeatureFlag::SupraAutomationPayloadGasCheck => AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK,
         }
     }
 }
@@ -446,6 +448,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             },
             AptosFeatureFlag::SUPRA_NATIVE_AUTOMATION => FeatureFlag::SupraNativeAutomation,
             AptosFeatureFlag::SUPRA_ETH_TRIE=> FeatureFlag::SupraEthTrie,
+            AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK => FeatureFlag::SupraAutomationPayloadGasCheck
         }
     }
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -868,7 +868,7 @@ task gas parameters in scope of automation registration transaction will pass ga
 Lifetime: transient
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>: u64 = 88;
+<pre><code><b>const</b> <a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>: u64 = 90;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -133,6 +133,8 @@ return true.
 -  [Function `supra_native_automation_enabled`](#0x1_features_supra_native_automation_enabled)
 -  [Function `get_supra_eth_trie_feature`](#0x1_features_get_supra_eth_trie_feature)
 -  [Function `supra_eth_trie_enabled`](#0x1_features_supra_eth_trie_enabled)
+-  [Function `get_supra_automation_payload_gas_check_feature`](#0x1_features_get_supra_automation_payload_gas_check_feature)
+-  [Function `supra_automation_payload_gas_check_enabled`](#0x1_features_supra_automation_payload_gas_check_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -854,6 +856,19 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_STRUCT_CONSTRUCTORS">STRUCT_CONSTRUCTORS</a>: u64 = 15;
+</code></pre>
+
+
+
+<a id="0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK"></a>
+
+Whether gas check of automation-task during registration is enabled. Once enabled, the inner payload along with
+task gas parameters in scope of automation registration transaction will pass gas check.
+
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>: u64 = 88;
 </code></pre>
 
 
@@ -3351,6 +3366,54 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_eth_trie_enabled">supra_eth_trie_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SUPRA_ETH_TRIE">SUPRA_ETH_TRIE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_get_supra_automation_payload_gas_check_feature"></a>
+
+## Function `get_supra_automation_payload_gas_check_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_supra_automation_payload_gas_check_feature">get_supra_automation_payload_gas_check_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_supra_automation_payload_gas_check_feature">get_supra_automation_payload_gas_check_feature</a>(): u64 {
+    <a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_supra_automation_payload_gas_check_enabled"></a>
+
+## Function `supra_automation_payload_gas_check_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_automation_payload_gas_check_enabled">supra_automation_payload_gas_check_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_automation_payload_gas_check_enabled">supra_automation_payload_gas_check_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK">SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -687,6 +687,20 @@ module std::features {
         is_enabled(SUPRA_ETH_TRIE)
     }
 
+    /// Whether gas check of automation-task during registration is enabled. Once enabled, the inner payload along with
+    /// task gas parameters in scope of automation registration transaction will pass gas check.
+    ///
+    /// Lifetime: transient
+    const SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK: u64 = 88;
+
+    public fun get_supra_automation_payload_gas_check_feature(): u64 {
+        SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK
+    }
+
+    public fun supra_automation_payload_gas_check_enabled(): bool acquires Features {
+        is_enabled(SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -691,7 +691,7 @@ module std::features {
     /// task gas parameters in scope of automation registration transaction will pass gas check.
     ///
     /// Lifetime: transient
-    const SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK: u64 = 88;
+    const SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK: u64 = 90;
 
     public fun get_supra_automation_payload_gas_check_feature(): u64 {
         SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -595,6 +595,20 @@ pub enum StatusCode {
     RESERVED_VALIDATION_ERROR_9 = 44,
     // Failed to identify active automated task by provided index/sequence-number
     NO_ACTIVE_AUTOMATED_TASK = 45,
+    // Length of program field of automation payload in raw transaction exceeded max length
+    AUTOMATION_PAYLOAD_EXCEEDED_MAX_TRANSACTION_SIZE = 46,
+    // Max gas units submitted with for automation-task exceeds max gas units bound
+    // in VM
+    AUTOMATION_TASK_MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND = 47,
+    // Max gas units submitted for the automation-task not enough to cover the
+    // intrinsic cost of the transaction.
+    AUTOMATION_TASK_MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS = 48,
+    // Gas unit price capacity submitted for the automation-task is below minimum gas price
+    // set in the VM.
+    AUTOMATION_TASK_GAS_PRICE_CAP_BELOW_MIN_BOUND = 49,
+    // Gas unit price capacity submitted for the automation-task is above the maximum
+    // gas price set in the VM.
+    AUTOMATION_TASK_GAS_PRICE_CAP_ABOVE_MAX_BOUND = 50,
 
     // When a code module/script is published it is verified. These are the
     // possible errors that can arise from the verification process.

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -90,6 +90,7 @@ pub enum FeatureFlag {
     // Ends up in 11th byte, 0th bit
     SUPRA_NATIVE_AUTOMATION = 88,
     SUPRA_ETH_TRIE= 89,
+    SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK = 90,
 }
 
 impl FeatureFlag {
@@ -156,6 +157,7 @@ impl FeatureFlag {
             FeatureFlag::CONCURRENT_FUNGIBLE_BALANCE,
             FeatureFlag::LIMIT_VM_TYPE_SIZE,
             FeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH,
+            FeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK,
         ]
     }
 }


### PR DESCRIPTION
- Added dedicated VM status-codes for gas checks failures in scope of automation payload gas-parameters checks during automation task registration

Fixes:
- [Automation] Feature flag to enable/disable inner payload gas-check [#1906](https://github.com/Entropy-Foundation/smr-moonshot/issues/1906)
- [Automation] Extend VmStatus error codes to report automation task inner payload gas-check errors [#1907](https://github.com/Entropy-Foundation/smr-moonshot/issues/1907)