### PR TITLE
[smr-moonshot Issue #1973] bcs support for view api

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1967,7 +1967,7 @@ impl MultisigAccountWithSequenceNumber {
     }
 }
 
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 pub struct TypeArgVec {
     /// TypeTag arguments separated by spaces.
     ///
@@ -2075,7 +2075,7 @@ impl TryInto<Vec<serde_json::Value>> for ArgWithTypeVec {
 }
 
 /// Common options for constructing an entry function transaction payload.
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 pub struct EntryFunctionArguments {
     /// Function name as `<ADDRESS>::<MODULE_ID>::<FUNCTION_NAME>`
     ///


### PR DESCRIPTION
- https://github.com/Entropy-Foundation/smr-moonshot/issues/1973

>  Impl Clone derive macro for `TypeArgVec` and `EntryFunctionArguments`

## smr-moonshot PR
- https://github.com/Entropy-Foundation/smr-moonshot/pull/1981