### PR TITLE
[AN-Issue-#1968] Api to get task details in bulk

### DIFF
--- a/aptos-move/e2e-testsuite/src/tests/vm_viewer.rs
+++ b/aptos-move/e2e-testsuite/src/tests/vm_viewer.rs
@@ -14,7 +14,7 @@ const ACCOUNT_BALANCE: &str = "0x1::coin::balance";
 const ACCOUNT_SEQ_NUM: &str = "0x1::account::get_sequence_number";
 const SUPRA_COIN: &str = "0x1::supra_coin::SupraCoin";
 
-fn to_view_function(fn_ref: MemberId, ty_args: Vec<TypeTag>, args: Vec<Vec<u8>>) -> ViewFunction {
+pub(crate) fn to_view_function(fn_ref: MemberId, ty_args: Vec<TypeTag>, args: Vec<Vec<u8>>) -> ViewFunction {
     ViewFunction::new(fn_ref.module_id, fn_ref.member_id, ty_args, args)
 }
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -49,6 +49,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `get_registry_total_locked_balance`](#0x1_automation_registry_get_registry_total_locked_balance)
 -  [Function `get_active_task_ids`](#0x1_automation_registry_get_active_task_ids)
 -  [Function `get_task_details`](#0x1_automation_registry_get_task_details)
+-  [Function `get_task_details_bulk`](#0x1_automation_registry_get_task_details_bulk)
 -  [Function `has_sender_active_task_with_id`](#0x1_automation_registry_has_sender_active_task_with_id)
 -  [Function `get_registry_fee_address`](#0x1_automation_registry_get_registry_fee_address)
 -  [Function `get_gas_committed_for_next_epoch`](#0x1_automation_registry_get_gas_committed_for_next_epoch)
@@ -2108,6 +2109,40 @@ Error will be returned if entry with specified task index does not exist.
     <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, task_index), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
     <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, task_index)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_get_task_details_bulk"></a>
+
+## Function `get_task_details_bulk`
+
+Retrieves the details of a automation tasks entry by their task index.
+If a task does not exist, it is not included in the result, and no error is reported
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details_bulk">get_task_details_bulk</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_task_details_bulk">get_task_details_bulk</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a>&gt; <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    <b>let</b> automation_task_metadata = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> task_details = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
+        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&automation_task_metadata.tasks, task_index)) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> task_details, <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&automation_task_metadata.tasks, task_index))
+        }
+    });
+    task_details
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -479,6 +479,20 @@ module supra_framework::automation_registry {
     }
 
     #[view]
+    /// Retrieves the details of a automation tasks entry by their task index.
+    /// If a task does not exist, it is not included in the result, and no error is reported
+    public fun get_task_details_bulk(task_indexes: vector<u64>): vector<AutomationTaskMetaData> acquires AutomationRegistry {
+        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
+        let task_details = vector[];
+        vector::for_each(task_indexes, |task_index| {
+            if (enumerable_map::contains(&automation_task_metadata.tasks, task_index)) {
+                vector::push_back(&mut task_details, enumerable_map::get_value(&automation_task_metadata.tasks, task_index))
+            }
+        });
+        task_details
+    }
+
+    #[view]
     /// Checks whether there is an active task in registry with specified input task index.
     public fun has_sender_active_task_with_id(sender: address, task_index: u64): bool acquires AutomationRegistry {
         let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);


### PR DESCRIPTION
Compared the data retrieval and deserialization when retrieving 
- 500 tasks :
     - step by step using AptosVmViewer (~28 secs)
     - in 25 bulk using ApotsVmViewer (~14 secs)
- 5000 tasks:
     - step by step using AptosVmViewer (~454ms)
     - in 25 bulk using ApotsVmViewer (~163ms)

The bulk retrieval only showed 2-3x of acceleration.
Why 25 tasks because of the experiments results that Nizam did and shared the result in this thread: https://supraoracles.slack.com/archives/C07TE2ZRX2R/p1732282031414689
