### PR TITLE
[AN-Issue-1823] Enabled full epoch charges for a new short tasks.

### DIFF
--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -59,7 +59,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `estimate_automation_fee`](#0x1_automation_registry_estimate_automation_fee)
 -  [Function `estimate_automation_fee_with_committed_occupancy`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy)
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
--  [Function `task_active_duration`](#0x1_automation_registry_task_active_duration)
 -  [Function `estimate_automation_fee_with_committed_occupancy_internal`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal)
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
@@ -2401,34 +2400,6 @@ Returns the current status of the registration in the automation registry.
 
 </details>
 
-<a id="0x1_automation_registry_task_active_duration"></a>
-
-## Function `task_active_duration`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_task_active_duration">task_active_duration</a>(task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, current_time: u64): u64
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_task_active_duration">task_active_duration</a>(task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a>, current_time: u64): u64 {
-    <b>if</b> (task.expiry_time &lt;= current_time) {
-        0
-    } <b>else</b> {
-        task.expiry_time - current_time
-    }
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal"></a>
 
 ## Function `estimate_automation_fee_with_committed_occupancy_internal`
@@ -3327,14 +3298,15 @@ It returns calculated task fee for the interval the task will be active.
     <b>if</b> (task.expiry_time &lt;= current_time) { <b>return</b> 0 };
     // Subtraction is safe here, <b>as</b> we already excluded expired tasks
     <b>let</b> task_active_timeframe = task.expiry_time - current_time;
-    // If the task is a new task i.e. in Pending state,
-    // and it's a short task - active duration is less than the input potential_fee_timeframe(which is epoch-interval),
-    // then it is task's first and only epoch and we calculate the fee for entire epoch.
+    // If the task is a new task i.e. in Pending state, then it is charged always for
+    // the input potential_fee_timeframe(which is epoch-interval),
+    // For the new tasks which active-timeframe is less than epoch-interval
+    // it would mean it is their first and only epoch and we charge the fee for entire epoch.
     // Note that although the new short tasks are charged for entire epoch, the refunding logic remains the same for
     // them <b>as</b> for the long tasks.
     // This way bad-actors will be discourged <b>to</b> submit small and short tasks <b>with</b> big occupancy by blocking other
     // good-actors register tasks.
-    <b>let</b> actual_fee_timeframe = <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a> && task_active_timeframe &lt; potential_fee_timeframe) {
+    <b>let</b> actual_fee_timeframe = <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
         potential_fee_timeframe
     } <b>else</b> {
         <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_active_timeframe, potential_fee_timeframe)

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -59,6 +59,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `estimate_automation_fee`](#0x1_automation_registry_estimate_automation_fee)
 -  [Function `estimate_automation_fee_with_committed_occupancy`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy)
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
+-  [Function `task_active_duration`](#0x1_automation_registry_task_active_duration)
 -  [Function `estimate_automation_fee_with_committed_occupancy_internal`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal)
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
@@ -68,8 +69,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `finalize_epoch_change`](#0x1_automation_registry_finalize_epoch_change)
 -  [Function `finalize_epoch_change_for_feature_disabled_state`](#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state)
 -  [Function `update_state_for_new_epoch`](#0x1_automation_registry_update_state_for_new_epoch)
--  [Function `refund_cleanup_and_activate_tasks`](#0x1_automation_registry_refund_cleanup_and_activate_tasks)
--  [Function `cleanup_and_activate_tasks`](#0x1_automation_registry_cleanup_and_activate_tasks)
+-  [Function `refund_cleanup_tasks`](#0x1_automation_registry_refund_cleanup_tasks)
+-  [Function `cleanup_tasks`](#0x1_automation_registry_cleanup_tasks)
 -  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
 -  [Function `safe_deposit_refund`](#0x1_automation_registry_safe_deposit_refund)
 -  [Function `safe_unlock_locked_deposit`](#0x1_automation_registry_safe_unlock_locked_deposit)
@@ -2400,6 +2401,34 @@ Returns the current status of the registration in the automation registry.
 
 </details>
 
+<a id="0x1_automation_registry_task_active_duration"></a>
+
+## Function `task_active_duration`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_task_active_duration">task_active_duration</a>(task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, current_time: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_task_active_duration">task_active_duration</a>(task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a>, current_time: u64): u64 {
+    <b>if</b> (task.expiry_time &lt;= current_time) {
+        0
+    } <b>else</b> {
+        task.expiry_time - current_time
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal"></a>
 
 ## Function `estimate_automation_fee_with_committed_occupancy_internal`
@@ -2836,7 +2865,7 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
     };
 
     <b>if</b> (refund_automation_fee_per_sec != 0) {
-        <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(
+        <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_tasks">refund_cleanup_tasks</a>(
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
             refund_bookkeeping,
             current_time,
@@ -2844,7 +2873,7 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
             refund_automation_fee_per_sec,
             refund_interval)
     } <b>else</b> {
-        <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, current_time)
+        <a href="automation_registry.md#0x1_automation_registry_cleanup_tasks">cleanup_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, current_time)
     }
 }
 </code></pre>
@@ -2853,16 +2882,16 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 </details>
 
-<a id="0x1_automation_registry_refund_cleanup_and_activate_tasks"></a>
+<a id="0x1_automation_registry_refund_cleanup_tasks"></a>
 
-## Function `refund_cleanup_and_activate_tasks`
+## Function `refund_cleanup_tasks`
 
-Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks and activates the pending tasks.
+Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks.
 Also calculates and returns the total committed max gas for the new epoch along with the task indexes
 that have been removed from the registry.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_tasks">refund_cleanup_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
 </code></pre>
 
 
@@ -2871,7 +2900,7 @@ that have been removed from the registry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_and_activate_tasks">refund_cleanup_and_activate_tasks</a>(
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_tasks">refund_cleanup_tasks</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     current_time: u64,
@@ -2920,7 +2949,6 @@ that have been removed from the registry.
             <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
         } <b>else</b> {
-            task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
             tcmg = tcmg + task.max_gas_amount;
         }
     });
@@ -2937,16 +2965,16 @@ that have been removed from the registry.
 
 </details>
 
-<a id="0x1_automation_registry_cleanup_and_activate_tasks"></a>
+<a id="0x1_automation_registry_cleanup_tasks"></a>
 
-## Function `cleanup_and_activate_tasks`
+## Function `cleanup_tasks`
 
-Cleans up expired and cancelled tasks and activates the pending tasks.
+Cleans up expired and cancelled.
 Also calculates and returns the total committed max gas for the new epoch along with the task indexes
 that have been removed from the registry.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_tasks">cleanup_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
 </code></pre>
 
 
@@ -2955,7 +2983,7 @@ that have been removed from the registry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_and_activate_tasks">cleanup_and_activate_tasks</a>(
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_tasks">cleanup_tasks</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     current_time: u64
@@ -2983,7 +3011,6 @@ that have been removed from the registry.
             <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
         } <b>else</b> {
-            task.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
             tcmg = tcmg + task.max_gas_amount;
         }
     });
@@ -3280,7 +3307,7 @@ This is supposed to be called only after removing expired task and must not be c
 It returns calculated task fee for the interval the task will be active.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, interval: u64, current_time: u64, automation_fee_per_sec: u256): u64
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, potential_fee_timeframe: u64, current_time: u64, automation_fee_per_sec: u256): u64
 </code></pre>
 
 
@@ -3292,17 +3319,28 @@ It returns calculated task fee for the interval the task will be active.
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     task: &<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a>,
-    interval: u64,
+    potential_fee_timeframe: u64,
     current_time: u64,
     automation_fee_per_sec: u256
 ): u64 {
     <b>if</b> (automation_fee_per_sec == 0) { <b>return</b> 0 };
     <b>if</b> (task.expiry_time &lt;= current_time) { <b>return</b> 0 };
     // Subtraction is safe here, <b>as</b> we already excluded expired tasks
-    <b>let</b> remaining_time = task.expiry_time - current_time;
-    <b>let</b> min_interval = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(remaining_time, interval);
+    <b>let</b> task_active_timeframe = task.expiry_time - current_time;
+    // If the task is a new task i.e. in Pending state,
+    // and it's a short task - active duration is less than the input potential_fee_timeframe(which is epoch-interval),
+    // then it is task's first and only epoch and we calculate the fee for entire epoch.
+    // Note that although the new short tasks are charged for entire epoch, the refunding logic remains the same for
+    // them <b>as</b> for the long tasks.
+    // This way bad-actors will be discourged <b>to</b> submit small and short tasks <b>with</b> big occupancy by blocking other
+    // good-actors register tasks.
+    <b>let</b> actual_fee_timeframe = <b>if</b> (task.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a> && task_active_timeframe &lt; potential_fee_timeframe) {
+        potential_fee_timeframe
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_active_timeframe, potential_fee_timeframe)
+    };
     <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_for_interval">calculate_automation_fee_for_interval</a>(
-        min_interval,
+        actual_fee_timeframe,
         task.max_gas_amount,
         automation_fee_per_sec,
         arc.registry_max_gas_cap)
@@ -3410,7 +3448,7 @@ Calculate automation congestion fee for the epoch
 
     // Calculate congestion threshold surplus for the current epoch
     <b>let</b> threshold_usage = <a href="automation_registry.md#0x1_automation_registry_upscale_from_u256">upscale_from_u256</a>(tcmg) * 100 / max_gas_cap;
-    <b>if</b> (threshold_usage &lt; threshold_percentage) 0
+    <b>if</b> (threshold_usage &lt;= threshold_percentage) 0
     <b>else</b> {
         <b>let</b> threshold_surplus_normalized = (threshold_usage - threshold_percentage) / 100;
 
@@ -3533,15 +3571,24 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
     // Process each active task and calculate fee for the epoch for the tasks
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-        <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
-            task_index,
-            owner: task_meta.owner,
-            fee: <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec),
-            expiry_time: task_meta.expiry_time,
-            automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-            max_gas_amount: task_meta.max_gas_amount,
-            locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+        <b>let</b> task = {
+            <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+            <b>let</b> fee= <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+            // If the task reached this phase that means it is valid active task for the new epoch.
+            // During cleanup all expired tasks <b>has</b> been removed from the registry but the state of the tasks is not updated.
+            // As here we need <b>to</b> distinguish new tasks from already existing active tasks,
+            // <b>as</b> the fee calculation for them will be different based on their active duration in the epoch.
+            // For more details see calculate_task_fee function.
+            task_meta.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+            <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+                task_index,
+                owner: task_meta.owner,
+                fee,
+                expiry_time: task_meta.expiry_time,
+                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                max_gas_amount: task_meta.max_gas_amount,
+                locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+            }
         };
         <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -824,7 +824,7 @@ module supra_framework::automation_registry {
         };
 
         if (refund_automation_fee_per_sec != 0) {
-            refund_cleanup_and_activate_tasks(
+            refund_cleanup_tasks(
                 automation_registry,
                 refund_bookkeeping,
                 current_time,
@@ -832,14 +832,14 @@ module supra_framework::automation_registry {
                 refund_automation_fee_per_sec,
                 refund_interval)
         } else {
-            cleanup_and_activate_tasks(automation_registry, refund_bookkeeping, current_time)
+            cleanup_tasks(automation_registry, refund_bookkeeping, current_time)
         }
     }
 
-    /// Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks and activates the pending tasks.
+    /// Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks.
     /// Also calculates and returns the total committed max gas for the new epoch along with the task indexes
     /// that have been removed from the registry.
-    fun refund_cleanup_and_activate_tasks(
+    fun refund_cleanup_tasks(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         current_time: u64,
@@ -888,7 +888,6 @@ module supra_framework::automation_registry {
                 enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
                 vector::push_back(&mut removed_tasks, task_index);
             } else {
-                task.state = ACTIVE;
                 tcmg = tcmg + task.max_gas_amount;
             }
         });
@@ -900,10 +899,10 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Cleans up expired and cancelled tasks and activates the pending tasks.
+    /// Cleans up expired and cancelled.
     /// Also calculates and returns the total committed max gas for the new epoch along with the task indexes
     /// that have been removed from the registry.
-    fun cleanup_and_activate_tasks(
+    fun cleanup_tasks(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         current_time: u64
@@ -931,7 +930,6 @@ module supra_framework::automation_registry {
                 enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
                 vector::push_back(&mut removed_tasks, task_index);
             } else {
-                task.state = ACTIVE;
                 tcmg = tcmg + task.max_gas_amount;
             }
         });
@@ -1101,17 +1099,28 @@ module supra_framework::automation_registry {
     fun calculate_task_fee(
         arc: &AutomationRegistryConfig,
         task: &AutomationTaskMetaData,
-        interval: u64,
+        potential_fee_timeframe: u64,
         current_time: u64,
         automation_fee_per_sec: u256
     ): u64 {
         if (automation_fee_per_sec == 0) { return 0 };
         if (task.expiry_time <= current_time) { return 0 };
         // Subtraction is safe here, as we already excluded expired tasks
-        let remaining_time = task.expiry_time - current_time;
-        let min_interval = math64::min(remaining_time, interval);
+        let task_active_timeframe = task.expiry_time - current_time;
+        // If the task is a new task i.e. in Pending state,
+        // and it's a short task - active duration is less than the input potential_fee_timeframe(which is epoch-interval),
+        // then it is task's first and only epoch and we calculate the fee for entire epoch.
+        // Note that although the new short tasks are charged for entire epoch, the refunding logic remains the same for
+        // them as for the long tasks.
+        // This way bad-actors will be discourged to submit small and short tasks with big occupancy by blocking other
+        // good-actors register tasks.
+        let actual_fee_timeframe = if (task.state == PENDING && task_active_timeframe < potential_fee_timeframe) {
+            potential_fee_timeframe
+        } else {
+            math64::min(task_active_timeframe, potential_fee_timeframe)
+        };
         calculate_automation_fee_for_interval(
-            min_interval,
+            actual_fee_timeframe,
             task.max_gas_amount,
             automation_fee_per_sec,
             arc.registry_max_gas_cap)
@@ -1242,15 +1251,24 @@ module supra_framework::automation_registry {
 
         // Process each active task and calculate fee for the epoch for the tasks
         vector::for_each(task_ids, |task_index| {
-            let task_meta = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
-            let task = AutomationTaskFeeMeta {
-                task_index,
-                owner: task_meta.owner,
-                fee: calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec),
-                expiry_time: task_meta.expiry_time,
-                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                max_gas_amount: task_meta.max_gas_amount,
-                locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+            let task = {
+                let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+                let fee= calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
+                // If the task reached this phase that means it is valid active task for the new epoch.
+                // During cleanup all expired tasks has been removed from the registry but the state of the tasks is not updated.
+                // As here we need to distinguish new tasks from already existing active tasks,
+                // as the fee calculation for them will be different based on their active duration in the epoch.
+                // For more details see calculate_task_fee function.
+                task_meta.state = ACTIVE;
+                AutomationTaskFeeMeta {
+                    task_index,
+                    owner: task_meta.owner,
+                    fee,
+                    expiry_time: task_meta.expiry_time,
+                    automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                    max_gas_amount: task_meta.max_gas_amount,
+                    locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+                }
             };
             try_withdraw_task_automation_fee(
                 automation_registry,
@@ -2903,9 +2921,8 @@ module supra_framework::automation_registry {
             // tasks only will be charged for the next epoch.
             check_account_balance(user_address, expected_user_current_balance);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-            check_task_state(ar, task3, exists, ACTIVE);
-            // reset the state
-            update_task_state(ar, task3, PENDING);
+            // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+            check_task_state(ar, task3, exists, PENDING);
         };
 
         // Set some locked fee which is enough to pay refund if necessary
@@ -2926,10 +2943,10 @@ module supra_framework::automation_registry {
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
             check_task_state(ar, task1, exists, ACTIVE);
             check_task_state(ar, task2, exists, ACTIVE);
-            check_task_state(ar, task3, exists, ACTIVE);
+            // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+            check_task_state(ar, task3, exists, PENDING);
 
             // Refund is expected only for ACTIVE AND CANCELLED TASK BUT NOT FOR PENDING
-            update_task_state(ar, task3, PENDING);
             update_task_state(ar, task2, CANCELLED);
             let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
             consume_intermediate_state(result);
@@ -2943,12 +2960,12 @@ module supra_framework::automation_registry {
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
             check_task_state(ar, task1, exists, ACTIVE);
             check_task_state(ar, task2, !exists, CANCELLED);
-            check_task_state(ar, task3, exists, ACTIVE);
+            // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+            check_task_state(ar, task3, exists, PENDING);
 
             // Now we have only task1 as Active and task 3 as pending.
             // If epoch duration surpasses tasks expiration time, then they are refunded on  locked deposit, and removed from registry.
             // even pending task.
-            update_task_state(ar, task3, PENDING);
             let result = update_state_for_new_epoch(
                 ar,
                 refund_bookkeeping,
@@ -3046,7 +3063,8 @@ module supra_framework::automation_registry {
 
         check_task_state(ar, task1, exists, ACTIVE);
         check_task_state(ar, task2, !exists, CANCELLED);
-        check_task_state(ar, task3, exists, ACTIVE);
+        // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+        check_task_state(ar, task3, exists, PENDING);
 
         check_account_balance(user_address, expected_user_current_balance);
         // // Check registry balance
@@ -3226,6 +3244,86 @@ module supra_framework::automation_registry {
         let r2 = vector::borrow(&results, 1);
         assert!(r1.fee == 0, 5);
         assert!(r2.fee == 0, 6);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_automation_task_fee_calculation_for_short_tasks(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let t1_t2_max_gas = 44_000_000;
+        let expiry_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+
+        // Old but short task, will be charged according to active time
+        let task1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas,
+            100_000_000,
+            expiry_time,
+            ACTIVE);
+
+        // New short task will be charged full epoch fee
+        let task2 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas,
+            100_000_000,
+            expiry_time,
+            PENDING);
+
+        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+        // Epoch cut short 2 times
+        let fwk_address = address_of(framework);
+
+        // if epoch length matches or greater the expected epoch interval then no refund is expected
+        // event if there is a locked fee.
+        let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+        let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
+        let tcmg = ((2 * t1_t2_max_gas) as u256);
+        // Take into account CANCELLED tasks as well
+        // Tasks are still valid
+        let results = calculate_tasks_automation_fees(
+            ar,
+            arc,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
+            tcmg);
+        assert!(vector::length(&results) == 2, 2);
+
+        let expected_fee = expected_automation_fee_per_task + expected_congestion_fee_per_task;
+        let r1 = vector::borrow(&results, task1);
+        let r2 = vector::borrow(&results, task2);
+        assert!(r1.fee == expected_fee / 2, 3);
+        // As task to is short and new task it will be charged for full epoch
+        assert!(r2.fee == expected_fee, 4);
+
+        // Now lets assume task as activated and epoch has been kept short, refund for both tasks will be done in the
+        // same manneer according to their exiration time.
+        update_task_state(ar, task2, ACTIVE);
+
+        let current_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 4;
+        let refund_interval = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS - current_time;
+        // Each task will be active still for EPOCH_INTERVAL_FOR_TEST_IN_SECS / 4 duration,
+        // as expiry time was EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let results = calculate_tasks_automation_fees(
+            ar,
+            arc,
+            refund_interval,
+            current_time,
+            tcmg);
+        assert!(vector::length(&results) == 2, 5);
+
+        let expected_fee = expected_automation_fee_per_task + expected_congestion_fee_per_task;
+        let r1 = vector::borrow(&results, task1);
+        let r2 = vector::borrow(&results, task2);
+        assert!(r1.fee == expected_fee / 4, 6);
+        // For this task full epoch fee was charged, but the refund is done according to expiry time
+        assert!(r2.fee == expected_fee / 4, 7);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3749,8 +3847,7 @@ module supra_framework::automation_registry {
         // Stop the same task 2 times, second time it will not abort it just skip the task_id if it's not found
         stop_tasks(user, vector[0]);
         assert!(!has_task_with_id(0), 1);
-
-        // stop_tasks(user, vector[0]);
+        stop_tasks(user, vector[0]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -3304,7 +3304,7 @@ module supra_framework::automation_registry {
         assert!(r2.fee == expected_fee, 4);
 
         // Now lets assume task as activated and epoch has been kept short, refund for both tasks will be done in the
-        // same manneer according to their exiration time.
+        // same manner according to their expiration time.
         update_task_state(ar, task2, ACTIVE);
 
         let current_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 4;

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1107,14 +1107,15 @@ module supra_framework::automation_registry {
         if (task.expiry_time <= current_time) { return 0 };
         // Subtraction is safe here, as we already excluded expired tasks
         let task_active_timeframe = task.expiry_time - current_time;
-        // If the task is a new task i.e. in Pending state,
-        // and it's a short task - active duration is less than the input potential_fee_timeframe(which is epoch-interval),
-        // then it is task's first and only epoch and we calculate the fee for entire epoch.
+        // If the task is a new task i.e. in Pending state, then it is charged always for
+        // the input potential_fee_timeframe(which is epoch-interval),
+        // For the new tasks which active-timeframe is less than epoch-interval
+        // it would mean it is their first and only epoch and we charge the fee for entire epoch.
         // Note that although the new short tasks are charged for entire epoch, the refunding logic remains the same for
         // them as for the long tasks.
         // This way bad-actors will be discourged to submit small and short tasks with big occupancy by blocking other
         // good-actors register tasks.
-        let actual_fee_timeframe = if (task.state == PENDING && task_active_timeframe < potential_fee_timeframe) {
+        let actual_fee_timeframe = if (task.state == PENDING) {
             potential_fee_timeframe
         } else {
             math64::min(task_active_timeframe, potential_fee_timeframe)
@@ -4108,8 +4109,10 @@ module supra_framework::automation_registry {
         assert!(active_task_ids == vector[], 1);
     }
 
+    #[test_only]
+    // Kept only for performance analysis intentions
     // Register 500 tasks to measure registration time/used-gas
-    #[test(framework = @supra_framework, user = @0x1cafe)]
+    // #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_task_registration_performance(
         framework: &signer,
         user: &signer
@@ -4117,12 +4120,14 @@ module supra_framework::automation_registry {
         task_registration_performance(framework, user);
     }
 
+    #[test_only]
+    // Kept only for performance analysis intentions
     // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
     // And run 3 epochs to check gas-used when
     //  - full epoch passed
     //  - 1/3 of epoch passed to simulate refund, but tasks are still active
     //  - last epoch identifies all tasks are expired
-    #[test(framework = @supra_framework, user = @0x1cafe)]
+    // #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_task_activation_on_new_epoch_performance(
         framework: &signer,
         user: &signer

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -34,7 +34,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         &pkg_path,
         build_config.clone(),
         // TODO(Gas): double check if this is correct
-        UnitTestingConfig::default_with_bound(Some(100_000_000)),
+        UnitTestingConfig::default_with_bound(Some(100_000)),
         aptos_test_natives(),
         aptos_test_feature_flags_genesis(),
         /* cost_table */ None,
@@ -52,7 +52,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         ok = run_move_unit_tests(
             &pkg_path,
             build_config,
-            UnitTestingConfig::default_with_bound(Some(100_000_000)),
+            UnitTestingConfig::default_with_bound(Some(100_000)),
             aptos_test_natives(),
             aptos_test_feature_flags_genesis(),
             /* cost_table */ None,


### PR DESCRIPTION
- Now the pending tasks will be activated when epoch fee calculation has been done.
- Now the pending tasks which have ttl less than an epoch-duration will be charged for full epoch length, but any epoch fee refund will still be done based on their TTL

Relates to https://github.com/Entropy-Foundation/smr-moonshot/issues/1823