### PR TITLE
[AN-Issue-1978] Automation Cycle concept introduction

### DIFF
--- a/aptos-move/framework/src/natives/automation_registry_callbacks.rs
+++ b/aptos-move/framework/src/natives/automation_registry_callbacks.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Supra.
+// SPDX-License-Identifier: Apache-2.0
+use aptos_native_interface::{
+    SafeNativeBuilder, SafeNativeContext, SafeNativeResult,
+};
+use move_vm_runtime::native_functions::NativeFunction;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{Value},
+};
+use smallvec::{smallvec, SmallVec};
+use std::{collections::VecDeque};
+
+
+/***************************************************************************************************
+ * native fun to check whether the binary has been updated which supports automation registry
+ * lifecycle management based on the cycle
+ *
+ * dummy function
+ *
+ * gas cost: 0
+ *
+ **************************************************************************************************/
+fn native_cycle_based_automation_registry_management_support(
+    _context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    _arguments: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    Ok(smallvec![Value::bool(true)])
+}
+
+/***************************************************************************************************
+ * module
+ *
+ **************************************************************************************************/
+pub fn make_all(
+    builder: &SafeNativeBuilder,
+) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
+    let natives = [
+        ("native_cycle_based_automation_registry_management_support", native_cycle_based_automation_registry_management_support),
+    ];
+
+    builder.make_named_natives(natives)
+}

--- a/aptos-move/framework/src/natives/automation_registry_callbacks.rs
+++ b/aptos-move/framework/src/natives/automation_registry_callbacks.rs
@@ -21,7 +21,7 @@ use std::{collections::VecDeque};
  * gas cost: 0
  *
  **************************************************************************************************/
-fn native_cycle_based_automation_registry_management_support(
+fn native_automation_cycle_management_support(
     _context: &mut SafeNativeContext,
     _ty_args: Vec<Type>,
     _arguments: VecDeque<Value>,
@@ -37,7 +37,7 @@ pub fn make_all(
     builder: &SafeNativeBuilder,
 ) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
     let natives = [
-        ("native_cycle_based_automation_registry_management_support", native_cycle_based_automation_registry_management_support),
+        ("native_automation_cycle_management_support", native_automation_cycle_management_support),
     ];
 
     builder.make_named_natives(natives)

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -21,6 +21,7 @@ pub mod string_utils;
 pub mod transaction_context;
 pub mod type_info;
 pub mod util;
+mod automation_registry_callbacks;
 
 use crate::natives::cryptography::multi_ed25519;
 use aggregator_natives::{aggregator, aggregator_factory, aggregator_v2};
@@ -96,6 +97,7 @@ pub fn all_natives(
         "dispatchable_fungible_asset",
         dispatchable_fungible_asset::make_all(builder)
     );
+    add_natives_from_module!("automation_registry", automation_registry_callbacks::make_all(builder));
 
     make_table_from_iter(framework_addr, natives)
 }

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -3,7 +3,8 @@
 
 # Module `0x1::automation_registry`
 
-Supra Automation tegistry
+Copywrite (c) -- 2025 Supra
+Supra Automation Registry
 
 This contract is part of the Supra Framework and is designed to manage automated task entries
 
@@ -11,11 +12,11 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `ActiveAutomationRegistryConfig`](#0x1_automation_registry_ActiveAutomationRegistryConfig)
 -  [Resource `AutomationRegistryConfig`](#0x1_automation_registry_AutomationRegistryConfig)
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
--  [Resource `TransitionState`](#0x1_automation_registry_TransitionState)
+-  [Struct `TransitionState`](#0x1_automation_registry_TransitionState)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
 -  [Struct `AutomationCycleDuration`](#0x1_automation_registry_AutomationCycleDuration)
--  [Resource `AutomationCycleInfo`](#0x1_automation_registry_AutomationCycleInfo)
--  [Resource `AutomationCycleEvent`](#0x1_automation_registry_AutomationCycleEvent)
+-  [Struct `AutomationCycleInfo`](#0x1_automation_registry_AutomationCycleInfo)
+-  [Struct `AutomationCycleEvent`](#0x1_automation_registry_AutomationCycleEvent)
 -  [Resource `AutomationCycleDetails`](#0x1_automation_registry_AutomationCycleDetails)
 -  [Resource `AutomationRefundBookkeeping`](#0x1_automation_registry_AutomationRefundBookkeeping)
 -  [Resource `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
@@ -339,12 +340,12 @@ It tracks entries both pending and completed, organized by unique indices.
 
 <a id="0x1_automation_registry_TransitionState"></a>
 
-## Resource `TransitionState`
+## Struct `TransitionState`
 
 It tracks entries both pending and completed, organized by unique indices.
 
 
-<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> <b>has</b> <b>copy</b>, drop, store, key
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -411,7 +412,7 @@ Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> <b>has</b> <b>copy</b>, key
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> <b>has</b> <b>copy</b>, drop, key
 </code></pre>
 
 
@@ -478,12 +479,12 @@ Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
 
 <a id="0x1_automation_registry_AutomationCycleInfo"></a>
 
-## Resource `AutomationCycleInfo`
+## Struct `AutomationCycleInfo`
 
 Cycle state.
 
 
-<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>has</b> <b>copy</b>, drop, store, key
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -524,13 +525,13 @@ Cycle state.
 
 <a id="0x1_automation_registry_AutomationCycleEvent"></a>
 
-## Resource `AutomationCycleEvent`
+## Struct `AutomationCycleEvent`
 
 Event emitted in the cycle-state.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleEvent">AutomationCycleEvent</a> <b>has</b> <b>copy</b>, drop, store, key
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleEvent">AutomationCycleEvent</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -571,7 +572,7 @@ Cycle state.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> <b>has</b> <b>copy</b>, drop, store, key
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> <b>has</b> <b>copy</b>, drop, key
 </code></pre>
 
 
@@ -1776,6 +1777,21 @@ Triggered when cycle end is identified.
 
 
 
+<a id="0x1_automation_registry_CYCLE_READY"></a>
+
+Constants describing CYCLE state.
+State transition flaw is:
+CYCLE_READY -> CYCLE_STARTED
+CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
+CYCLE_FINISHED ->  { CYCLE_STARTED}
+CYCLE_SUSPENDED ->  {CYCLE_READY, STARTED}
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>: u8 = 0;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_CYCLE_STARTED"></a>
 
 Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by autoamtion cycle manager in native layer.
@@ -2037,6 +2053,16 @@ Attempt to do migration to cycle based automation which is already enabled.
 
 
 
+<a id="0x1_automation_registry_EINVALID_REFUND_DURATION"></a>
+
+Attempt to run refund action with duration more than cycle duration is.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_REFUND_DURATION">EINVALID_REFUND_DURATION</a>: u64 = 35;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EINVALID_REGISTRY_STATE"></a>
 
 Attempt to run operation in invalid registry state.
@@ -2182,21 +2208,6 @@ Constants describing task state.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>: u8 = 0;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_READY_TO_START_NEW_CYCLE"></a>
-
-Constants describing CYCLE state.
-State transition flaw is:
-READY_TO_START -> CYCLE_STARTED
-CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
-CYCLE_FINISHED ->  { CYCLE_STARTED}
-CYCLE_SUSPENDED ->  {READY_TO_START, STARTED}
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>: u8 = 0;
 </code></pre>
 
 
@@ -3061,6 +3072,13 @@ Update Automation Registry Config along with cycle duration.
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
+    // Update cycle duration in buffer
+    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
+    <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
+        duration_secs: cycle_duration_secs
+    };
+    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
+    <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
 
     <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
         supra_framework,
@@ -3075,13 +3093,6 @@ Update Automation Registry Config along with cycle duration.
         cycle_duration_secs,
     );
 
-    // Update cycle duration in buffer
-    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
-    <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
-        duration_secs: cycle_duration_secs
-    };
-    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
-    <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
 }
 </code></pre>
 
@@ -3393,9 +3404,9 @@ Public entry function to initialize bookeeping resource when feature enabling au
 ## Function `migrate_v2`
 
 API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
-detached from epoch-change.
-IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
-end-up in inconsistent state.
+detached from epoch-change and cycle based lifecycle of the automation registry is enabled.
+IMPORTANT: Should alwasy be followed by <code>SUPRA_AUTOMATION_CYCLE</code> feature flag being enabled and
+supra_governance::reconfiguration otherwise registry/chain will end-up in inconsistent state.
 
 monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
 thus not causing any inconcistensy in the chain
@@ -3417,7 +3428,7 @@ thus not causing any inconcistensy in the chain
 
     // Prepare the state for migration
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+    <b>let</b> automation_epoch_info = <b>move_from</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
 
     <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
         @supra_framework
@@ -3429,31 +3440,27 @@ thus not causing any inconcistensy in the chain
     <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         &automation_registry_config,
-        automation_epoch_info,
+        &automation_epoch_info,
         current_time
     );
 
     // Start migration by enabling feature, initializing the cycle releated resouces
-    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_next_epoch">features::change_feature_flags_for_next_epoch</a>(
-        supra_framework,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_get_supra_automation_cycle_feature">features::get_supra_automation_cycle_feature</a>()],
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
     <b>let</b> id = 0;
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
         start_time: current_time,
         index: id,
         duration_secs: cycle_duration_secs,
-        state: <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>,
+        state: <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>,
         transition_state: std::option::none()
     });
-    // Remain in READY_TO_START statey <b>if</b> feature is not enabled or registry is not fully initialized
+    // Remain in <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a> statey <b>if</b> feature is not enabled or registry is not fully initialized
     <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>()) {
         <b>return</b>
     };
     // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
-    <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>();
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info)
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info);
+
 }
 </code></pre>
 
@@ -3571,7 +3578,7 @@ is in ongoing state, then migrate_v2 function should be utilized instead.
     <b>let</b> (cycle_state, cycle_id) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
         (<a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, 1)
     } <b>else</b> {
-        (<a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>, 0)
+        (<a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>, 0)
     };
 
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
@@ -3596,7 +3603,7 @@ is in ongoing state, then migrate_v2 function should be utilized instead.
 ## Function `monitor_cycle_end`
 
 Checks the cycle end and emit an event on it.
-Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
+Does nothig if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>()
@@ -3609,7 +3616,7 @@ Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>()) {
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>() || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
         <b>return</b>
     };
     <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>();
@@ -3659,10 +3666,10 @@ then lifecycle is restarted.
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
         // If the lifecycle <b>has</b> been suspended and we are recovering from it, then we <b>update</b> config from buffer and
         // then start a new cycle directly.
-        // Unless we are in READY_TO_START state feature flag being enabled will not have <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> effect.
+        // Unless we are in <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a> state, the feature flag being enabled will not have <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> effect.
         // All the other states mean that we are in the middle of previous transition, which should end
         // before reenabling the feature.
-        <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>) {
+        <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>) {
             <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_length">enumerable_map::length</a>(&registry_data.tasks) != 0) {
                 <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorInconsistentSuspendedState">ErrorInconsistentSuspendedState</a> {});
                 <b>return</b>
@@ -3672,6 +3679,7 @@ then lifecycle is restarted.
         };
         <b>return</b>
     };
+
     // We do not <b>update</b> config here, <b>as</b> due <b>to</b> feature being disabled, cycle ends early so it is expected
     // that <b>native</b> layer will detect this state and generate refund transactions for a cycle that <b>has</b> been kept short.
     // So the confing should remain intact.
@@ -3853,7 +3861,7 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitte
     // Operational constraint: can only be invoked by the VM
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
-        <b>return</b>;
+        <b>return</b>
     };
 
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
@@ -4007,6 +4015,7 @@ Action from native layer will be tiggered by move layer when automation registy 
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>assert</b>!(cycle_info.duration_secs &gt;= duration, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REFUND_DURATION">EINVALID_REFUND_DURATION</a>);
 
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
@@ -4427,7 +4436,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) {
     cycle_info.transition_state = std::option::none&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>&gt;();
-    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>)
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>)
 }
 </code></pre>
 
@@ -5709,9 +5718,7 @@ automation registry management.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>() {
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
-        <a href="automation_registry.md#0x1_automation_registry_native_automation_cycle_management_support">native_automation_cycle_management_support</a>();
-    }
+    <a href="automation_registry.md#0x1_automation_registry_native_automation_cycle_management_support">native_automation_cycle_management_support</a>();
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -11,10 +11,10 @@ This contract is part of the Supra Framework and is designed to manage automated
 
 -  [Resource `ActiveAutomationRegistryConfig`](#0x1_automation_registry_ActiveAutomationRegistryConfig)
 -  [Resource `AutomationRegistryConfig`](#0x1_automation_registry_AutomationRegistryConfig)
+-  [Struct `AutomationRegistryConfigV2`](#0x1_automation_registry_AutomationRegistryConfigV2)
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
 -  [Struct `TransitionState`](#0x1_automation_registry_TransitionState)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
--  [Struct `AutomationCycleDuration`](#0x1_automation_registry_AutomationCycleDuration)
 -  [Struct `AutomationCycleInfo`](#0x1_automation_registry_AutomationCycleInfo)
 -  [Struct `AutomationCycleEvent`](#0x1_automation_registry_AutomationCycleEvent)
 -  [Resource `AutomationCycleDetails`](#0x1_automation_registry_AutomationCycleDetails)
@@ -120,6 +120,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
 -  [Function `try_withdraw_task_automation_fee`](#0x1_automation_registry_try_withdraw_task_automation_fee)
+-  [Function `update_config_from_buffer_for_migration`](#0x1_automation_registry_update_config_from_buffer_for_migration)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `check_registration_task_duration`](#0x1_automation_registry_check_registration_task_duration)
@@ -262,6 +263,87 @@ Automation registry configuration parameters
 </dt>
 <dd>
  Maximum number of tasks that registry can hold.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationRegistryConfigV2"></a>
+
+## Struct `AutomationRegistryConfigV2`
+
+Automation registry configuration parameters
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfigV2">AutomationRegistryConfigV2</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>task_duration_cap_in_secs: u64</code>
+</dt>
+<dd>
+ Maximum allowable duration (in seconds) from the registration time that an automation task can run.
+ If the expiration time exceeds this duration, the task registration will fail.
+</dd>
+<dt>
+<code>registry_max_gas_cap: u64</code>
+</dt>
+<dd>
+ Maximum gas allocation for automation tasks per epoch
+ Exceeding this limit during task registration will cause failure and is used in fee calculation.
+</dd>
+<dt>
+<code>automation_base_fee_in_quants_per_sec: u64</code>
+</dt>
+<dd>
+ Base fee per second for the full capacity of the automation registry, measured in quants/sec.
+ The capacity is considered full if the total committed gas of all registered tasks equals registry_max_gas_cap.
+</dd>
+<dt>
+<code>flat_registration_fee_in_quants: u64</code>
+</dt>
+<dd>
+ Flat registration fee charged by default for each task.
+</dd>
+<dt>
+<code>congestion_threshold_percentage: u8</code>
+</dt>
+<dd>
+ Ratio (in the range [0;100]) representing the acceptable upper limit of committed gas amount
+ relative to registry_max_gas_cap. Beyond this threshold, congestion fees apply.
+</dd>
+<dt>
+<code>congestion_base_fee_in_quants_per_sec: u64</code>
+</dt>
+<dd>
+ Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
+</dd>
+<dt>
+<code>congestion_exponent: u8</code>
+</dt>
+<dd>
+ The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
+</dd>
+<dt>
+<code>task_capacity: u16</code>
+</dt>
+<dd>
+ Maximum number of tasks that registry can hold.
+</dd>
+<dt>
+<code>cycle_duration_secs: u64</code>
+</dt>
+<dd>
+ Automation cycle duration in secods
 </dd>
 </dl>
 
@@ -420,7 +502,7 @@ Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> <b>has</b> <b>copy</b>, drop, key
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> <b>has</b> <b>copy</b>, key
 </code></pre>
 
 
@@ -451,35 +533,6 @@ Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
 </dt>
 <dd>
  Current epoch start time which is the same as last_reconfiguration_time
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_AutomationCycleDuration"></a>
-
-## Struct `AutomationCycleDuration`
-
-Cycle Duration wrapper to store in the config-buffer.
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> <b>has</b> <b>copy</b>, drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>duration_secs: u64</code>
-</dt>
-<dd>
- Automation cycle duration in seconds.
 </dd>
 </dl>
 
@@ -3154,13 +3207,6 @@ Update Automation Registry Config along with cycle duration.
         congestion_threshold_percentage,
         congestion_exponent);
 
-    // Update cycle duration in buffer
-    <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
-        duration_secs: cycle_duration_secs
-    };
-    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
-    <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
-
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
 
     <b>assert</b>!(
@@ -3168,7 +3214,7 @@ Update Automation Registry Config along with cycle duration.
         <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT">EUNACCEPTABLE_AUTOMATION_GAS_LIMIT</a>
     );
 
-    <b>let</b> new_automation_registry_config = <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
+    <b>let</b> new_automation_registry_config = <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfigV2">AutomationRegistryConfigV2</a> {
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         automation_base_fee_in_quants_per_sec,
@@ -3176,16 +3222,16 @@ Update Automation Registry Config along with cycle duration.
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
         congestion_exponent,
-        task_capacity
+        task_capacity,
+        cycle_duration_secs
     };
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_automation_registry_config);
 
-    // next_epoch_registry_max_gas_cap will be <b>update</b> instantly
+    // next cyle registry max gas cap will be <b>update</b> instantly
     <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
 
     <a href="event.md#0x1_event_emit">event::emit</a>(new_automation_registry_config);
-
 }
 </code></pre>
 
@@ -3534,7 +3580,7 @@ thus not causing any inconcistensy in the chain
     <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         &automation_registry_config,
-        &automation_epoch_info,
+        automation_epoch_info,
         current_time
     );
 
@@ -3553,6 +3599,8 @@ thus not causing any inconcistensy in the chain
     };
     // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    // Update the config <b>to</b> start the cycle <b>with</b> new config.
+    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer_for_migration">update_config_from_buffer_for_migration</a>(cycle_info);
     <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info);
 }
 </code></pre>
@@ -4320,7 +4368,7 @@ Refunds the deposit fee of the task and removes from registry.
 Updates the cycle state if the transition is identified to be finalized.
 
 As transition happens from suspended state and while transition was in progress
-- if the feature was enabled back, then the transition will happend direclty to starated state,
+- if the feature was enabled back, then the transition will happen direclty to starated state,
 - otherwise the transition will be done to the ready state.
 
 In both cases config will be updated. In this case we will make sure to keep the consistency of state
@@ -4354,8 +4402,10 @@ when transition to ready state happens through paths
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
 
-    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+        // Update the config in case <b>if</b> transition flow is STARTED -&gt; SUSPENDED-&gt; STARTED.
+        // <b>to</b> reflect new configs for the new cycle <b>if</b> it <b>has</b> been updated during SUSPENDED state processing
+        <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
         <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info)
     } <b>else</b> {
         <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info)
@@ -4636,7 +4686,28 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) {
-    cycle_info.transition_state = std::option::none&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>&gt;();
+    // If the cycle duration updated <b>has</b> been identified during transtion, then the transition state is kept
+    // <b>with</b> reset values <b>except</b> new cycle duration <b>to</b> have it properly set for the next new cycle.
+    // This may happen in case of cycle was ended and feature-flag <b>has</b> been disbaled before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> task <b>has</b>
+    // been processed for the cycle transition.
+    // Note that we want <b>to</b> have consistent data in ready state which says that the cycle pointed in the ready state
+    // <b>has</b> been finished/summerized, and we are ready <b>to</b> start the next new cycle. and all the cycle inforamation should
+    // match the finalized/summerized cycle since its start, including cycle duration
+    <b>if</b> (std::option::is_some(&cycle_info.transition_state)) {
+        <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+        <b>if</b> (transition_state.new_cycle_duration == cycle_info.duration_secs) {
+            cycle_info.transition_state = std::option::none&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>&gt;();
+        } <b>else</b> {
+            // Reset all <b>except</b> new cycle duration
+            transition_state.refund_duration = 0;
+            transition_state.automation_fee_per_sec = 0;
+            transition_state.gas_committed_for_new_cycle = 0;
+            transition_state.gas_committed_for_next_cycle = 0;
+            transition_state.locked_fees = 0;
+            transition_state.expected_tasks_to_be_processed = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+            transition_state.actual_processed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+        }
+    };
     <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>)
 }
 </code></pre>
@@ -4708,6 +4779,7 @@ In all cases if there are no tasks in registry the state will be updated directl
 ) <b>acquires</b>  <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_length">enumerable_map::length</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks) == 0) {
         // Registry is empty <b>move</b> <b>to</b> ready state directly
+        // <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info);
         <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>);
         <b>return</b>
     };
@@ -4764,7 +4836,7 @@ Refunds automation fee for epoch for all eligible tasks and clears automation re
 fee primitives.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64)
 </code></pre>
 
 
@@ -4776,17 +4848,23 @@ fee primitives.
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
+    aei: <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
     current_time: u64
 ) {
-    <b>let</b> previous_epoch_duration = current_time - aei.start_time;
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
+        start_time,
+        epoch_interval: _,
+        expected_epoch_duration,
+
+    } = aei;
+    <b>let</b> previous_epoch_duration = current_time - start_time;
     <b>let</b> refund_interval = 0;
     <b>let</b> refund_automation_fee_per_sec = 0;
 
     // If epoch actual duration is greater or equal <b>to</b> expected epoch-duration then there is nothing <b>to</b> refund.
-    <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees != 0 && previous_epoch_duration &lt; aei.expected_epoch_duration) {
+    <b>if</b> (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees != 0 && previous_epoch_duration &lt; expected_epoch_duration) {
         <b>let</b> previous_tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
-        refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
+        refund_interval = expected_epoch_duration - previous_epoch_duration;
         // Compute the automation fee multiplier for ended epoch
         refund_automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
     };
@@ -5429,6 +5507,47 @@ would allow the congestion fee to increase in a non-linear fashion.
 
 </details>
 
+<a id="0x1_automation_registry_update_config_from_buffer_for_migration"></a>
+
+## Function `update_config_from_buffer_for_migration`
+
+The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
+This function will be called only during migration and can be removed in subsequent releases
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer_for_migration">update_config_from_buffer_for_migration</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer_for_migration">update_config_from_buffer_for_migration</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;()) {
+        <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;();
+        <b>let</b> automation_registry_config = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
+            @supra_framework
+        ).main_config;
+        automation_registry_config.task_duration_cap_in_secs = buffer.task_duration_cap_in_secs;
+        automation_registry_config.registry_max_gas_cap = buffer.registry_max_gas_cap;
+        automation_registry_config.automation_base_fee_in_quants_per_sec = buffer.automation_base_fee_in_quants_per_sec;
+        automation_registry_config.flat_registration_fee_in_quants = buffer.flat_registration_fee_in_quants;
+        automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
+        automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
+        automation_registry_config.congestion_exponent = buffer.congestion_exponent;
+        automation_registry_config.task_capacity = buffer.task_capacity;
+    };
+    // In case <b>if</b> between supra-framework <b>update</b> and migration step the config <b>has</b> been updated using the new API.
+    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_update_config_from_buffer"></a>
 
 ## Function `update_config_from_buffer`
@@ -5446,29 +5565,28 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;()) {
-        <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;();
-        <b>let</b> automation_registry_config = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
-            @supra_framework
-        ).main_config;
-        automation_registry_config.task_duration_cap_in_secs = buffer.task_duration_cap_in_secs;
-        automation_registry_config.registry_max_gas_cap = buffer.registry_max_gas_cap;
-        automation_registry_config.automation_base_fee_in_quants_per_sec = buffer.automation_base_fee_in_quants_per_sec;
-        automation_registry_config.flat_registration_fee_in_quants = buffer.flat_registration_fee_in_quants;
-        automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
-        automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
-        automation_registry_config.congestion_exponent = buffer.congestion_exponent;
-        automation_registry_config.task_capacity = buffer.task_capacity;
+    <b>if</b> (!<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfigV2">AutomationRegistryConfigV2</a>&gt;()) {
+        <b>return</b>
     };
-    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a>&gt;()) {
-        <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a>&gt;();
-        <b>if</b> (std::option::is_some(&cycle_info.transition_state)) {
-            <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
-            transition_state.new_cycle_duration = buffer.duration_secs;
-        } <b>else</b> {
-            cycle_info.duration_secs = buffer.duration_secs;
-        }
-    };
+    <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfigV2">AutomationRegistryConfigV2</a>&gt;();
+    <b>let</b> automation_registry_config = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
+        @supra_framework
+    ).main_config;
+    automation_registry_config.task_duration_cap_in_secs = buffer.task_duration_cap_in_secs;
+    automation_registry_config.registry_max_gas_cap = buffer.registry_max_gas_cap;
+    automation_registry_config.automation_base_fee_in_quants_per_sec = buffer.automation_base_fee_in_quants_per_sec;
+    automation_registry_config.flat_registration_fee_in_quants = buffer.flat_registration_fee_in_quants;
+    automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
+    automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
+    automation_registry_config.congestion_exponent = buffer.congestion_exponent;
+    automation_registry_config.task_capacity = buffer.task_capacity;
+
+    <b>if</b> (std::option::is_some(&cycle_info.transition_state)) {
+        <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+        transition_state.new_cycle_duration = buffer.cycle_duration_secs;
+    } <b>else</b> {
+        cycle_info.duration_secs = buffer.cycle_duration_secs;
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -127,8 +127,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `upscale_from_u256`](#0x1_automation_registry_upscale_from_u256)
 -  [Function `downscale_to_u64`](#0x1_automation_registry_downscale_to_u64)
 -  [Function `downscale_to_u256`](#0x1_automation_registry_downscale_to_u256)
--  [Function `assert_cycle_based_automation_registry_management_support`](#0x1_automation_registry_assert_cycle_based_automation_registry_management_support)
--  [Function `native_cycle_based_automation_registry_management_support`](#0x1_automation_registry_native_cycle_based_automation_registry_management_support)
+-  [Function `assert_automation_cycle_management_support`](#0x1_automation_registry_assert_automation_cycle_management_support)
+-  [Function `native_automation_cycle_management_support`](#0x1_automation_registry_native_automation_cycle_management_support)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -407,7 +407,7 @@ It tracks entries both pending and completed, organized by unique indices.
 
 ## Resource `AutomationEpochInfo`
 
-Epoch state. Deprecated since SUPRA_CYCLE_BASED_AUTOMATION version.
+Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
@@ -3413,7 +3413,7 @@ thus not causing any inconcistensy in the chain
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
     assert_supra_framework(supra_framework);
-    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_cycle_based_automation_enabled">features::supra_cycle_based_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>);
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>);
 
     // Prepare the state for migration
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
@@ -3436,7 +3436,7 @@ thus not causing any inconcistensy in the chain
     // Start migration by enabling feature, initializing the cycle releated resouces
     <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_next_epoch">features::change_feature_flags_for_next_epoch</a>(
         supra_framework,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_get_supra_cycle_based_automation_feature">features::get_supra_cycle_based_automation_feature</a>()],
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_get_supra_automation_cycle_feature">features::get_supra_automation_cycle_feature</a>()],
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
     <b>let</b> id = 0;
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
@@ -3451,7 +3451,7 @@ thus not causing any inconcistensy in the chain
         <b>return</b>
     };
     // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
-    <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>();
+    <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>();
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info)
 }
@@ -3502,7 +3502,7 @@ Deprecated in favor of initialize_v2
 
 ## Function `initialize_v2`
 
-Initialization of Automation Registry with configuration parameters for SUPRA_CYCLE_BASED_AUTOMATION version.
+Initialization of Automation Registry with configuration parameters for SUPRA_AUTOMATION_CYCLE version.
 Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
 automation feature is being introduced very first time.
 In case if framework upgrade is happening on the chain where automation feature is already released and
@@ -3568,7 +3568,7 @@ is in ongoing state, then migrate_v2 function should be utilized instead.
         registration_enabled: <b>true</b>,
     });
 
-    <b>let</b> (cycle_state, cycle_id) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_cycle_based_automation_enabled">features::supra_cycle_based_automation_enabled</a>()) {
+    <b>let</b> (cycle_state, cycle_id) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
         (<a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, 1)
     } <b>else</b> {
         (<a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>, 0)
@@ -3612,7 +3612,7 @@ Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
     <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>()) {
         <b>return</b>
     };
-    <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>();
+    <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>();
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>if</b> (cycle_info.state != <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>
         || cycle_info.start_time + cycle_info.duration_secs &lt; <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>()) {
@@ -3698,7 +3698,7 @@ then lifecycle is restarted.
 ## Function `update_epoch_interval_in_registry`
 
 Update epoch interval in registry while actually update happens in block module
-Deprecated since SUPRA_CYCLE_BASED_AUTOMATION feature release in favor of monitor_cycle_end
+Deprecated since SUPRA_AUTOMATION_CYCLE feature release in favor of monitor_cycle_end
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64)
@@ -5691,15 +5691,15 @@ Insertion sort implementation for vector
 
 </details>
 
-<a id="0x1_automation_registry_assert_cycle_based_automation_registry_management_support"></a>
+<a id="0x1_automation_registry_assert_automation_cycle_management_support"></a>
 
-## Function `assert_cycle_based_automation_registry_management_support`
+## Function `assert_automation_cycle_management_support`
 
-If SUPRA_CYCLE_BASED_AUTOMATION is enabled then call native function to assert full support of cycle based
+If SUPRA_AUTOMATION_CYCLE is enabled then call native function to assert full support of cycle based
 automation registry management.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>()
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>()
 </code></pre>
 
 
@@ -5708,9 +5708,9 @@ automation registry management.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>() {
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_cycle_based_automation_enabled">features::supra_cycle_based_automation_enabled</a>()) {
-        <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>();
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>() {
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
+        <a href="automation_registry.md#0x1_automation_registry_native_automation_cycle_management_support">native_automation_cycle_management_support</a>();
     }
 }
 </code></pre>
@@ -5719,13 +5719,13 @@ automation registry management.
 
 </details>
 
-<a id="0x1_automation_registry_native_cycle_based_automation_registry_management_support"></a>
+<a id="0x1_automation_registry_native_automation_cycle_management_support"></a>
 
-## Function `native_cycle_based_automation_registry_management_support`
+## Function `native_automation_cycle_management_support`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>(): bool
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_native_automation_cycle_management_support">native_automation_cycle_management_support</a>(): bool
 </code></pre>
 
 
@@ -5734,7 +5734,7 @@ automation registry management.
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>(): bool;
+<pre><code><b>native</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_native_automation_cycle_management_support">native_automation_cycle_management_support</a>(): bool;
 </code></pre>
 
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -562,12 +562,6 @@ Event emitted for cycle state transition.
 <dd>
  The state transitioned from
 </dd>
-<dt>
-<code>event_time: u64</code>
-</dt>
-<dd>
- Timestamp of the state transition event registration
-</dd>
 </dl>
 
 
@@ -4617,7 +4611,6 @@ Note it is expected that committed_occupancy does not include currnet task's occ
     <b>let</b> <a href="event.md#0x1_event">event</a> = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleEvent">AutomationCycleEvent</a> {
         cycle_state_info: <a href="automation_registry.md#0x1_automation_registry_into_automation_cycle_info">into_automation_cycle_info</a>(cycle_info),
         old_state,
-        event_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
     };
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="event.md#0x1_event">event</a>)
 }

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -3,7 +3,7 @@
 
 # Module `0x1::automation_registry`
 
-Supra Automation Registry
+Supra Automation tegistry
 
 This contract is part of the Supra Framework and is designed to manage automated task entries
 
@@ -12,8 +12,12 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `AutomationRegistryConfig`](#0x1_automation_registry_AutomationRegistryConfig)
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
+-  [Struct `AutomationCycleDuration`](#0x1_automation_registry_AutomationCycleDuration)
+-  [Resource `AutomationCycleInfo`](#0x1_automation_registry_AutomationCycleInfo)
 -  [Resource `AutomationRefundBookkeeping`](#0x1_automation_registry_AutomationRefundBookkeeping)
 -  [Resource `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
+-  [Struct `AutomationCycleFinished`](#0x1_automation_registry_AutomationCycleFinished)
+-  [Struct `AutomationCycleStarted`](#0x1_automation_registry_AutomationCycleStarted)
 -  [Struct `TaskRegistrationFeeWithdraw`](#0x1_automation_registry_TaskRegistrationFeeWithdraw)
 -  [Struct `TaskRegistrationDepositFeeWithdraw`](#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw)
 -  [Struct `RegistryFeeWithdraw`](#0x1_automation_registry_RegistryFeeWithdraw)
@@ -60,17 +64,22 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `estimate_automation_fee`](#0x1_automation_registry_estimate_automation_fee)
 -  [Function `estimate_automation_fee_with_committed_occupancy`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy)
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
+-  [Function `get_cycle_duration`](#0x1_automation_registry_get_cycle_duration)
+-  [Function `get_cycle_info`](#0x1_automation_registry_get_cycle_info)
 -  [Function `estimate_automation_fee_with_committed_occupancy_internal`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal)
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
 -  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
+-  [Function `initialize_v2`](#0x1_automation_registry_initialize_v2)
+-  [Function `migrate_v2`](#0x1_automation_registry_migrate_v2)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
--  [Function `finalize_epoch_change`](#0x1_automation_registry_finalize_epoch_change)
--  [Function `finalize_epoch_change_for_feature_disabled_state`](#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state)
--  [Function `update_state_for_new_epoch`](#0x1_automation_registry_update_state_for_new_epoch)
--  [Function `refund_cleanup_tasks`](#0x1_automation_registry_refund_cleanup_tasks)
--  [Function `cleanup_tasks`](#0x1_automation_registry_cleanup_tasks)
+-  [Function `on_cycle_end_internal`](#0x1_automation_registry_on_cycle_end_internal)
+-  [Function `move_to_finished_state`](#0x1_automation_registry_move_to_finished_state)
+-  [Function `move_to_suspended_state`](#0x1_automation_registry_move_to_suspended_state)
+-  [Function `move_to_started_state`](#0x1_automation_registry_move_to_started_state)
+-  [Function `update_state_for_migration`](#0x1_automation_registry_update_state_for_migration)
+-  [Function `refund_fee`](#0x1_automation_registry_refund_fee)
 -  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
 -  [Function `safe_deposit_refund`](#0x1_automation_registry_safe_deposit_refund)
 -  [Function `safe_unlock_locked_deposit`](#0x1_automation_registry_safe_unlock_locked_deposit)
@@ -88,6 +97,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `update_config`](#0x1_automation_registry_update_config)
+-  [Function `update_config_v2`](#0x1_automation_registry_update_config_v2)
+-  [Function `update_registration_config_internal`](#0x1_automation_registry_update_registration_config_internal)
 -  [Function `enable_registration`](#0x1_automation_registry_enable_registration)
 -  [Function `disable_registration`](#0x1_automation_registry_disable_registration)
 -  [Function `register`](#0x1_automation_registry_register)
@@ -95,12 +106,15 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `cancel_task`](#0x1_automation_registry_cancel_task)
 -  [Function `stop_tasks`](#0x1_automation_registry_stop_tasks)
 -  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
+-  [Function `monitor_cycle_end`](#0x1_automation_registry_monitor_cycle_end)
 -  [Function `sort_vector`](#0x1_automation_registry_sort_vector)
 -  [Function `upscale_from_u8`](#0x1_automation_registry_upscale_from_u8)
 -  [Function `upscale_from_u64`](#0x1_automation_registry_upscale_from_u64)
 -  [Function `upscale_from_u256`](#0x1_automation_registry_upscale_from_u256)
 -  [Function `downscale_to_u64`](#0x1_automation_registry_downscale_to_u64)
 -  [Function `downscale_to_u256`](#0x1_automation_registry_downscale_to_u256)
+-  [Function `assert_cycle_based_automation_registry_management_support`](#0x1_automation_registry_assert_cycle_based_automation_registry_management_support)
+-  [Function `native_cycle_based_automation_registry_management_support`](#0x1_automation_registry_native_cycle_based_automation_registry_management_support)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -312,7 +326,7 @@ It tracks entries both pending and completed, organized by unique indices.
 
 ## Resource `AutomationEpochInfo`
 
-Epoch state
+Epoch state. Deprecated since SUPRA_NATIVE_AUTOMATION_V2 version.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
@@ -347,6 +361,82 @@ Epoch state
 </dt>
 <dd>
  Current epoch start time which is the same as last_reconfiguration_time
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationCycleDuration"></a>
+
+## Struct `AutomationCycleDuration`
+
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>duration_secs: u64</code>
+</dt>
+<dd>
+ Automation cycle duration in seconds.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationCycleInfo"></a>
+
+## Resource `AutomationCycleInfo`
+
+Cycle state.
+
+
+<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>has</b> <b>copy</b>, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>index: u64</code>
+</dt>
+<dd>
+ Current cycle id. Incremented when a start of the new cycle is processed.
+</dd>
+<dt>
+<code>state: u8</code>
+</dt>
+<dd>
+ State of the current cycle, CYCLE_FINISHED, CYCLE_STARTED. If state is FINISHED, means transition to the next cycle
+ is in progress.
+</dd>
+<dt>
+<code>start_time: u64</code>
+</dt>
+<dd>
+ Current cycle start time which is updated with the current chain time when a cycle is increamented.
+</dd>
+<dt>
+<code>duration_secs: u64</code>
+</dt>
+<dd>
+ Automation cycle duration in seconds.
 </dd>
 </dl>
 
@@ -477,6 +567,70 @@ Automation Deposited fee bookkeeping configs
  It will be refunded fully when active task is expired or cancelled by user
  and partially if a pending task is cancelled by user or an active task is cancelled by the system due to
  insufficient balance to  pay the automation fee for the epoch
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationCycleFinished"></a>
+
+## Struct `AutomationCycleFinished`
+
+Event emitted at automation cycle end.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleFinished">AutomationCycleFinished</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>cycle_id: u64</code>
+</dt>
+<dd>
+ Finished Cycle id.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationCycleStarted"></a>
+
+## Struct `AutomationCycleStarted`
+
+Event emitted at automation cycle end.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleStarted">AutomationCycleStarted</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>cycle_id: u64</code>
+</dt>
+<dd>
+ Started Cycle id.
+</dd>
+<dt>
+<code><a href="timestamp.md#0x1_timestamp">timestamp</a>: u64</code>
+</dt>
+<dd>
+ Cycle start timestamp.
 </dd>
 </dl>
 
@@ -1473,6 +1627,25 @@ Insufficient balance in the resource wallet for withdrawal
 
 
 
+<a id="0x1_automation_registry_CYCLE_FINISHED"></a>
+
+Constants describing CYCLE state.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>: u8 = 0;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_CYCLE_STARTED"></a>
+
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>: u8 = 1;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_DECIMAL"></a>
 
 Decimal place to make
@@ -1523,12 +1696,32 @@ Congestion exponent must be non-zero.
 
 
 
+<a id="0x1_automation_registry_ECYCLE_DURATION_NON_ZERO"></a>
+
+Automation registry max gas capacity cannot be zero.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>: u64 = 30;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EDEPOSIT_REFUND"></a>
 
 Failed to unlock/refund deposit for a task. Internal error, for more details see emitted error events.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>: u64 = 27;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EDEPRECATED_SINCE_V2"></a>
+
+Deprecated function call since SUPRA_NATIVE_AUTOMATION_V2 release.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>: u64 = 29;
 </code></pre>
 
 
@@ -1563,12 +1756,12 @@ Failed to unlock/refund epoch fee for a task. Internal error, for more details s
 
 
 
-<a id="0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH"></a>
+<a id="0x1_automation_registry_EEXPIRY_BEFORE_NEXT_CYCLE"></a>
 
-Expiry time must be after the start of the next epoch
+Expiry time must be after the start of the next cycle
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>: u64 = 3;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_CYCLE">EEXPIRY_BEFORE_NEXT_CYCLE</a>: u64 = 3;
 </code></pre>
 
 
@@ -1754,7 +1947,7 @@ Current committed gas amount is greater than the automation gas limit.
 
 <a id="0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP"></a>
 
-Current epoch interval is greater than specified task duration cap.
+Current automation cycle interval is greater than specified task duration cap.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>: u64 = 18;
@@ -1768,6 +1961,15 @@ Unauthorized access: the caller is not the owner of the task
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>: u64 = 8;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_LIFECYCLE_SUSPENDED"></a>
+
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_LIFECYCLE_SUSPENDED">LIFECYCLE_SUSPENDED</a>: u8 = 2;
 </code></pre>
 
 
@@ -1861,9 +2063,9 @@ Checks whether all required resources are created.
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>(): bool {
     <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework)
-        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework)
-        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework)
+        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework)
+        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework)
 }
 </code></pre>
 
@@ -2331,8 +2533,14 @@ Get automation epoch info
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_automation_epoch_info">get_automation_epoch_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
-    *<b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_automation_epoch_info">get_automation_epoch_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+    <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
+        expected_epoch_duration: 0,
+        epoch_interval: 0,
+        start_time: 0,
+
+    }
 }
 </code></pre>
 
@@ -2361,7 +2569,7 @@ occupancy for the next epoch.
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee">estimate_automation_fee</a>(
     task_occupancy: u64
-): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>let</b> registry = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(task_occupancy, registry.gas_committed_for_next_epoch)
 }
@@ -2393,13 +2601,13 @@ maximum allowed occupancy for the next epoch.
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(
     task_occupancy: u64,
     committed_occupancy: u64
-): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <b>let</b> epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
     <b>let</b> config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
         task_occupancy,
         committed_occupancy,
-        epoch_info,
+        cycle_info.duration_secs,
         config
     )
 }
@@ -2435,6 +2643,58 @@ Returns the current status of the registration in the automation registry.
 
 </details>
 
+<a id="0x1_automation_registry_get_cycle_duration"></a>
+
+## Function `get_cycle_duration`
+
+Returns the current duration of the automation cycle.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_duration">get_cycle_duration</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_duration">get_cycle_duration</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+    <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework).duration_secs
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_get_cycle_info"></a>
+
+## Function `get_cycle_info`
+
+Returns the current status of the registration in the automation registry.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_info">get_cycle_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_info">get_cycle_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+    *<b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal"></a>
 
 ## Function `estimate_automation_fee_with_committed_occupancy_internal`
@@ -2445,7 +2705,7 @@ maximum allowed occupancy for the next epoch.
 Note it is expected that committed_occupancy does not include currnet task's occupancy.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(task_occupancy: u64, committed_occupancy: u64, epoch_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, active_config: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">automation_registry::ActiveAutomationRegistryConfig</a>): u64
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(task_occupancy: u64, committed_occupancy: u64, duration: u64, active_config: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">automation_registry::ActiveAutomationRegistryConfig</a>): u64
 </code></pre>
 
 
@@ -2457,7 +2717,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
     task_occupancy: u64,
     committed_occupancy: u64,
-    epoch_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
+    duration: u64,
     active_config: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>
 ): u64 {
     <b>let</b> total_committed_max_gas = committed_occupancy + task_occupancy;
@@ -2473,7 +2733,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
     };
 
     <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_for_interval">calculate_automation_fee_for_interval</a>(
-        epoch_info.epoch_interval,
+        duration,
         task_occupancy,
         automation_fee_per_sec,
         active_config.next_epoch_registry_max_gas_cap)
@@ -2490,7 +2750,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, congestion_threshold_percentage: u8, congestion_exponent: u8)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(cycle_duration_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, congestion_threshold_percentage: u8, congestion_exponent: u8)
 </code></pre>
 
 
@@ -2500,7 +2760,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
-    epoch_interval_secs: u64,
+    cycle_duration_secs: u64,
     task_duration_cap_in_secs: u64,
     registry_max_gas_cap: u64,
     congestion_threshold_percentage: u8,
@@ -2508,7 +2768,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 ) {
     <b>assert</b>!(congestion_threshold_percentage &lt;= <a href="automation_registry.md#0x1_automation_registry_MAX_PERCENTAGE">MAX_PERCENTAGE</a>, <a href="automation_registry.md#0x1_automation_registry_EMAX_CONGESTION_THRESHOLD">EMAX_CONGESTION_THRESHOLD</a>);
     <b>assert</b>!(congestion_exponent &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECONGESTION_EXP_NON_ZERO">ECONGESTION_EXP_NON_ZERO</a>);
-    <b>assert</b>!(task_duration_cap_in_secs &gt; epoch_interval_secs, <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>);
+    <b>assert</b>!(task_duration_cap_in_secs &gt; cycle_duration_secs, <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>);
     <b>assert</b>!(registry_max_gas_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EREGISTRY_MAX_GAS_CAP_NON_ZERO">EREGISTRY_MAX_GAS_CAP_NON_ZERO</a>);
 }
 </code></pre>
@@ -2551,6 +2811,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 ## Function `initialize`
 
 Initialization of Automation Registry with configuration parameters is expected metrics.
+Deprecated in favor of initialize_v2
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
@@ -2574,9 +2835,76 @@ Initialization of Automation Registry with configuration parameters is expected 
     congestion_exponent: u8,
     task_capacity: u16,
 ) {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_initialize_refund_bookkeeping_resource"></a>
+
+## Function `initialize_refund_bookkeeping_resource`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+        total_deposited_automation_fee: 0
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_initialize_v2"></a>
+
+## Function `initialize_v2`
+
+Initialization of Automation Registry with configuration parameters for SUPRA_NATIVE_AUTOMATION_V2 version.
+Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
+automation feature is being introduced very first time.
+In case if framework upgrade is happening on the chain where automation feature is already released and
+is in ongoing state, then migrate_v2 function should be utilized instead.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    cycle_duration_secs: u64,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
-        epoch_interval_secs,
+        cycle_duration_secs,
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         congestion_threshold_percentage,
@@ -2612,10 +2940,11 @@ Initialization of Automation Registry with configuration parameters is expected 
         registration_enabled: <b>true</b>,
     });
 
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
-        expected_epoch_duration: epoch_interval_secs,
-        epoch_interval: epoch_interval_secs,
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
         start_time: 0,
+        index: 0,
+        duration_secs: cycle_duration_secs,
+        state: <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>
     });
 
     <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework)
@@ -2626,13 +2955,21 @@ Initialization of Automation Registry with configuration parameters is expected 
 
 </details>
 
-<a id="0x1_automation_registry_initialize_refund_bookkeeping_resource"></a>
+<a id="0x1_automation_registry_migrate_v2"></a>
 
-## Function `initialize_refund_bookkeeping_resource`
+## Function `migrate_v2`
+
+API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
+detached from epoch-change.
+IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
+end-up in inconsistent state.
+
+TODO: Think of having native fucntion as means to identify that binary is not updated and lets have it called from
+monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
+thus not causing any inconcistensy in the chain
 
 
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64)
 </code></pre>
 
 
@@ -2641,11 +2978,42 @@ Initialization of Automation Registry with configuration parameters is expected 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-        total_deposited_automation_fee: 0
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64
+    ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+    assert_supra_framework(supra_framework);
+
+    // Prepare the state for migration
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+
+    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
+        @supra_framework
+    ).main_config;
+
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    // Refund the epoch fees <b>as</b> epoch will be cut short and on_new_epoch will be dummy due <b>to</b> migration,
+    // so this is the only place <b>to</b> do the refunds
+    <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        &automation_registry_config,
+        automation_epoch_info,
+        current_time
+    );
+
+    // Start migration by enabling feature, initializing the cycle releated resouces
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_next_epoch">features::change_feature_flags_for_next_epoch</a>(
+        supra_framework,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_get_supra_native_automation_v2_feature">features::get_supra_native_automation_v2_feature</a>()],
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
+    <b>let</b> id = 0;
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+        start_time: current_time,
+        index: id,
+        duration_secs: cycle_duration_secs,
+        state: <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>
     });
+    // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>();
 }
 </code></pre>
 
@@ -2657,7 +3025,7 @@ Initialization of Automation Registry with configuration parameters is expected 
 
 ## Function `on_new_epoch`
 
-On new epoch this function will be triggered and update the automation registry state
+On new epoch caused by reconfiguration this function will be triggered and update the automation registry state
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>()
@@ -2669,59 +3037,46 @@ On new epoch this function will be triggered and update the automation registry 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>(
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-    // Unless registry in initialized, registry will not be updated on new epoch.
-    // Here we need <b>to</b> be careful <b>as</b> well. If the feature is disabled for the current epoch then
-    //  - refund for the previous epoch should be done <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> charges <b>has</b> been done.
-    //  - all tasks should be removed from registry state
-    // Note that <b>with</b> the current setup feature::on_new_epoch is called before <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>
-    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+        // If the lifecycle <b>has</b> been suspended and we are recovering from it, then we <b>update</b> config from buffer and
+        // then start a new cycle directly
+        <b>if</b> ( cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_LIFECYCLE_SUSPENDED">LIFECYCLE_SUSPENDED</a>) {
+            <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
+            <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
+        };
         <b>return</b>
     };
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
-    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-
-    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
-        @supra_framework
-    ).main_config;
-
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> intermediate_state = <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        refund_bookkeeping,
-        &automation_registry_config,
-        automation_epoch_info,
-        current_time
-    );
+    // We do not <b>update</b> config here, <b>as</b> due <b>to</b> feature being disabled, cycle ends early so it is expected
+    // that <b>native</b> layer will detect this state and generate refund transactions for a cycle that <b>has</b> been kept short.
+    // So the confing should remain intact.
+    <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(cycle_info);
+}
+</code></pre>
 
 
-    // Apply the latest configuration <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> parameter <b>has</b> been updated
-    // only after refund <b>has</b> been done for previous epoch.
+
+</details>
+
+<a id="0x1_automation_registry_on_cycle_end_internal"></a>
+
+## Function `on_cycle_end_internal`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
-
-    // If feature is not enabled then we are not charging and tasks are cleared.
-    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-        <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state">finalize_epoch_change_for_feature_disabled_state</a>(
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-            automation_epoch_info,
-            refund_bookkeeping,
-            current_time,
-            intermediate_state);
-        <b>return</b>
-    };
-
-    <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        refund_bookkeeping,
-        &automation_registry_config,
-        automation_epoch_info.epoch_interval,
-        current_time,
-        &<b>mut</b> intermediate_state,
-    );
-
-    <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, automation_epoch_info, current_time, intermediate_state);
+    <a href="automation_registry.md#0x1_automation_registry_move_to_finished_state">move_to_finished_state</a>()
 }
 </code></pre>
 
@@ -2729,13 +3084,13 @@ On new epoch this function will be triggered and update the automation registry 
 
 </details>
 
-<a id="0x1_automation_registry_finalize_epoch_change"></a>
+<a id="0x1_automation_registry_move_to_finished_state"></a>
 
-## Function `finalize_epoch_change`
+## Function `move_to_finished_state`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64, intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_finished_state">move_to_finished_state</a>()
 </code></pre>
 
 
@@ -2744,34 +3099,11 @@ On new epoch this function will be triggered and update the automation registry 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change">finalize_epoch_change</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
-    current_time: u64,
-    intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>
-) {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
-        gas_committed_for_new_epoch,
-        gas_committed_for_next_epoch,
-        epoch_locked_fees,
-        removed_tasks,
-    } = intermediate_state;
-
-    <b>let</b> epoch_locked_fees_value = <a href="coin.md#0x1_coin_value">coin::value</a>(&epoch_locked_fees);
-    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
-
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = epoch_locked_fees_value;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (gas_committed_for_new_epoch <b>as</b> u256);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    automation_epoch_info.start_time = current_time;
-    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
-        task_indexes: removed_tasks
-    });
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
-        task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_finished_state">move_to_finished_state</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
+    cycle_info.state = <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_AutomationCycleFinished">AutomationCycleFinished</a> {
+        cycle_id: cycle_info.index,
     });
 }
 </code></pre>
@@ -2780,13 +3112,13 @@ On new epoch this function will be triggered and update the automation registry 
 
 </details>
 
-<a id="0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state"></a>
+<a id="0x1_automation_registry_move_to_suspended_state"></a>
 
-## Function `finalize_epoch_change_for_feature_disabled_state`
+## Function `move_to_suspended_state`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state">finalize_epoch_change_for_feature_disabled_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>)
 </code></pre>
 
 
@@ -2795,39 +3127,11 @@ On new epoch this function will be triggered and update the automation registry 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_finalize_epoch_change_for_feature_disabled_state">finalize_epoch_change_for_feature_disabled_state</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    automation_epoch_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    current_time: u64,
-    intermediate_state: <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>
-) {
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
-        gas_committed_for_new_epoch: _,
-        gas_committed_for_next_epoch: _,
-        epoch_locked_fees,
-        removed_tasks,
-    } = intermediate_state;
-
-    destroy_zero(epoch_locked_fees);
-
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-
-    <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(
-        &<b>mut</b> removed_tasks,
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks));
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> { task_indexes: removed_tasks });
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
-        task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>) {
+    cycle_info.state = <a href="automation_registry.md#0x1_automation_registry_LIFECYCLE_SUSPENDED">LIFECYCLE_SUSPENDED</a>;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_AutomationCycleFinished">AutomationCycleFinished</a> {
+        cycle_id: cycle_info.index,
     });
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_clear">enumerable_map::clear</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    automation_epoch_info.start_time = current_time;
-    automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
 }
 </code></pre>
 
@@ -2835,15 +3139,13 @@ On new epoch this function will be triggered and update the automation registry 
 
 </details>
 
-<a id="0x1_automation_registry_update_state_for_new_epoch"></a>
+<a id="0x1_automation_registry_move_to_started_state"></a>
 
-## Function `update_state_for_new_epoch`
-
-Checks all tasks for refunds, cancellation and expirations.
-Cleans the stale tasks and calculates gas-committed for the new epoch.
+## Function `move_to_started_state`
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>)
 </code></pre>
 
 
@@ -2852,13 +3154,43 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_new_epoch">update_state_for_new_epoch</a>(
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>) {
+    cycle_info.state = <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>;
+    cycle_info.index = cycle_info.index + 1;
+    cycle_info.start_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_AutomationCycleStarted">AutomationCycleStarted</a> {
+        cycle_id: cycle_info.index,
+        <a href="timestamp.md#0x1_timestamp">timestamp</a>: cycle_info.start_time
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_state_for_migration"></a>
+
+## Function `update_state_for_migration`
+
+Checks all tasks for epoch fee refunds.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>,
     current_time: u64
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+) {
     <b>let</b> previous_epoch_duration = current_time - aei.start_time;
     <b>let</b> refund_interval = 0;
     <b>let</b> refund_automation_fee_per_sec = 0;
@@ -2870,18 +3202,11 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
         // Compute the automation fee multiplier for ended epoch
         refund_automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
     };
+    <a href="automation_registry.md#0x1_automation_registry_refund_fee">refund_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, arc, refund_automation_fee_per_sec, refund_interval, current_time);
 
-    <b>if</b> (refund_automation_fee_per_sec != 0) {
-        <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_tasks">refund_cleanup_tasks</a>(
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-            refund_bookkeeping,
-            current_time,
-            arc,
-            refund_automation_fee_per_sec,
-            refund_interval)
-    } <b>else</b> {
-        <a href="automation_registry.md#0x1_automation_registry_cleanup_tasks">cleanup_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, current_time)
-    }
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
 }
 </code></pre>
 
@@ -2889,16 +3214,13 @@ Cleans the stale tasks and calculates gas-committed for the new epoch.
 
 </details>
 
-<a id="0x1_automation_registry_refund_cleanup_tasks"></a>
+<a id="0x1_automation_registry_refund_fee"></a>
 
-## Function `refund_cleanup_tasks`
-
-Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks.
-Also calculates and returns the total committed max gas for the new epoch along with the task indexes
-that have been removed from the registry.
+## Function `refund_fee`
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_tasks">refund_cleanup_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_fee">refund_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64, current_time: u64)
 </code></pre>
 
 
@@ -2907,17 +3229,17 @@ that have been removed from the registry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_cleanup_tasks">refund_cleanup_tasks</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    current_time: u64,
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_fee">refund_fee</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     refund_automation_fee_per_sec: u256,
     refund_interval: u64,
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+    current_time: u64)
+{
+    <b>if</b> (refund_automation_fee_per_sec == 0) {
+        <b>return</b>
+    };
     <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <b>let</b> tcmg = 0;
-    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
@@ -2925,7 +3247,7 @@ that have been removed from the registry.
     <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
         <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
             <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
                 arc,
@@ -2942,92 +3264,7 @@ that have been removed from the registry.
                 refund);
             epoch_locked_fees = remaining_epoch_locked_fees;
         };
-
-        // Drop or activate task for this current epoch.
-        <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
-            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-                refund_bookkeeping,
-                &resource_signer,
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-                task.task_index,
-                task.owner,
-                task.locked_fee_for_next_epoch,
-            task.locked_fee_for_next_epoch);
-            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-        } <b>else</b> {
-            tcmg = tcmg + task.max_gas_amount;
-        }
     });
-    <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
-        removed_tasks,
-        gas_committed_for_new_epoch: tcmg,
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>(),
-    }
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_cleanup_tasks"></a>
-
-## Function `cleanup_tasks`
-
-Cleans up expired and cancelled.
-Also calculates and returns the total committed max gas for the new epoch along with the task indexes
-that have been removed from the registry.
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_tasks">cleanup_tasks</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, current_time: u64): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cleanup_tasks">cleanup_tasks</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    current_time: u64
-): <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <b>let</b> tcmg = 0;
-    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-    // Perform clean up and updation of state (we can't <b>use</b> enumerable_map::for_each, <b>as</b> actually we need value <b>as</b> mutable ref)
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-        // Drop or activate task for this current epoch.
-        <b>if</b> (task.expiry_time &lt;= current_time || task.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>) {
-            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-                refund_bookkeeping,
-                &resource_signer,
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-                task.task_index,
-                task.owner,
-                task.locked_fee_for_next_epoch,
-                task.locked_fee_for_next_epoch);
-            <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-        } <b>else</b> {
-            tcmg = tcmg + task.max_gas_amount;
-        }
-    });
-
-    <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
-        removed_tasks,
-        gas_committed_for_new_epoch: tcmg,
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>(),
-    }
 }
 </code></pre>
 
@@ -3713,7 +3950,7 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;()) {
         <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;();
         <b>let</b> automation_registry_config = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
@@ -3727,6 +3964,13 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
         automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
         automation_registry_config.congestion_exponent = buffer.congestion_exponent;
         automation_registry_config.task_capacity = buffer.task_capacity;
+    };
+    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a>&gt;()) {
+        <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a>&gt;();
+        <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(
+            @supra_framework
+        );
+        cycle_info.duration_secs = buffer.duration_secs;
     };
 }
 </code></pre>
@@ -3830,14 +4074,107 @@ Update Automation Registry Config
     congestion_base_fee_in_quants_per_sec: u64,
     congestion_exponent: u8,
     task_capacity: u16,
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
+) {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_config_v2"></a>
+
+## Function `update_config_v2`
+
+Update Automation Registry Config along with cycle duration.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_v2">update_config_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, cycle_duration_secs: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_v2">update_config_v2</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+    cycle_duration_secs: u64,
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+
+
+    <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
+        supra_framework,
+        task_duration_cap_in_secs,
+        registry_max_gas_cap,
+        automation_base_fee_in_quants_per_sec,
+        flat_registration_fee_in_quants,
+        congestion_threshold_percentage,
+        congestion_base_fee_in_quants_per_sec,
+        congestion_exponent,
+        task_capacity,
+        cycle_duration_secs,
+    );
+
+    // Update cycle duration in buffer
+    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
+    <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
+        duration_secs: cycle_duration_secs
+    };
+    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
+    <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_registration_config_internal"></a>
+
+## Function `update_registration_config_internal`
+
+Update Automation Registry Config releated to registration.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, cycle_duration_secs: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+    cycle_duration_secs: u64,
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
 
     <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
-        automation_epoch_info.epoch_interval,
+        cycle_duration_secs,
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         congestion_threshold_percentage,
@@ -3953,7 +4290,7 @@ Registers a new automation task entry.
     automation_fee_cap_for_epoch: u64,
     tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     aux_data: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Guarding registration <b>if</b> feature is not enabled.
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&aux_data), <a href="automation_registry.md#0x1_automation_registry_ENO_AUX_DATA_SUPPORTED">ENO_AUX_DATA_SUPPORTED</a>);
@@ -3966,7 +4303,7 @@ Registers a new automation task entry.
 
     <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+    <b>let</b> automation_cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
 
     //Well-formedness check of payload_tx is done in <b>native</b> layer beforehand.
 
@@ -3975,7 +4312,7 @@ Registers a new automation task entry.
         expiry_time,
         registration_time,
         &automation_registry_config.main_config,
-        automation_epoch_info
+        automation_cycle_info
     );
 
     <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
@@ -3992,7 +4329,7 @@ Registers a new automation task entry.
     <b>let</b> estimated_automation_fee_for_epoch = <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
         max_gas_amount,
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch,
-        automation_epoch_info,
+        automation_cycle_info.duration_secs,
         automation_registry_config);
     <b>assert</b>!(automation_fee_cap_for_epoch &gt;= estimated_automation_fee_for_epoch,
         <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH">EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH</a>
@@ -4047,7 +4384,7 @@ Registers a new automation task entry.
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_check_registration_task_duration">check_registration_task_duration</a>(expiry_time: u64, registration_time: u64, automation_registry_config: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_epoch_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_check_registration_task_duration">check_registration_task_duration</a>(expiry_time: u64, registration_time: u64, automation_registry_config: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_cycle_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>)
 </code></pre>
 
 
@@ -4060,7 +4397,7 @@ Registers a new automation task entry.
     expiry_time: u64,
     registration_time: u64,
     automation_registry_config: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    automation_epoch_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>
+    automation_cycle_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>
 ) {
     <b>assert</b>!(expiry_time &gt; registration_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
     <b>let</b> task_duration = expiry_time - registration_time;
@@ -4068,8 +4405,8 @@ Registers a new automation task entry.
 
     // Check that task is valid at least in the next epoch
     <b>assert</b>!(
-        expiry_time &gt; (automation_epoch_info.start_time + automation_epoch_info.epoch_interval),
-        <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_EPOCH">EEXPIRY_BEFORE_NEXT_EPOCH</a>
+        expiry_time &gt; (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
+        <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_CYCLE">EEXPIRY_BEFORE_NEXT_CYCLE</a>
     );
 }
 </code></pre>
@@ -4103,7 +4440,7 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(
     owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task_index: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>{
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>{
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
     <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
@@ -4136,10 +4473,10 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
         automation_task_metadata_mut.state = <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>;
     };
 
-    <b>let</b> epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
-    // This check means the task was expected <b>to</b> be executed in the next epoch, but it <b>has</b> been cancelled.
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
+    // This check means the task was expected <b>to</b> be executed in the next cycle, but it <b>has</b> been cancelled.
     // We need <b>to</b> remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
-    <b>if</b> (automation_task_metadata.expiry_time &gt; (epoch_info.start_time + epoch_info.expected_epoch_duration)) {
+    <b>if</b> (automation_task_metadata.expiry_time &gt; (cycle_info.start_time + cycle_info.duration_secs)) {
         <b>assert</b>!(
             <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &gt;= automation_task_metadata.max_gas_amount,
             <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_UNDERFLOW">EGAS_COMMITTEED_VALUE_UNDERFLOW</a>
@@ -4179,14 +4516,14 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
 <pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_stop_tasks">stop_tasks</a>(
     owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
     // Ensure that task indexes are provided
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes), <a href="automation_registry.md#0x1_automation_registry_EEMPTY_TASK_INDEXES">EEMPTY_TASK_INDEXES</a>);
 
     <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> arc = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework).main_config;
-    <b>let</b> epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
     <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
 
     <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
@@ -4200,13 +4537,12 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
 
     // Calculate refundable fee for this remaining time task in current epoch
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> epoch_end_time = epoch_info.expected_epoch_duration + epoch_info.start_time;
-    <b>let</b> residual_interval = <b>if</b> (epoch_end_time &lt;= current_time) {
+    <b>let</b> cycle_end_time = cycle_info.duration_secs + cycle_info.start_time;
+    <b>let</b> residual_interval = <b>if</b> (cycle_end_time &lt;= current_time) {
         0
     } <b>else</b> {
-        epoch_end_time - current_time
+        cycle_end_time - current_time
     };
-
 
     // Loop through each task index <b>to</b> validate and stop the task
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
@@ -4222,7 +4558,7 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
             // This check means the task was expected <b>to</b> be executed in the next epoch, but it <b>has</b> been stopped.
             // We need <b>to</b> remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
             // Also it checks that task should not be cancelled.
-            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> && task.expiry_time &gt; epoch_end_time) {
+            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> && task.expiry_time &gt; cycle_end_time) {
                 // Prevent underflow in gas committed
                 <b>assert</b>!(
                     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &gt;= task.max_gas_amount,
@@ -4295,9 +4631,10 @@ by the max gas amount of the stopped task. Half of the remaining task fee is ref
 ## Function `update_epoch_interval_in_registry`
 
 Update epoch interval in registry while actually update happens in block module
+Deprecated since SUPRA_NATIVE_AUTOMATION_V2 feature release in favor of monitor_cycle_end
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(epoch_interval_microsecs: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64)
 </code></pre>
 
 
@@ -4306,11 +4643,41 @@ Update epoch interval in registry while actually update happens in block module
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(epoch_interval_microsecs: u64) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a> {
-    <b>if</b> (<b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework)) {
-        <b>let</b> automation_epoch_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
-        automation_epoch_info.epoch_interval = epoch_interval_microsecs / <a href="automation_registry.md#0x1_automation_registry_MICROSECS_CONVERSION_FACTOR">MICROSECS_CONVERSION_FACTOR</a>;
-    };
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64) {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_monitor_cycle_end"></a>
+
+## Function `monitor_cycle_end`
+
+Checks the cycle end and emit an event on it.
+Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>() {
+    // TODO: check is initialized, <b>if</b> not emit <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> but do not fail.
+    // check <b>if</b> SUPRA_NATIVE_AUTOMATION feature is disabled, do nothing
+    // call dummy <b>native</b> function which should be available <b>if</b> SUPRA_NATIVE_AUTOMATION_V2 is enabled.
+    //    - It does nothing , <b>if</b> binary is also updated, otherwise VM will panic causing <a href="block.md#0x1_block">block</a>-prologue <b>to</b>
+    //      fail resulting in node failure <b>as</b> well.
+    // Otherwise <b>if</b> cycle_start + cycle_duration &gt;= current time, mark the cycle <b>as</b> finished:
+    // on_cycle_end_internal
+    <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>();
 }
 </code></pre>
 
@@ -4457,6 +4824,56 @@ Insertion sort implementation for vector
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_downscale_to_u256">downscale_to_u256</a>(value: u256): u256 { value / <a href="automation_registry.md#0x1_automation_registry_DECIMAL">DECIMAL</a> }
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_assert_cycle_based_automation_registry_management_support"></a>
+
+## Function `assert_cycle_based_automation_registry_management_support`
+
+If SUPRA_NATIVE_AUTOMATION_V2 is enabled then call native function to assert full support of cycle based
+automation registry management.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>() {
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_v2_enabled">features::supra_native_automation_v2_enabled</a>()) {
+        <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>();
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_native_cycle_based_automation_registry_management_support"></a>
+
+## Function `native_cycle_based_automation_registry_management_support`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>(): bool;
 </code></pre>
 
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -49,7 +49,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `is_transition_finalized`](#0x1_automation_registry_is_transition_finalized)
 -  [Function `is_transition_in_progress`](#0x1_automation_registry_is_transition_in_progress)
 -  [Function `update_processed_tasks`](#0x1_automation_registry_update_processed_tasks)
--  [Function `append_processed_tasks`](#0x1_automation_registry_append_processed_tasks)
+-  [Function `append_processed_task`](#0x1_automation_registry_append_processed_task)
 -  [Function `already_processed`](#0x1_automation_registry_already_processed)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
@@ -71,7 +71,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `get_automation_epoch_info`](#0x1_automation_registry_get_automation_epoch_info)
 -  [Function `estimate_automation_fee`](#0x1_automation_registry_estimate_automation_fee)
 -  [Function `estimate_automation_fee_with_committed_occupancy`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy)
--  [Function `calculate_automation_fee_unit_for_committed_occupancy`](#0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy)
+-  [Function `calculate_automation_fee_multiplier_for_committed_occupancy`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy)
+-  [Function `calculate_automation_fee_unit_for_current_cycle`](#0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle)
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
 -  [Function `get_cycle_duration`](#0x1_automation_registry_get_cycle_duration)
 -  [Function `get_cycle_info`](#0x1_automation_registry_get_cycle_info)
@@ -90,24 +91,25 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
 -  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
 -  [Function `register`](#0x1_automation_registry_register)
--  [Function `on_drop`](#0x1_automation_registry_on_drop)
--  [Function `on_charge`](#0x1_automation_registry_on_charge)
--  [Function `on_refund_and_cleanup`](#0x1_automation_registry_on_refund_and_cleanup)
+-  [Function `process_tasks`](#0x1_automation_registry_process_tasks)
+-  [Function `on_cycle_transition`](#0x1_automation_registry_on_cycle_transition)
+-  [Function `on_cycle_suspend`](#0x1_automation_registry_on_cycle_suspend)
+-  [Function `drop_or_charge_tasks`](#0x1_automation_registry_drop_or_charge_tasks)
+-  [Function `drop_or_charge_task`](#0x1_automation_registry_drop_or_charge_task)
+-  [Function `refund_deposit_and_drop`](#0x1_automation_registry_refund_deposit_and_drop)
 -  [Function `into_automation_cycle_info`](#0x1_automation_registry_into_automation_cycle_info)
 -  [Function `update_cycle_transition_state_from_suspended`](#0x1_automation_registry_update_cycle_transition_state_from_suspended)
 -  [Function `update_cycle_transition_state_from_finished`](#0x1_automation_registry_update_cycle_transition_state_from_finished)
 -  [Function `estimate_automation_fee_with_committed_occupancy_internal`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal)
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
--  [Function `on_cycle_start_internal`](#0x1_automation_registry_on_cycle_start_internal)
 -  [Function `on_cycle_end_internal`](#0x1_automation_registry_on_cycle_end_internal)
 -  [Function `update_cycle_state_to`](#0x1_automation_registry_update_cycle_state_to)
 -  [Function `move_to_ready_state`](#0x1_automation_registry_move_to_ready_state)
 -  [Function `move_to_started_state`](#0x1_automation_registry_move_to_started_state)
--  [Function `move_to_suspended_state`](#0x1_automation_registry_move_to_suspended_state)
+-  [Function `try_move_to_suspended_state`](#0x1_automation_registry_try_move_to_suspended_state)
 -  [Function `update_state_for_migration`](#0x1_automation_registry_update_state_for_migration)
--  [Function `refund_fee`](#0x1_automation_registry_refund_fee)
--  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
+-  [Function `refund_tasks_fees`](#0x1_automation_registry_refund_tasks_fees)
 -  [Function `safe_deposit_refund`](#0x1_automation_registry_safe_deposit_refund)
 -  [Function `safe_unlock_locked_deposit`](#0x1_automation_registry_safe_unlock_locked_deposit)
 -  [Function `safe_unlock_locked_epoch_fee`](#0x1_automation_registry_safe_unlock_locked_epoch_fee)
@@ -115,15 +117,13 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `safe_refund`](#0x1_automation_registry_safe_refund)
 -  [Function `calculate_task_fee`](#0x1_automation_registry_calculate_task_fee)
 -  [Function `calculate_automation_fee_for_interval`](#0x1_automation_registry_calculate_automation_fee_for_interval)
+-  [Function `calculate_automation_fee_multiplier_for_current_cycle_internal`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal)
 -  [Function `calculate_automation_fee_multiplier_for_epoch`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch)
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
--  [Function `try_charge_tasks_automation_fees`](#0x1_automation_registry_try_charge_tasks_automation_fees)
--  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
 -  [Function `try_withdraw_task_automation_fee`](#0x1_automation_registry_try_withdraw_task_automation_fee)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
--  [Function `update_registration_config_internal`](#0x1_automation_registry_update_registration_config_internal)
 -  [Function `check_registration_task_duration`](#0x1_automation_registry_check_registration_task_duration)
 -  [Function `sort_vector`](#0x1_automation_registry_sort_vector)
 -  [Function `upscale_from_u8`](#0x1_automation_registry_upscale_from_u8)
@@ -359,6 +359,12 @@ It tracks entries both pending and completed, organized by unique indices.
 
 <dl>
 <dt>
+<code>refund_duration: u64</code>
+</dt>
+<dd>
+ Remaining duration if cycle was kept short. Actual only in case of suspention.
+</dd>
+<dt>
 <code>new_cycle_duration: u64</code>
 </dt>
 <dd>
@@ -371,7 +377,7 @@ It tracks entries both pending and completed, organized by unique indices.
  Calculated automation fee per second for the new cycle.
 </dd>
 <dt>
-<code>gas_committed_for_this_cycle: u64</code>
+<code>gas_committed_for_new_cycle: u64</code>
 </dt>
 <dd>
  Gas committed for the new cycle being transitioned.
@@ -2009,10 +2015,20 @@ Resource Account does not have sufficient balance to process the refund for the 
 
 <a id="0x1_automation_registry_EINVALID_CHARGE_ACTION"></a>
 
-Attempt to run charge action with inconsistent input values compared to internal state.
+Attempt to run charge action with inconsistent input values compared to internal state, or with cancelled task.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>: u64 = 34;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EINVALID_DROP_ACTION"></a>
+
+Attempt to drop task which is still valid
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_DROP_ACTION">EINVALID_DROP_ACTION</a>: u64 = 36;
 </code></pre>
 
 
@@ -2328,13 +2344,13 @@ The length of the transaction hash.
 
 </details>
 
-<a id="0x1_automation_registry_append_processed_tasks"></a>
+<a id="0x1_automation_registry_append_processed_task"></a>
 
-## Function `append_processed_tasks`
+## Function `append_processed_task`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64)
 </code></pre>
 
 
@@ -2343,7 +2359,7 @@ The length of the transaction hash.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64) {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64) {
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> state.actual_processed_tasks, task_index);
 }
 </code></pre>
@@ -2950,9 +2966,9 @@ maximum allowed occupancy for the next epoch.
 
 </details>
 
-<a id="0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy"></a>
+<a id="0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy"></a>
 
-## Function `calculate_automation_fee_unit_for_committed_occupancy`
+## Function `calculate_automation_fee_multiplier_for_committed_occupancy`
 
 Calculates automation fee per second for the specified task occupancy
 referencing the current automation registry fee parameters, specified total/committed occupancy and current registry
@@ -2960,7 +2976,7 @@ maximum allowed occupancy.
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy">calculate_automation_fee_unit_for_committed_occupancy</a>(total_committed_max_gas: u64): u64
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy">calculate_automation_fee_multiplier_for_committed_occupancy</a>(total_committed_max_gas: u64): u64
 </code></pre>
 
 
@@ -2969,16 +2985,47 @@ maximum allowed occupancy.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy">calculate_automation_fee_unit_for_committed_occupancy</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy">calculate_automation_fee_multiplier_for_committed_occupancy</a>(
     total_committed_max_gas: u64
 ): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    // Compute the automation fee multiplier for epoch
+    // Compute the automation fee multiplier for cycle
     <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
         &active_config.main_config,
         (total_committed_max_gas <b>as</b> u256),
         active_config.main_config.registry_max_gas_cap);
     (automation_fee_per_sec <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle"></a>
+
+## Function `calculate_automation_fee_unit_for_current_cycle`
+
+Calculates automation fee per second for the current cycle
+referencing the current automation registry fee parameters, and committed gas for this cycle stored in
+the automation registry and current maximum allowed occupancy.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle">calculate_automation_fee_unit_for_current_cycle</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle">calculate_automation_fee_unit_for_current_cycle</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    // Compute the automation fee multiplier for this cycle
+    <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal">calculate_automation_fee_multiplier_for_current_cycle_internal</a>(active_config, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>)
 }
 </code></pre>
 
@@ -3161,16 +3208,28 @@ Update Automation Registry Config along with cycle duration.
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
+    <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
+        cycle_duration_secs,
+        task_duration_cap_in_secs,
+        registry_max_gas_cap,
+        congestion_threshold_percentage,
+        congestion_exponent);
+
     // Update cycle duration in buffer
-    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
     <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
         duration_secs: cycle_duration_secs
     };
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
     <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
 
-    <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
-        supra_framework,
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+
+    <b>assert</b>!(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &lt; registry_max_gas_cap,
+        <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT">EUNACCEPTABLE_AUTOMATION_GAS_LIMIT</a>
+    );
+
+    <b>let</b> new_automation_registry_config = <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         automation_base_fee_in_quants_per_sec,
@@ -3178,9 +3237,15 @@ Update Automation Registry Config along with cycle duration.
         congestion_threshold_percentage,
         congestion_base_fee_in_quants_per_sec,
         congestion_exponent,
-        task_capacity,
-        cycle_duration_secs,
-    );
+        task_capacity
+    };
+    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_automation_registry_config);
+
+    // next_epoch_registry_max_gas_cap will be <b>update</b> instantly
+    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(new_automation_registry_config);
 
 }
 </code></pre>
@@ -3514,6 +3579,7 @@ thus not causing any inconcistensy in the chain
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
     assert_supra_framework(supra_framework);
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>);
+    <b>assert</b>!(<b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework), <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>);
 
     // Prepare the state for migration
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
@@ -3549,7 +3615,6 @@ thus not causing any inconcistensy in the chain
     // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info);
-
 }
 </code></pre>
 
@@ -3664,11 +3729,12 @@ is in ongoing state, then migrate_v2 function should be utilized instead.
         registration_enabled: <b>true</b>,
     });
 
-    <b>let</b> (cycle_state, cycle_id) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
-        (<a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, 1)
-    } <b>else</b> {
-        (<a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>, 0)
-    };
+    <b>let</b> (cycle_state, cycle_id) =
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>() && <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+            (<a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, 1)
+        } <b>else</b> {
+            (<a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>, 0)
+        };
 
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
         start_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
@@ -3711,7 +3777,7 @@ Does nothig if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
     <a href="automation_registry.md#0x1_automation_registry_assert_automation_cycle_management_support">assert_automation_cycle_management_support</a>();
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>if</b> (cycle_info.state != <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>
-        || cycle_info.start_time + cycle_info.duration_secs &lt; <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>()) {
+        || cycle_info.start_time + cycle_info.duration_secs &gt; <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>()) {
         <b>return</b>
     };
     <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info)
@@ -3773,12 +3839,12 @@ then lifecycle is restarted.
     // that <b>native</b> layer will detect this state and generate refund transactions for a cycle that <b>has</b> been kept short.
     // So the confing should remain intact.
     <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>) {
-        <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(registry_data, cycle_info);
+        <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(registry_data, cycle_info);
     } <b>else</b> <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a> && std::option::is_some(&cycle_info.transition_state)) {
         <b>let</b> trasition_state = std::option::borrow(&cycle_info.transition_state);
         <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(trasition_state)) {
             // Just entered cycle-end phase, and meanwhile also feature <b>has</b> been disabled so it is safe <b>to</b> <b>move</b> <b>to</b> suspended state.
-            <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(registry_data, cycle_info);
+            <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(registry_data, cycle_info);
         }
         // Otherwise wait of the cycle transition <b>to</b> end and then feature flag value will be taken into <a href="account.md#0x1_account">account</a>.
     }
@@ -3930,14 +3996,14 @@ Registers a new automation task entry.
 
 </details>
 
-<a id="0x1_automation_registry_on_drop"></a>
+<a id="0x1_automation_registry_process_tasks"></a>
 
-## Function `on_drop`
+## Function `process_tasks`
 
-Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitted by native layer ahead of cycle transition
+Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emitted by native layer ahead of cycle transition
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_drop">on_drop</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_process_tasks">process_tasks</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -3946,47 +4012,17 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitte
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_drop">on_drop</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_process_tasks">process_tasks</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     // Operational constraint: can only be invoked by the VM
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>) {
+        <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(vm, task_indexes);
         <b>return</b>
     };
-
-    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
-    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
-    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-
-    <b>let</b> transaction_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
-    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
-        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-
-            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-                refund_bookkeeping,
-                &resource_signer,
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-                task_index,
-                task.owner,
-                task.locked_fee_for_next_epoch,
-                task.locked_fee_for_next_epoch);
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-            <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(transaction_state, task_index);
-        };
-    });
-
-    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info);
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
-        task_indexes: removed_tasks
-    });
-
+    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(vm, task_indexes);
 }
 </code></pre>
 
@@ -3994,14 +4030,13 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitte
 
 </details>
 
-<a id="0x1_automation_registry_on_charge"></a>
+<a id="0x1_automation_registry_on_cycle_transition"></a>
 
-## Function `on_charge`
-
-Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emitted by native layer ahead of cycle transition
+## Function `on_cycle_transition`
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_charge">on_charge</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, gas_committed_for_new_cycle: u64)
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4010,7 +4045,7 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emit
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_charge">on_charge</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, gas_committed_for_new_cycle: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     // Operational constraint: can only be invoked by the VM
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
@@ -4024,35 +4059,24 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emit
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
 
     <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
-    <b>if</b> (transition_state.gas_committed_for_this_cycle == 0) {
-        transition_state.gas_committed_for_this_cycle = gas_committed_for_new_cycle;
-        transition_state.automation_fee_per_sec = automation_fee_per_sec;
-    } <b>else</b> {
-        <b>assert</b>!(transition_state.gas_committed_for_this_cycle == gas_committed_for_new_cycle, <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>);
-        <b>assert</b>!(transition_state.automation_fee_per_sec == automation_fee_per_sec, <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>);
-    };
 
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
     <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <b>let</b> intermedate_result = <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
         removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-        gas_committed_for_new_epoch: gas_committed_for_new_cycle,
+        gas_committed_for_new_epoch: transition_state.gas_committed_for_new_cycle,
         gas_committed_for_next_epoch: 0,
         epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>()
     };
 
-    <b>let</b> charge_duration = transition_state.new_cycle_duration;
-
-    <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
+    <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_tasks">drop_or_charge_tasks</a>(
+        task_indexes,
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         refund_bookkeeping,
         transition_state,
         &automation_registry_config.main_config,
-        (automation_fee_per_sec <b>as</b> u256),
-    charge_duration,
-    <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
-        task_indexes,
+        <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
         &<b>mut</b> intermedate_result
     );
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
@@ -4080,15 +4104,13 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emit
 
 </details>
 
-<a id="0x1_automation_registry_on_refund_and_cleanup"></a>
+<a id="0x1_automation_registry_on_cycle_suspend"></a>
 
-## Function `on_refund_and_cleanup`
-
-Called by MoveVm on <code>AutomationBookkeepingAction::RefundAndCleanup</code> action.
-Action from native layer will be tiggered by move layer when automation registy cycle is updated to SUSPENDED.
+## Function `on_cycle_suspend`
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_refund_and_cleanup">on_refund_and_cleanup</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, duration: u64, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4097,7 +4119,7 @@ Action from native layer will be tiggered by move layer when automation registy 
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_refund_and_cleanup">on_refund_and_cleanup</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, duration: u64, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     // Operational constraint: can only be invoked by the VM
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
@@ -4109,7 +4131,8 @@ Action from native layer will be tiggered by move layer when automation registy 
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
-    <b>assert</b>!(cycle_info.duration_secs &gt;= duration, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REFUND_DURATION">EINVALID_REFUND_DURATION</a>);
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+
 
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
@@ -4120,19 +4143,19 @@ Action from native layer will be tiggered by move layer when automation registy 
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
     <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
         <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
             <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
 
-            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+            // Do not attempt fee refund <b>if</b> remaining duration is 0
+            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a> && transition_state.refund_duration != 0) {
                 <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
                     &arc.main_config,
                     &task,
-                    duration,
+                    transition_state.refund_duration,
                     current_time,
-                    (automation_fee_per_sec <b>as</b> u256));
+                    (transition_state.automation_fee_per_sec <b>as</b> u256));
                 <b>let</b> (_, remaining_epoch_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
                     epoch_locked_fees,
                     &resource_signer,
@@ -4152,7 +4175,7 @@ Action from native layer will be tiggered by move layer when automation registy 
                 task.locked_fee_for_next_epoch,
                 task.locked_fee_for_next_epoch);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-            <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(transition_state, task_index);
+            <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(transition_state, task_index);
         };
     });
 
@@ -4160,6 +4183,176 @@ Action from native layer will be tiggered by move layer when automation registy 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
         task_indexes: removed_tasks
     });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_drop_or_charge_tasks"></a>
+
+## Function `drop_or_charge_tasks`
+
+Traverses all input task indexes and either drops or tries to charge automation fee if possible.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_tasks">drop_or_charge_tasks</a>(task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, current_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_tasks">drop_or_charge_tasks</a>(
+    task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;,
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    current_time: u64,
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
+) {
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    <b>let</b> current_cycle_end_time = current_time + transition_state.new_cycle_duration;
+
+    // Sort task indexes <b>to</b> charge automation fees in the tasks chronological order
+    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
+
+    // Process each active task and calculate fee for the epoch for the tasks
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
+        <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_task">drop_or_charge_task</a>(
+            task_index,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+            refund_bookkeeping,
+            arc,
+            transition_state,
+            &resource_signer,
+            current_time,
+            current_cycle_end_time,
+            intermediate_state
+        )
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_drop_or_charge_task"></a>
+
+## Function `drop_or_charge_task`
+
+Drops or charges the input task.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_task">drop_or_charge_task</a>(task_index: u64, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, current_time: u64, current_cycle_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_task">drop_or_charge_task</a>(
+    task_index: u64,
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>,
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    current_time: u64,
+    current_cycle_end_time: u64,
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
+)
+{
+    <b>if</b> (<a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(transition_state,task_index) || !<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+        <b>return</b>
+    };
+    <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(transition_state, task_index);
+    <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+    <b>if</b> (task_meta.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task_meta.expiry_time &lt;= current_time) {
+        <a href="automation_registry.md#0x1_automation_registry_refund_deposit_and_drop">refund_deposit_and_drop</a>(task_index, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, resource_signer, &<b>mut</b> intermediate_state.removed_tasks);
+        <b>return</b>
+    };
+
+    <b>let</b> fee= <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
+        arc,
+        task_meta,
+        transition_state.new_cycle_duration,
+        current_time,
+        (transition_state.automation_fee_per_sec <b>as</b> u256));
+    // If the task reached this phase that means it is valid active task for the new epoch.
+    // During cleanup all expired tasks <b>has</b> been removed from the registry but the state of the tasks is not updated.
+    // As here we need <b>to</b> distinguish new tasks from already existing active tasks,
+    // <b>as</b> the fee calculation for them will be different based on their active duration in the epoch.
+    // For more details see calculate_task_fee function.
+    task_meta.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+    <b>let</b> task = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+        task_index,
+        owner: task_meta.owner,
+        fee,
+        expiry_time: task_meta.expiry_time,
+        automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+        max_gas_amount: task_meta.max_gas_amount,
+        locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+    };
+    <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        refund_bookkeeping,
+        resource_signer,
+        task,
+        current_cycle_end_time,
+        intermediate_state
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_refund_deposit_and_drop"></a>
+
+## Function `refund_deposit_and_drop`
+
+Refunds the deposit fee of the task and removes from registry.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_deposit_and_drop">refund_deposit_and_drop</a>(task_index: u64, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, removed_tasks: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_deposit_and_drop">refund_deposit_and_drop</a>(
+    task_index: u64,
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    removed_tasks: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+
+)  {
+    <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+    <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+        refund_bookkeeping,
+        resource_signer,
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+        task_index,
+        task.owner,
+        task.locked_fee_for_next_epoch,
+        task.locked_fee_for_next_epoch);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(removed_tasks, task_index);
 }
 </code></pre>
 
@@ -4269,17 +4462,29 @@ which will not proceeded farther in any case.
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>,
-) {
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
 
-    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+    <b>let</b> transition_state = std::option::borrow(&cycle_info.transition_state);
     <b>let</b> transition_finalized = <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(transition_state);
 
     <b>if</b> (transition_finalized) {
-        <a href="automation_registry.md#0x1_automation_registry_on_cycle_start_internal">on_cycle_start_internal</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info);
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (transition_state.gas_committed_for_new_cycle <b>as</b> u256);
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = transition_state.locked_fees;
+
+        // Set current <a href="timestamp.md#0x1_timestamp">timestamp</a> <b>as</b> cycle start_time
+        // Increase cycle and <b>update</b> the state <b>to</b> Started
+        <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
+        <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids)) {
+            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
+                task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
+            });
+        }
     };
     <b>if</b> (transition_finalized  && !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-        <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info)
+        <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info)
     }
 }
 </code></pre>
@@ -4359,6 +4564,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
     congestion_threshold_percentage: u8,
     congestion_exponent: u8,
 ) {
+    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
     <b>assert</b>!(congestion_threshold_percentage &lt;= <a href="automation_registry.md#0x1_automation_registry_MAX_PERCENTAGE">MAX_PERCENTAGE</a>, <a href="automation_registry.md#0x1_automation_registry_EMAX_CONGESTION_THRESHOLD">EMAX_CONGESTION_THRESHOLD</a>);
     <b>assert</b>!(congestion_exponent &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECONGESTION_EXP_NON_ZERO">ECONGESTION_EXP_NON_ZERO</a>);
     <b>assert</b>!(task_duration_cap_in_secs &gt; cycle_duration_secs, <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_TASK_DURATION_CAP">EUNACCEPTABLE_TASK_DURATION_CAP</a>);
@@ -4399,49 +4605,6 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 </details>
 
-<a id="0x1_automation_registry_on_cycle_start_internal"></a>
-
-## Function `on_cycle_start_internal`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_start_internal">on_cycle_start_internal</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_start_internal">on_cycle_start_internal</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>
-) {
-    // Indicates that moving <b>to</b> cycle start from transition state.
-    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
-    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
-
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (transition_state.gas_committed_for_this_cycle <b>as</b> u256);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = transition_state.locked_fees;
-
-    // Set current <a href="timestamp.md#0x1_timestamp">timestamp</a> <b>as</b> cycle start_time
-    // Increase cycle and <b>update</b> the state <b>to</b> Started
-    <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
-    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids)) {
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
-            task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
-        });
-    }
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_on_cycle_end_internal"></a>
 
 ## Function `on_cycle_end_internal`
@@ -4459,20 +4622,31 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_length">enumerable_map::length</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks) == 0) {
+        // Registry is empty <b>update</b> config-buffer and <b>move</b> <b>to</b> started state directly
+        <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
+        <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
+        <b>return</b>
+    };
     <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
+        refund_duration: 0,
         new_cycle_duration: cycle_info.duration_secs,
         automation_fee_per_sec: 0,
-        gas_committed_for_this_cycle: 0,
+        gas_committed_for_new_cycle: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch,
         gas_committed_for_next_cycle: 0,
         locked_fees: 0,
         expected_tasks_to_be_processed: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks),
         actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
     };
     cycle_info.transition_state = std::option::some(transition_state);
-    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>);
     // During cycle transition we <b>update</b> config only after transition state is created in order <b>to</b> have new cycle
     // duration <b>as</b> transition parameter.
     <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
+    // Calculate automation fee per second for the new epoch only after configuration is updated.
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+    transition_state.automation_fee_per_sec =
+        <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy">calculate_automation_fee_multiplier_for_committed_occupancy</a>(transition_state.gas_committed_for_new_cycle);
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>);
 }
 </code></pre>
 
@@ -4566,22 +4740,27 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 </details>
 
-<a id="0x1_automation_registry_move_to_suspended_state"></a>
+<a id="0x1_automation_registry_try_move_to_suspended_state"></a>
 
-## Function `move_to_suspended_state`
+## Function `try_move_to_suspended_state`
 
-Transition to suspended state is expected
+Transition to suspended state is expected to be called
 a) when cycle is active and in progress
-- here we do simply move to suspended state so native layer can start requesting refunds and cleanup actions
+- here we do simply move to suspended state so native layer can start requesting tasks processing
+which will end up in  refunds and cleanup. Note that refund will be done based on total gas-committed
+for the current cycle defined at the begining for the cycle, and using current automation fee parameters
 b) when cycle has just finished and there was another transaction causing feature suspension
 - as this both events happen in scope of the same block, then we will simply update the state to suspended
-and the native layer should identify this and request refund and cleanup with 0 fee and 0 duration,
-which will lead to simply deposit refund and cleanup.
+and the native layer should identify the transition and request processing of the all available tasks.
+Note that in this case automation fee refund will not be expected and suspention and cycle end matched and
+no fee was yet charged to be refunded.
+So the duration for refund and automation-fee-per-second for refund will be 0
 c) when cycle transition was in progress and there was a feature suspension, but it could not be applied,
-and postponed till the cycle transition concluded
+and postponed till the cycle transition concludes
+In all cases if there are no tasks in registry the state will be updated directly to CYCLE_READY state.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -4590,18 +4769,37 @@ and postponed till the cycle transition concluded
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>
+) <b>acquires</b>  <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_length">enumerable_map::length</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks) == 0) {
+        // Registry is empty <b>move</b> <b>to</b> ready state directly
+        <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>);
+        <b>return</b>
+    };
     <b>if</b> (std::option::is_none(&cycle_info.transition_state)) {
+        <b>assert</b>!(<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt;= cycle_info.start_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+        <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+        <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
         <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
+            refund_duration: cycle_info.duration_secs + cycle_info.start_time - <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
             new_cycle_duration: cycle_info.duration_secs,
-            automation_fee_per_sec: 0,
-            gas_committed_for_this_cycle: 0,
+            automation_fee_per_sec: <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal">calculate_automation_fee_multiplier_for_current_cycle_internal</a>(active_config, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>),
+            gas_committed_for_new_cycle: 0,
             gas_committed_for_next_cycle: 0,
             locked_fees: 0,
             expected_tasks_to_be_processed: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks),
             actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
         };
         cycle_info.transition_state = std::option::some(transition_state);
+    } <b>else</b> {
+        <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+        <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+        <b>assert</b>!(!<a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+        // Did not manage <b>to</b> charge cycle fee, so automation_fee_per_sec be 0 along <b>with</b> remaining duration
+        // So the tasks sent for refund, will get only deposit refunded.
+        transition_state.refund_duration = 0;
+        transition_state.automation_fee_per_sec = 0;
+        transition_state.gas_committed_for_new_cycle = 0;
     };
     <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>)
 }
@@ -4615,7 +4813,8 @@ and postponed till the cycle transition concluded
 
 ## Function `update_state_for_migration`
 
-Checks all tasks for epoch fee refunds.
+Refunds automation fee for epoch for all eligible tasks and clears automation registry state in terms of
+fee primitives.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, aei: &<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">automation_registry::AutomationEpochInfo</a>, current_time: u64)
@@ -4644,9 +4843,8 @@ Checks all tasks for epoch fee refunds.
         // Compute the automation fee multiplier for ended epoch
         refund_automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(arc, previous_tcmg, arc.registry_max_gas_cap);
     };
-    <a href="automation_registry.md#0x1_automation_registry_refund_fee">refund_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, arc, refund_automation_fee_per_sec, refund_interval, current_time);
+    <a href="automation_registry.md#0x1_automation_registry_refund_tasks_fees">refund_tasks_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, arc, refund_automation_fee_per_sec, refund_interval, current_time);
 
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
 }
@@ -4656,13 +4854,14 @@ Checks all tasks for epoch fee refunds.
 
 </details>
 
-<a id="0x1_automation_registry_refund_fee"></a>
+<a id="0x1_automation_registry_refund_tasks_fees"></a>
 
-## Function `refund_fee`
+## Function `refund_tasks_fees`
+
+Refunds automation fee for epoch for all eligible tasks.
 
 
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_fee">refund_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64, current_time: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_tasks_fees">refund_tasks_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, refund_automation_fee_per_sec: u256, refund_interval: u64, current_time: u64)
 </code></pre>
 
 
@@ -4671,7 +4870,7 @@ Checks all tasks for epoch fee refunds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_fee">refund_fee</a>(
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_tasks_fees">refund_tasks_fees</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     refund_automation_fee_per_sec: u256,
@@ -4706,49 +4905,6 @@ Checks all tasks for epoch fee refunds.
                 refund);
             epoch_locked_fees = remaining_epoch_locked_fees;
         };
-    });
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_safe_deposit_refund_all"></a>
-
-## Function `safe_deposit_refund_all`
-
-Traverses through all existing tasks and refunds deposited fee upon registration fully.
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund_all">safe_deposit_refund_all</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>) {
-    <b>let</b> ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(ids, |task_index| {
-        <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_ref">enumerable_map::get_value_ref</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-            refund_bookkeeping,
-            &resource_signer,
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-            task.task_index,
-            task.owner,
-            task.locked_fee_for_next_epoch,
-            task.locked_fee_for_next_epoch);
     });
 }
 </code></pre>
@@ -5075,6 +5231,38 @@ This is supposed to be called only after removing expired task and must not be c
 
 </details>
 
+<a id="0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal"></a>
+
+## Function `calculate_automation_fee_multiplier_for_current_cycle_internal`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal">calculate_automation_fee_multiplier_for_current_cycle_internal</a>(active_config: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">automation_registry::ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal">calculate_automation_fee_multiplier_for_current_cycle_internal</a>(
+    active_config: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>,
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>
+): u64 {
+    // Compute the automation fee multiplier for this cycle
+    <b>let</b> multiplier = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
+        &active_config.main_config,
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch,
+        active_config.main_config.registry_max_gas_cap);
+    (multiplier <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch"></a>
 
 ## Function `calculate_automation_fee_multiplier_for_epoch`
@@ -5213,166 +5401,6 @@ would allow the congestion fee to increase in a non-linear fashion.
 
 </details>
 
-<a id="0x1_automation_registry_try_charge_tasks_automation_fees"></a>
-
-## Function `try_charge_tasks_automation_fees`
-
-Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-- If the user has sufficient balance, deducts the fee and emits a success event.
-- If the balance is insufficient, removes the task and emits a cancellation event.
-- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_fee_per_sec: u256, cycle_duration: u64, current_time: u64, task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    automation_fee_per_sec: u256,
-    cycle_duration: u64,
-    current_time: u64,
-    task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;,
-    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
-) {
-
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-    <b>let</b> current_cycle_end_time = current_time + cycle_duration;
-
-    // Sort task indexes <b>to</b> charge automation fees in the tasks chronological order
-    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
-
-    // Process each active task and calculate fee for the epoch for the tasks
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(transition_state, task_index) && <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(transition_state, task_index);
-            <b>let</b> task = {
-                <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-                <b>let</b> fee= <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, cycle_duration, current_time, automation_fee_per_sec);
-                // If the task reached this phase that means it is valid active task for the new epoch.
-                // During cleanup all expired tasks <b>has</b> been removed from the registry but the state of the tasks is not updated.
-                // As here we need <b>to</b> distinguish new tasks from already existing active tasks,
-                // <b>as</b> the fee calculation for them will be different based on their active duration in the epoch.
-                // For more details see calculate_task_fee function.
-                task_meta.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-                <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
-                    task_index,
-                    owner: task_meta.owner,
-                    fee,
-                    expiry_time: task_meta.expiry_time,
-                    automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                    max_gas_amount: task_meta.max_gas_amount,
-                    locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
-                }
-            };
-            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-                refund_bookkeeping,
-                &resource_signer,
-                task,
-                current_cycle_end_time,
-                intermediate_state
-            );
-        };
-    });
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_try_withdraw_task_automation_fees"></a>
-
-## Function `try_withdraw_task_automation_fees`
-
-Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-- If the user has sufficient balance, deducts the fee and emits a success event.
-- If the balance is insufficient, removes the task and emits a cancellation event.
-- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, epoch_interval: u64, current_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fees">try_withdraw_task_automation_fees</a>(
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
-    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
-    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    epoch_interval: u64,
-    current_time: u64,
-    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
-) {
-    // Compute the automation fee multiplier for epoch
-    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
-        arc,
-        (intermediate_state.gas_committed_for_new_epoch <b>as</b> u256),
-        arc.registry_max_gas_cap);
-
-    <b>let</b> task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-    );
-    <b>let</b> current_epoch_end_time = current_time + epoch_interval;
-
-    // Sort task indexes <b>to</b> charge automation fees in the tasks chronological order
-    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
-
-    // Process each active task and calculate fee for the epoch for the tasks
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>let</b> task = {
-            <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-            <b>let</b> fee= <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
-            // If the task reached this phase that means it is valid active task for the new epoch.
-            // During cleanup all expired tasks <b>has</b> been removed from the registry but the state of the tasks is not updated.
-            // As here we need <b>to</b> distinguish new tasks from already existing active tasks,
-            // <b>as</b> the fee calculation for them will be different based on their active duration in the epoch.
-            // For more details see calculate_task_fee function.
-            task_meta.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
-            <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
-                task_index,
-                owner: task_meta.owner,
-                fee,
-                expiry_time: task_meta.expiry_time,
-                automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                max_gas_amount: task_meta.max_gas_amount,
-                locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
-            }
-        };
-        <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-            refund_bookkeeping,
-            &resource_signer,
-            task,
-            current_epoch_end_time,
-            intermediate_state
-        );
-    });
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_try_withdraw_task_automation_fee"></a>
 
 ## Function `try_withdraw_task_automation_fee`
@@ -5396,18 +5424,16 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
     current_epoch_end_time: u64,
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>) {
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
+    // It might happen that task <b>has</b> been expired by the time charging is being done.
+    // This may be caused by the fact that bookkeeping transactions <b>has</b> been withheld due <b>to</b> epoch transition.
     <b>if</b> (task.fee &gt; task.automation_fee_cap) {
-        <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+        <a href="automation_registry.md#0x1_automation_registry_refund_deposit_and_drop">refund_deposit_and_drop</a>(
+            task.task_index,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
             refund_bookkeeping,
             resource_signer,
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-            task.task_index,
-            task.owner,
-            task.locked_deposit_fee,
-            task.locked_deposit_fee
+            &<b>mut</b> intermediate_state.removed_tasks
         );
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task.task_index);
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> intermediate_state.removed_tasks, task.task_index);
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelledCapacitySurpassed">TaskCancelledCapacitySurpassed</a> {
             task_index: task.task_index,
             owner: task.owner,
@@ -5534,74 +5560,6 @@ Transfers the specified fee amount from the resource account to the target accou
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
     <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, <b>to</b>, amount);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_update_registration_config_internal"></a>
-
-## Function `update_registration_config_internal`
-
-Update Automation Registry Config releated to registration.
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, cycle_duration_secs: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
-    cycle_duration_secs: u64,
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-
-    <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
-        cycle_duration_secs,
-        task_duration_cap_in_secs,
-        registry_max_gas_cap,
-        congestion_threshold_percentage,
-        congestion_exponent);
-
-    <b>assert</b>!(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &lt; registry_max_gas_cap,
-        <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT">EUNACCEPTABLE_AUTOMATION_GAS_LIMIT</a>
-    );
-
-    <b>let</b> new_automation_registry_config = <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
-        task_duration_cap_in_secs,
-        registry_max_gas_cap,
-        automation_base_fee_in_quants_per_sec,
-        flat_registration_fee_in_quants,
-        congestion_threshold_percentage,
-        congestion_base_fee_in_quants_per_sec,
-        congestion_exponent,
-        task_capacity
-    };
-    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_automation_registry_config);
-
-    // next_epoch_registry_max_gas_cap will be <b>update</b> instantly
-    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
-    automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(new_automation_registry_config);
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -11,13 +11,14 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Resource `ActiveAutomationRegistryConfig`](#0x1_automation_registry_ActiveAutomationRegistryConfig)
 -  [Resource `AutomationRegistryConfig`](#0x1_automation_registry_AutomationRegistryConfig)
 -  [Resource `AutomationRegistry`](#0x1_automation_registry_AutomationRegistry)
+-  [Resource `TransitionState`](#0x1_automation_registry_TransitionState)
 -  [Resource `AutomationEpochInfo`](#0x1_automation_registry_AutomationEpochInfo)
 -  [Struct `AutomationCycleDuration`](#0x1_automation_registry_AutomationCycleDuration)
 -  [Resource `AutomationCycleInfo`](#0x1_automation_registry_AutomationCycleInfo)
+-  [Resource `AutomationCycleEvent`](#0x1_automation_registry_AutomationCycleEvent)
+-  [Resource `AutomationCycleDetails`](#0x1_automation_registry_AutomationCycleDetails)
 -  [Resource `AutomationRefundBookkeeping`](#0x1_automation_registry_AutomationRefundBookkeeping)
 -  [Resource `AutomationTaskMetaData`](#0x1_automation_registry_AutomationTaskMetaData)
--  [Struct `AutomationCycleFinished`](#0x1_automation_registry_AutomationCycleFinished)
--  [Struct `AutomationCycleStarted`](#0x1_automation_registry_AutomationCycleStarted)
 -  [Struct `TaskRegistrationFeeWithdraw`](#0x1_automation_registry_TaskRegistrationFeeWithdraw)
 -  [Struct `TaskRegistrationDepositFeeWithdraw`](#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw)
 -  [Struct `RegistryFeeWithdraw`](#0x1_automation_registry_RegistryFeeWithdraw)
@@ -36,6 +37,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `ErrorTaskDoesNotExist`](#0x1_automation_registry_ErrorTaskDoesNotExist)
 -  [Struct `ErrorTaskDoesNotExistForWithdrawal`](#0x1_automation_registry_ErrorTaskDoesNotExistForWithdrawal)
 -  [Struct `ErrorInsufficientBalanceToRefund`](#0x1_automation_registry_ErrorInsufficientBalanceToRefund)
+-  [Struct `ErrorInconsistentSuspendedState`](#0x1_automation_registry_ErrorInconsistentSuspendedState)
 -  [Struct `EnabledRegistrationEvent`](#0x1_automation_registry_EnabledRegistrationEvent)
 -  [Struct `DisabledRegistrationEvent`](#0x1_automation_registry_DisabledRegistrationEvent)
 -  [Struct `AutomationTaskFeeMeta`](#0x1_automation_registry_AutomationTaskFeeMeta)
@@ -43,6 +45,9 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Struct `IntermediateStateOfEpochChange`](#0x1_automation_registry_IntermediateStateOfEpochChange)
 -  [Struct `AutomationTaskFee`](#0x1_automation_registry_AutomationTaskFee)
 -  [Constants](#@Constants_0)
+-  [Function `is_transition_finalized`](#0x1_automation_registry_is_transition_finalized)
+-  [Function `is_transition_in_progress`](#0x1_automation_registry_is_transition_in_progress)
+-  [Function `update_processed_tasks`](#0x1_automation_registry_update_processed_tasks)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
@@ -66,18 +71,36 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
 -  [Function `get_cycle_duration`](#0x1_automation_registry_get_cycle_duration)
 -  [Function `get_cycle_info`](#0x1_automation_registry_get_cycle_info)
+-  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
+-  [Function `update_config`](#0x1_automation_registry_update_config)
+-  [Function `update_config_v2`](#0x1_automation_registry_update_config_v2)
+-  [Function `enable_registration`](#0x1_automation_registry_enable_registration)
+-  [Function `disable_registration`](#0x1_automation_registry_disable_registration)
+-  [Function `cancel_task`](#0x1_automation_registry_cancel_task)
+-  [Function `stop_tasks`](#0x1_automation_registry_stop_tasks)
+-  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
+-  [Function `migrate_v2`](#0x1_automation_registry_migrate_v2)
+-  [Function `initialize`](#0x1_automation_registry_initialize)
+-  [Function `initialize_v2`](#0x1_automation_registry_initialize_v2)
+-  [Function `monitor_cycle_end`](#0x1_automation_registry_monitor_cycle_end)
+-  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
+-  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
+-  [Function `register`](#0x1_automation_registry_register)
+-  [Function `on_drop`](#0x1_automation_registry_on_drop)
+-  [Function `on_charge`](#0x1_automation_registry_on_charge)
+-  [Function `on_refund_and_cleanup`](#0x1_automation_registry_on_refund_and_cleanup)
+-  [Function `into_automation_cycle_info`](#0x1_automation_registry_into_automation_cycle_info)
+-  [Function `update_cycle_transition_state_from_suspended`](#0x1_automation_registry_update_cycle_transition_state_from_suspended)
+-  [Function `update_cycle_transition_state_from_finished`](#0x1_automation_registry_update_cycle_transition_state_from_finished)
 -  [Function `estimate_automation_fee_with_committed_occupancy_internal`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal)
 -  [Function `validate_configuration_parameters_common`](#0x1_automation_registry_validate_configuration_parameters_common)
 -  [Function `create_registry_resource_account`](#0x1_automation_registry_create_registry_resource_account)
--  [Function `initialize`](#0x1_automation_registry_initialize)
--  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
--  [Function `initialize_v2`](#0x1_automation_registry_initialize_v2)
--  [Function `migrate_v2`](#0x1_automation_registry_migrate_v2)
--  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
+-  [Function `on_cycle_start_internal`](#0x1_automation_registry_on_cycle_start_internal)
 -  [Function `on_cycle_end_internal`](#0x1_automation_registry_on_cycle_end_internal)
--  [Function `move_to_finished_state`](#0x1_automation_registry_move_to_finished_state)
--  [Function `move_to_suspended_state`](#0x1_automation_registry_move_to_suspended_state)
+-  [Function `update_cycle_state_to`](#0x1_automation_registry_update_cycle_state_to)
+-  [Function `move_to_ready_state`](#0x1_automation_registry_move_to_ready_state)
 -  [Function `move_to_started_state`](#0x1_automation_registry_move_to_started_state)
+-  [Function `move_to_suspended_state`](#0x1_automation_registry_move_to_suspended_state)
 -  [Function `update_state_for_migration`](#0x1_automation_registry_update_state_for_migration)
 -  [Function `refund_fee`](#0x1_automation_registry_refund_fee)
 -  [Function `safe_deposit_refund_all`](#0x1_automation_registry_safe_deposit_refund_all)
@@ -91,22 +114,13 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `calculate_automation_fee_multiplier_for_epoch`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch)
 -  [Function `calculate_automation_congestion_fee`](#0x1_automation_registry_calculate_automation_congestion_fee)
 -  [Function `calculate_exponentiation`](#0x1_automation_registry_calculate_exponentiation)
+-  [Function `try_charge_tasks_automation_fees`](#0x1_automation_registry_try_charge_tasks_automation_fees)
 -  [Function `try_withdraw_task_automation_fees`](#0x1_automation_registry_try_withdraw_task_automation_fees)
 -  [Function `try_withdraw_task_automation_fee`](#0x1_automation_registry_try_withdraw_task_automation_fee)
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
--  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
--  [Function `update_config`](#0x1_automation_registry_update_config)
--  [Function `update_config_v2`](#0x1_automation_registry_update_config_v2)
 -  [Function `update_registration_config_internal`](#0x1_automation_registry_update_registration_config_internal)
--  [Function `enable_registration`](#0x1_automation_registry_enable_registration)
--  [Function `disable_registration`](#0x1_automation_registry_disable_registration)
--  [Function `register`](#0x1_automation_registry_register)
 -  [Function `check_registration_task_duration`](#0x1_automation_registry_check_registration_task_duration)
--  [Function `cancel_task`](#0x1_automation_registry_cancel_task)
--  [Function `stop_tasks`](#0x1_automation_registry_stop_tasks)
--  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
--  [Function `monitor_cycle_end`](#0x1_automation_registry_monitor_cycle_end)
 -  [Function `sort_vector`](#0x1_automation_registry_sort_vector)
 -  [Function `upscale_from_u8`](#0x1_automation_registry_upscale_from_u8)
 -  [Function `upscale_from_u64`](#0x1_automation_registry_upscale_from_u64)
@@ -125,6 +139,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/math64.md#0x1_math64">0x1::math64</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="supra_coin.md#0x1_supra_coin">0x1::supra_coin</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
@@ -322,11 +337,77 @@ It tracks entries both pending and completed, organized by unique indices.
 
 </details>
 
+<a id="0x1_automation_registry_TransitionState"></a>
+
+## Resource `TransitionState`
+
+It tracks entries both pending and completed, organized by unique indices.
+
+
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>new_cycle_duration: u64</code>
+</dt>
+<dd>
+ Duration of the new cycle.
+</dd>
+<dt>
+<code>automation_fee_per_sec: u64</code>
+</dt>
+<dd>
+ Calculated automation fee per second for the new cycle.
+</dd>
+<dt>
+<code>gas_committed_for_this_cycle: u64</code>
+</dt>
+<dd>
+ Gas committed for the new cycle being transitioned.
+</dd>
+<dt>
+<code>gas_committed_for_next_cycle: u64</code>
+</dt>
+<dd>
+ Gas committed for next cycle
+</dd>
+<dt>
+<code>locked_fees: u64</code>
+</dt>
+<dd>
+ Total fee charged to users during the cycle, which is not withdrawable
+</dd>
+<dt>
+<code>expected_tasks_to_be_processed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+ Number of the tasks to be processed during transition.
+</dd>
+<dt>
+<code>actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+ So far processed tasks during transition
+ In case if transition spans between multiple blocks then
+ upon recovery execution component will know the breaking point and can recover from it.
+</dd>
+</dl>
+
+
+</details>
+
 <a id="0x1_automation_registry_AutomationEpochInfo"></a>
 
 ## Resource `AutomationEpochInfo`
 
-Epoch state. Deprecated since SUPRA_NATIVE_AUTOMATION_V2 version.
+Epoch state. Deprecated since SUPRA_CYCLE_BASED_AUTOMATION version.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
@@ -402,8 +483,7 @@ Epoch state. Deprecated since SUPRA_NATIVE_AUTOMATION_V2 version.
 Cycle state.
 
 
-<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>has</b> <b>copy</b>, key
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>has</b> <b>copy</b>, drop, store, key
 </code></pre>
 
 
@@ -423,8 +503,7 @@ Cycle state.
 <code>state: u8</code>
 </dt>
 <dd>
- State of the current cycle, CYCLE_FINISHED, CYCLE_STARTED. If state is FINISHED, means transition to the next cycle
- is in progress.
+ State of the current cycle.
 </dd>
 <dt>
 <code>start_time: u64</code>
@@ -437,6 +516,100 @@ Cycle state.
 </dt>
 <dd>
  Automation cycle duration in seconds.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationCycleEvent"></a>
+
+## Resource `AutomationCycleEvent`
+
+Event emitted in the cycle-state.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleEvent">AutomationCycleEvent</a> <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>cycle_state_info: <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a></code>
+</dt>
+<dd>
+ Updated cycle state information.
+</dd>
+<dt>
+<code>old_state: u8</code>
+</dt>
+<dd>
+ The state transitioned from
+</dd>
+<dt>
+<code>event_time: u64</code>
+</dt>
+<dd>
+ Timestamp of the state transition event registration
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_automation_registry_AutomationCycleDetails"></a>
+
+## Resource `AutomationCycleDetails`
+
+Cycle state.
+
+
+<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>index: u64</code>
+</dt>
+<dd>
+ Cycle index corresponding to the current state. Incremented when a transition to the new cycle is finalized.
+</dd>
+<dt>
+<code>state: u8</code>
+</dt>
+<dd>
+ State of the current cycle.
+</dd>
+<dt>
+<code>start_time: u64</code>
+</dt>
+<dd>
+ Current cycle start time which is updated with the current chain time when a cycle is increamented.
+</dd>
+<dt>
+<code>duration_secs: u64</code>
+</dt>
+<dd>
+ Automation cycle duration in seconds.
+</dd>
+<dt>
+<code>transition_state: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>&gt;</code>
+</dt>
+<dd>
+ Intermediate state of cycle transition to next one or suspended state.
 </dd>
 </dl>
 
@@ -567,70 +740,6 @@ Automation Deposited fee bookkeeping configs
  It will be refunded fully when active task is expired or cancelled by user
  and partially if a pending task is cancelled by user or an active task is cancelled by the system due to
  insufficient balance to  pay the automation fee for the epoch
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_AutomationCycleFinished"></a>
-
-## Struct `AutomationCycleFinished`
-
-Event emitted at automation cycle end.
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleFinished">AutomationCycleFinished</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>cycle_id: u64</code>
-</dt>
-<dd>
- Finished Cycle id.
-</dd>
-</dl>
-
-
-</details>
-
-<a id="0x1_automation_registry_AutomationCycleStarted"></a>
-
-## Struct `AutomationCycleStarted`
-
-Event emitted at automation cycle end.
-
-
-<pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleStarted">AutomationCycleStarted</a> <b>has</b> drop, store
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>cycle_id: u64</code>
-</dt>
-<dd>
- Started Cycle id.
-</dd>
-<dt>
-<code><a href="timestamp.md#0x1_timestamp">timestamp</a>: u64</code>
-</dt>
-<dd>
- Cycle start timestamp.
 </dd>
 </dl>
 
@@ -1332,6 +1441,36 @@ the shortening of the epoch (1)
 
 </details>
 
+<a id="0x1_automation_registry_ErrorInconsistentSuspendedState"></a>
+
+## Struct `ErrorInconsistentSuspendedState`
+
+Event emitted when on new epoch inconsistent state of the registry has been identified.
+When automation is in suspended state, there are no tasks expected.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_ErrorInconsistentSuspendedState">ErrorInconsistentSuspendedState</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a id="0x1_automation_registry_EnabledRegistrationEvent"></a>
 
 ## Struct `EnabledRegistrationEvent`
@@ -1629,19 +1768,31 @@ Insufficient balance in the resource wallet for withdrawal
 
 <a id="0x1_automation_registry_CYCLE_FINISHED"></a>
 
-Constants describing CYCLE state.
+Triggered when cycle end is identified.
 
 
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>: u8 = 0;
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>: u8 = 2;
 </code></pre>
 
 
 
 <a id="0x1_automation_registry_CYCLE_STARTED"></a>
 
+Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by autoamtion cycle manager in native layer.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>: u8 = 1;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_CYCLE_SUSPENDED"></a>
+
+State describing the entire lifecycle of automation being suspended.
+Triggered when SUPRA_NATIVE_AUTOMATION feature is disabled.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>: u8 = 3;
 </code></pre>
 
 
@@ -1706,6 +1857,16 @@ Automation registry max gas capacity cannot be zero.
 
 
 
+<a id="0x1_automation_registry_ECYCLE_TRANSITION_IN_PROGRESS"></a>
+
+Attempt to register an automation task while cycle transition is in progress.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_ECYCLE_TRANSITION_IN_PROGRESS">ECYCLE_TRANSITION_IN_PROGRESS</a>: u64 = 32;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EDEPOSIT_REFUND"></a>
 
 Failed to unlock/refund deposit for a task. Internal error, for more details see emitted error events.
@@ -1718,7 +1879,7 @@ Failed to unlock/refund deposit for a task. Internal error, for more details see
 
 <a id="0x1_automation_registry_EDEPRECATED_SINCE_V2"></a>
 
-Deprecated function call since SUPRA_NATIVE_AUTOMATION_V2 release.
+Deprecated function call since cycle based automation release.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>: u64 = 29;
@@ -1826,6 +1987,16 @@ Resource Account does not have sufficient balance to process the refund for the 
 
 
 
+<a id="0x1_automation_registry_EINVALID_CHARGE_ACTION"></a>
+
+Attempt to run charge action with inconsistent input values compared to internal state.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>: u64 = 34;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EINVALID_EXPIRY_TIME"></a>
 
 Invalid expiry time: it cannot be earlier than the current time
@@ -1852,6 +2023,26 @@ Invalid max gas amount for automated task: it cannot be zero
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>: u64 = 5;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EINVALID_MIGRATION_ACTION"></a>
+
+Attempt to do migration to cycle based automation which is already enabled.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>: u64 = 31;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EINVALID_REGISTRY_STATE"></a>
+
+Attempt to run operation in invalid registry state.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>: u64 = 33;
 </code></pre>
 
 
@@ -1965,15 +2156,6 @@ Unauthorized access: the caller is not the owner of the task
 
 
 
-<a id="0x1_automation_registry_LIFECYCLE_SUSPENDED"></a>
-
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_LIFECYCLE_SUSPENDED">LIFECYCLE_SUSPENDED</a>: u8 = 2;
-</code></pre>
-
-
-
 <a id="0x1_automation_registry_MAX_PERCENTAGE"></a>
 
 100 Percentage
@@ -2000,6 +2182,21 @@ Constants describing task state.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>: u8 = 0;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_READY_TO_START_NEW_CYCLE"></a>
+
+Constants describing CYCLE state.
+State transition flaw is:
+READY_TO_START -> CYCLE_STARTED
+CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
+CYCLE_FINISHED ->  { CYCLE_STARTED}
+CYCLE_SUSPENDED ->  {READY_TO_START, STARTED}
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>: u8 = 0;
 </code></pre>
 
 
@@ -2044,6 +2241,78 @@ The length of the transaction hash.
 
 
 
+<a id="0x1_automation_registry_is_transition_finalized"></a>
+
+## Function `is_transition_finalized`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>): bool {
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.expected_tasks_to_be_processed) == <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.actual_processed_tasks)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_is_transition_in_progress"></a>
+
+## Function `is_transition_in_progress`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>): bool {
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.actual_processed_tasks) != 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_processed_tasks"></a>
+
+## Function `update_processed_tasks`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> state.actual_processed_tasks, task_indexes);
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_is_initialized"></a>
 
 ## Function `is_initialized`
@@ -2065,7 +2334,7 @@ Checks whether all required resources are created.
     <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework)
         && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework)
-        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework)
+        && <b>exists</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework)
 }
 </code></pre>
 
@@ -2569,7 +2838,7 @@ occupancy for the next epoch.
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee">estimate_automation_fee</a>(
     task_occupancy: u64
-): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>let</b> registry = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(task_occupancy, registry.gas_committed_for_next_epoch)
 }
@@ -2601,8 +2870,8 @@ maximum allowed occupancy for the next epoch.
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy">estimate_automation_fee_with_committed_occupancy</a>(
     task_occupancy: u64,
     committed_occupancy: u64
-): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>let</b> config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
         task_occupancy,
@@ -2660,8 +2929,8 @@ Returns the current duration of the automation cycle.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_duration">get_cycle_duration</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
-    <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework).duration_secs
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_duration">get_cycle_duration</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
+    <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework).duration_secs
 }
 </code></pre>
 
@@ -2686,8 +2955,1231 @@ Returns the current status of the registration in the automation registry.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_info">get_cycle_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
-    *<b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_info">get_cycle_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
+    <b>let</b> details = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry_into_automation_cycle_info">into_automation_cycle_info</a>(details)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_withdraw_automation_task_fees"></a>
+
+## Function `withdraw_automation_task_fees`
+
+Withdraw accumulated automation task fees from the resource account - access by admin
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <b>to</b>: <b>address</b>,
+    amount: u64
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(<b>to</b>, amount);
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RegistryFeeWithdraw">RegistryFeeWithdraw</a> { <b>to</b>, amount });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_config"></a>
+
+## Function `update_config`
+
+Update Automation Registry Config
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+) {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_config_v2"></a>
+
+## Function `update_config_v2`
+
+Update Automation Registry Config along with cycle duration.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_v2">update_config_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, cycle_duration_secs: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_v2">update_config_v2</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+    cycle_duration_secs: u64,
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+
+
+    <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
+        supra_framework,
+        task_duration_cap_in_secs,
+        registry_max_gas_cap,
+        automation_base_fee_in_quants_per_sec,
+        flat_registration_fee_in_quants,
+        congestion_threshold_percentage,
+        congestion_base_fee_in_quants_per_sec,
+        congestion_exponent,
+        task_capacity,
+        cycle_duration_secs,
+    );
+
+    // Update cycle duration in buffer
+    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
+    <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
+        duration_secs: cycle_duration_secs
+    };
+    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
+    <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_enable_registration"></a>
+
+## Function `enable_registration`
+
+Enables the registration process in the automation registry.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_enable_registration">enable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_enable_registration">enable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    automation_registry_config.registration_enabled = <b>true</b>;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_EnabledRegistrationEvent">EnabledRegistrationEvent</a> {});
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_disable_registration"></a>
+
+## Function `disable_registration`
+
+Disables the registration process in the automation registry.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_disable_registration">disable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_disable_registration">disable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    automation_registry_config.registration_enabled = <b>false</b>;
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_DisabledRegistrationEvent">DisabledRegistrationEvent</a> {});
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_cancel_task"></a>
+
+## Function `cancel_task`
+
+Cancel Automation task with specified task_index.
+Only existing task, which is PENDING or ACTIVE, can be cancelled and only by task owner.
+If the task is
+- active, its state is updated to be CANCELLED.
+- pending, it is removed form the list.
+- cancelled, an error is reported
+Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_index: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(
+    owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_index: u64
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>{
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_TRANSITION_IN_PROGRESS">ECYCLE_TRANSITION_IN_PROGRESS</a>);
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
+
+    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+    <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
+    <b>assert</b>!(automation_task_metadata.owner == owner, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
+    <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>, <a href="automation_registry.md#0x1_automation_registry_EALREADY_CANCELLED">EALREADY_CANCELLED</a>);
+    <b>if</b> (automation_task_metadata.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+        <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+            &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+        );
+        // When Pending tasks are cancelled, refund of the deposit fee is done <b>with</b> penalty
+        <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+            refund_bookkeeping,
+            &resource_signer,
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+            automation_task_metadata.task_index,
+            owner,
+            automation_task_metadata.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>,
+            automation_task_metadata.locked_fee_for_next_epoch);
+        <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>);
+        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+    } <b>else</b> { // it is safe not <b>to</b> check the state <b>as</b> above, the cancelled tasks are already rejected.
+        // Active tasks will be refunded the deposited amount fully at the end of the epoch
+        <b>let</b> automation_task_metadata_mut = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(
+            &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks,
+            task_index
+        );
+        automation_task_metadata_mut.state = <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>;
+    };
+
+    // This check means the task was expected <b>to</b> be executed in the next cycle, but it <b>has</b> been cancelled.
+    // We need <b>to</b> remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
+    <b>if</b> (automation_task_metadata.expiry_time &gt; (cycle_info.start_time + cycle_info.duration_secs)) {
+        <b>assert</b>!(
+            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &gt;= automation_task_metadata.max_gas_amount,
+            <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_UNDERFLOW">EGAS_COMMITTEED_VALUE_UNDERFLOW</a>
+        );
+        // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+    };
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelled">TaskCancelled</a> { task_index: automation_task_metadata.task_index, owner });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_stop_tasks"></a>
+
+## Function `stop_tasks`
+
+Immediately stops automation tasks for the specified <code>task_indexes</code>.
+Only tasks that exist and are owned by the sender can be stopped.
+If any of the specified tasks are not owned by the sender, the transaction will abort.
+When a task is stopped, the committed gas for the next epoch is reduced
+by the max gas amount of the stopped task. Half of the remaining task fee is refunded.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_stop_tasks">stop_tasks</a>(owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_stop_tasks">stop_tasks</a>(
+    owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
+    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_TRANSITION_IN_PROGRESS">ECYCLE_TRANSITION_IN_PROGRESS</a>);
+    // Ensure that task indexes are provided
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes), <a href="automation_registry.md#0x1_automation_registry_EEMPTY_TASK_INDEXES">EEMPTY_TASK_INDEXES</a>);
+
+    <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> arc = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework).main_config;
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+
+    <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
+
+    // Compute the automation fee multiplier for epoch
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(&arc, tcmg, arc.registry_max_gas_cap);
+
+    <b>let</b> stopped_task_details = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> total_refund_fee = 0;
+    <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
+
+    // Calculate refundable fee for this remaining time task in current epoch
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <b>let</b> cycle_end_time = cycle_info.duration_secs + cycle_info.start_time;
+    <b>let</b> residual_interval = <b>if</b> (cycle_end_time &lt;= current_time) {
+        0
+    } <b>else</b> {
+        cycle_end_time - current_time
+    };
+
+    // Loop through each task index <b>to</b> validate and stop the task
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
+        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            // Remove task from registry
+            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+
+            // Ensure only the task owner can stop it
+            <b>assert</b>!(task.owner == owner, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
+
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_remove_value">vector::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids, &task_index);
+
+            // This check means the task was expected <b>to</b> be executed in the next epoch, but it <b>has</b> been stopped.
+            // We need <b>to</b> remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
+            // Also it checks that task should not be cancelled.
+            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> && task.expiry_time &gt; cycle_end_time) {
+                // Prevent underflow in gas committed
+                <b>assert</b>!(
+                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &gt;= task.max_gas_amount,
+                    <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_UNDERFLOW">EGAS_COMMITTEED_VALUE_UNDERFLOW</a>
+                );
+
+                // Reduce committed gas by the stopped task's max gas
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - task.max_gas_amount;
+            };
+
+            <b>let</b> (epoch_fee_refund, deposit_refund) = <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+                <b>let</b> task_fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
+                    &arc,
+                    &task,
+                    residual_interval,
+                    current_time,
+                    automation_fee_per_sec
+                );
+                // Refund full deposit and the half of the remaining run-time fee when task is active or cancelled stage
+                (task_fee / <a href="automation_registry.md#0x1_automation_registry_REFUND_FRACTION">REFUND_FRACTION</a>, task.locked_fee_for_next_epoch)
+            } <b>else</b> {
+                (0, (task.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FRACTION">REFUND_FRACTION</a>))
+            };
+            <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(
+                refund_bookkeeping,
+                task.locked_fee_for_next_epoch,
+                task.task_index);
+            <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>);
+            <b>let</b> (result, remaining_epoch_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(
+                epoch_locked_fees,
+                epoch_fee_refund,
+                task.task_index);
+            <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EEPOCH_FEE_REFUND">EEPOCH_FEE_REFUND</a>);
+            epoch_locked_fees = remaining_epoch_locked_fees;
+
+            total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
+
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(
+                &<b>mut</b> stopped_task_details,
+                <a href="automation_registry.md#0x1_automation_registry_TaskStopped">TaskStopped</a> { task_index, deposit_refund, epoch_fee_refund }
+            );
+        }
+    });
+
+    // Refund and emit <a href="event.md#0x1_event">event</a> <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> tasks were stopped
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&stopped_task_details)) {
+        <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+            &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+        );
+
+        <b>let</b> resource_account_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address);
+        <b>assert</b>!(resource_account_balance &gt;= total_refund_fee, <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_BALANCE_FOR_REFUND">EINSUFFICIENT_BALANCE_FOR_REFUND</a>);
+        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, owner, total_refund_fee);
+
+        // Emit task stopped <a href="event.md#0x1_event">event</a>
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TasksStopped">TasksStopped</a> {
+            tasks: stopped_task_details,
+            owner
+        });
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_initialize_refund_bookkeeping_resource"></a>
+
+## Function `initialize_refund_bookkeeping_resource`
+
+Public entry function to initialize bookeeping resource when feature enabling automation deposit fee charges is released.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+        total_deposited_automation_fee: 0
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_migrate_v2"></a>
+
+## Function `migrate_v2`
+
+API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
+detached from epoch-change.
+IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
+end-up in inconsistent state.
+
+monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
+thus not causing any inconcistensy in the chain
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
+    assert_supra_framework(supra_framework);
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_cycle_based_automation_enabled">features::supra_cycle_based_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>);
+
+    // Prepare the state for migration
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
+
+    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
+        @supra_framework
+    ).main_config;
+
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    // Refund the epoch fees <b>as</b> epoch will be cut short and on_new_epoch will be dummy due <b>to</b> migration,
+    // so this is the only place <b>to</b> do the refunds
+    <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        &automation_registry_config,
+        automation_epoch_info,
+        current_time
+    );
+
+    // Start migration by enabling feature, initializing the cycle releated resouces
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_next_epoch">features::change_feature_flags_for_next_epoch</a>(
+        supra_framework,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_get_supra_cycle_based_automation_feature">features::get_supra_cycle_based_automation_feature</a>()],
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
+    <b>let</b> id = 0;
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
+        start_time: current_time,
+        index: id,
+        duration_secs: cycle_duration_secs,
+        state: <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>,
+        transition_state: std::option::none()
+    });
+    // Remain in READY_TO_START statey <b>if</b> feature is not enabled or registry is not fully initialized
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>()) {
+        <b>return</b>
+    };
+    // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
+    <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>();
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_initialize"></a>
+
+## Function `initialize`
+
+Initialization of Automation Registry with configuration parameters is expected metrics.
+Deprecated in favor of initialize_v2
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    epoch_interval_secs: u64,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+) {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_initialize_v2"></a>
+
+## Function `initialize_v2`
+
+Initialization of Automation Registry with configuration parameters for SUPRA_CYCLE_BASED_AUTOMATION version.
+Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
+automation feature is being introduced very first time.
+In case if framework upgrade is happening on the chain where automation feature is already released and
+is in ongoing state, then migrate_v2 function should be utilized instead.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    cycle_duration_secs: u64,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
+        cycle_duration_secs,
+        task_duration_cap_in_secs,
+        registry_max_gas_cap,
+        congestion_threshold_percentage,
+        congestion_exponent);
+
+    <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="automation_registry.md#0x1_automation_registry_create_registry_resource_account">create_registry_resource_account</a>(
+        supra_framework
+    );
+
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+        tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
+        current_index: 0,
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: 0,
+        gas_committed_for_this_epoch: 0,
+        registry_fee_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&registry_fee_resource_signer),
+        registry_fee_address_signer_cap,
+        epoch_active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+    });
+
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+        main_config: <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+        },
+        next_epoch_registry_max_gas_cap: registry_max_gas_cap,
+        registration_enabled: <b>true</b>,
+    });
+
+    <b>let</b> (cycle_state, cycle_id) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_cycle_based_automation_enabled">features::supra_cycle_based_automation_enabled</a>()) {
+        (<a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, 1)
+    } <b>else</b> {
+        (<a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>, 0)
+    };
+
+    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
+        start_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+        index: cycle_id,
+        duration_secs: cycle_duration_secs,
+        state: cycle_state,
+        transition_state: std::option::none&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>&gt;(),
+    });
+
+    <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework);
+
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_monitor_cycle_end"></a>
+
+## Function `monitor_cycle_end`
+
+Checks the cycle end and emit an event on it.
+Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>()) {
+        <b>return</b>
+    };
+    <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>();
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>if</b> (cycle_info.state != <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>
+        || cycle_info.start_time + cycle_info.duration_secs &lt; <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>()) {
+        <b>return</b>
+    };
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_new_epoch"></a>
+
+## Function `on_new_epoch`
+
+On new epoch caused by reconfiguration this function will be triggered and update the automation registry state.
+If registry is not fully initialized nothing is done. Epoch change can be caused by governance action or by DKG
+finalization. In case of the later case execution should not fail.
+
+If native automation feature is disabled then automation lifecycle is suspended. And detached managment will
+initiate refund and cealnup actions.
+
+If native automation feature is enabled and automation lifecycle has been in suspended state,
+then lifecycle is restarted.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
+        <b>return</b>
+    };
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>let</b> registry_data = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+        // If the lifecycle <b>has</b> been suspended and we are recovering from it, then we <b>update</b> config from buffer and
+        // then start a new cycle directly.
+        // Unless we are in READY_TO_START state feature flag being enabled will not have <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> effect.
+        // All the other states mean that we are in the middle of previous transition, which should end
+        // before reenabling the feature.
+        <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>) {
+            <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_length">enumerable_map::length</a>(&registry_data.tasks) != 0) {
+                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ErrorInconsistentSuspendedState">ErrorInconsistentSuspendedState</a> {});
+                <b>return</b>
+            };
+            <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
+            <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
+        };
+        <b>return</b>
+    };
+    // We do not <b>update</b> config here, <b>as</b> due <b>to</b> feature being disabled, cycle ends early so it is expected
+    // that <b>native</b> layer will detect this state and generate refund transactions for a cycle that <b>has</b> been kept short.
+    // So the confing should remain intact.
+    <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>) {
+        <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(registry_data, cycle_info);
+    } <b>else</b> <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a> && std::option::is_some(&cycle_info.transition_state)) {
+        <b>let</b> trasition_state = std::option::borrow(&cycle_info.transition_state);
+        <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(trasition_state)) {
+            // Just entered cycle-end phase, and meanwhile also feature <b>has</b> been disabled so it is safe <b>to</b> <b>move</b> <b>to</b> suspended state.
+            <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(registry_data, cycle_info);
+        }
+        // Otherwise wait of the cycle transition <b>to</b> end and then feature flag value will be taken into <a href="account.md#0x1_account">account</a>.
+    }
+    // If in already SUSPENED state or in READY state then do nothing.
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_epoch_interval_in_registry"></a>
+
+## Function `update_epoch_interval_in_registry`
+
+Update epoch interval in registry while actually update happens in block module
+Deprecated since SUPRA_CYCLE_BASED_AUTOMATION feature release in favor of monitor_cycle_end
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64) {
+    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_register"></a>
+
+## Function `register`
+
+Registers a new automation task entry.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_register">register</a>(owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, expiry_time: u64, max_gas_amount: u64, gas_price_cap: u64, automation_fee_cap_for_epoch: u64, tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, aux_data: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_register">register</a>(
+    owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    expiry_time: u64,
+    max_gas_amount: u64,
+    gas_price_cap: u64,
+    automation_fee_cap_for_epoch: u64,
+    tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    aux_data: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+    // Guarding registration <b>if</b> feature is not enabled.
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&aux_data), <a href="automation_registry.md#0x1_automation_registry_ENO_AUX_DATA_SUPPORTED">ENO_AUX_DATA_SUPPORTED</a>);
+
+    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    <b>let</b> automation_cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>assert</b>!(automation_registry_config.registration_enabled, <a href="automation_registry.md#0x1_automation_registry_ETASK_REGISTRATION_DISABLED">ETASK_REGISTRATION_DISABLED</a>);
+    <b>assert</b>!(automation_cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_TRANSITION_IN_PROGRESS">ECYCLE_TRANSITION_IN_PROGRESS</a>);
+
+    // If registry is full, reject task registration
+    <b>assert</b>!((<a href="automation_registry.md#0x1_automation_registry_get_task_count">get_task_count</a>() <b>as</b> u16) &lt; automation_registry_config.main_config.task_capacity, <a href="automation_registry.md#0x1_automation_registry_EREGISTRY_IS_FULL">EREGISTRY_IS_FULL</a>);
+
+    <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+
+    //Well-formedness check of payload_tx is done in <b>native</b> layer beforehand.
+
+    <b>let</b> registration_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+    <a href="automation_registry.md#0x1_automation_registry_check_registration_task_duration">check_registration_task_duration</a>(
+        expiry_time,
+        registration_time,
+        &automation_registry_config.main_config,
+        automation_cycle_info
+    );
+
+    <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
+    <b>assert</b>!(max_gas_amount &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>);
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&tx_hash) == <a href="automation_registry.md#0x1_automation_registry_TXN_HASH_LENGTH">TXN_HASH_LENGTH</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>);
+
+    <b>let</b> committed_gas = (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch <b>as</b> u128) + (max_gas_amount <b>as</b> u128);
+    <b>assert</b>!(committed_gas &lt;= <a href="automation_registry.md#0x1_automation_registry_MAX_U64">MAX_U64</a>, <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_OVERFLOW">EGAS_COMMITTEED_VALUE_OVERFLOW</a>);
+
+    <b>let</b> committed_gas = (committed_gas <b>as</b> u64);
+    <b>assert</b>!(committed_gas &lt;= automation_registry_config.next_epoch_registry_max_gas_cap, <a href="automation_registry.md#0x1_automation_registry_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
+
+    // Check the automation fee capacity
+    <b>let</b> estimated_automation_fee_for_epoch = <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
+        max_gas_amount,
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch,
+        automation_cycle_info.duration_secs,
+        automation_registry_config);
+    <b>assert</b>!(automation_fee_cap_for_epoch &gt;= estimated_automation_fee_for_epoch,
+        <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH">EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH</a>
+    );
+
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = committed_gas;
+    <b>let</b> task_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index;
+
+    <b>let</b> automation_task_metadata = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> {
+        task_index,
+        owner,
+        payload_tx,
+        expiry_time,
+        max_gas_amount,
+        gas_price_cap,
+        automation_fee_cap_for_epoch,
+        aux_data,
+        state: <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>,
+        registration_time,
+        tx_hash,
+        locked_fee_for_next_epoch: automation_fee_cap_for_epoch
+    };
+
+    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index, automation_task_metadata);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index + 1;
+
+    // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
+    <b>let</b> fee = automation_registry_config.main_config.flat_registration_fee_in_quants + automation_fee_cap_for_epoch;
+
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + automation_fee_cap_for_epoch;
+
+    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(owner_signer, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, fee);
+
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw">TaskRegistrationDepositFeeWithdraw</a> {
+        task_index,
+        owner,
+        registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
+        locked_deposit_fee: automation_fee_cap_for_epoch
+    });
+    <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_drop"></a>
+
+## Function `on_drop`
+
+Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitted by native layer ahead of cycle transition
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_drop">on_drop</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_drop">on_drop</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
+    // Operational constraint: can only be invoked by the VM
+    <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
+        <b>return</b>;
+    };
+
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+
+    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
+        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+
+            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+                refund_bookkeeping,
+                &resource_signer,
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch);
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
+        };
+    });
+
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info, removed_tasks);
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
+        task_indexes: removed_tasks
+    });
+
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_charge"></a>
+
+## Function `on_charge`
+
+Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emitted by native layer ahead of cycle transition
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_charge">on_charge</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, gas_committed_for_new_cycle: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_charge">on_charge</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, gas_committed_for_new_cycle: u64)
+<b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    // Operational constraint: can only be invoked by the VM
+    <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
+
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
+        <b>return</b>
+    };
+
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+    <b>if</b> (transition_state.gas_committed_for_this_cycle == 0) {
+        transition_state.gas_committed_for_this_cycle = gas_committed_for_new_cycle;
+        transition_state.automation_fee_per_sec = automation_fee_per_sec;
+    } <b>else</b> {
+        <b>assert</b>!(transition_state.gas_committed_for_this_cycle == gas_committed_for_new_cycle, <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>);
+        <b>assert</b>!(transition_state.automation_fee_per_sec == automation_fee_per_sec, <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>);
+    };
+
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    <b>let</b> intermedate_result = <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+        removed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        gas_committed_for_new_epoch: gas_committed_for_new_cycle,
+        gas_committed_for_next_epoch: 0,
+        epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>()
+    };
+
+    <b>let</b> processed_tasks = <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+        refund_bookkeeping,
+        &automation_registry_config.main_config,
+        (automation_fee_per_sec <b>as</b> u256),
+    transition_state.new_cycle_duration,
+    <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+        task_indexes,
+        &<b>mut</b> intermedate_result
+    );
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
+        removed_tasks,
+        gas_committed_for_new_epoch,
+        gas_committed_for_next_epoch,
+        epoch_locked_fees
+    } = intermedate_result;
+
+    transition_state.locked_fees = transition_state.locked_fees + <a href="coin.md#0x1_coin_value">coin::value</a>(&epoch_locked_fees);
+    transition_state.gas_committed_for_next_cycle = transition_state.gas_committed_for_next_cycle + gas_committed_for_next_epoch;
+    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
+
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info, processed_tasks);
+
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&removed_tasks)) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a>{
+            task_indexes: removed_tasks
+        })
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_on_refund_and_cleanup"></a>
+
+## Function `on_refund_and_cleanup`
+
+Called by MoveVm on <code>AutomationBookkeepingAction::RefundAndCleanup</code> action.
+Action from native layer will be tiggered by move layer when automation registy cycle is updated to SUSPENDED.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_refund_and_cleanup">on_refund_and_cleanup</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, duration: u64, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_refund_and_cleanup">on_refund_and_cleanup</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, duration: u64, automation_fee_per_sec: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
+<b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    // Operational constraint: can only be invoked by the VM
+    <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
+
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
+        <b>return</b>
+    };
+
+    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
+    <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
+    <b>let</b> arc = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
+        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+
+            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
+                <b>let</b> refund = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
+                    &arc.main_config,
+                    &task,
+                    duration,
+                    current_time,
+                    (automation_fee_per_sec <b>as</b> u256));
+                <b>let</b> (_, remaining_epoch_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_fee_refund">safe_fee_refund</a>(
+                    epoch_locked_fees,
+                    &resource_signer,
+                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    refund);
+                epoch_locked_fees = remaining_epoch_locked_fees;
+            };
+
+            <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
+                refund_bookkeeping,
+                &resource_signer,
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
+                task.task_index,
+                task.owner,
+                task.locked_fee_for_next_epoch,
+                task.locked_fee_for_next_epoch);
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
+        };
+    });
+
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info, removed_tasks);
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
+        task_indexes: removed_tasks
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_into_automation_cycle_info"></a>
+
+## Function `into_automation_cycle_info`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_into_automation_cycle_info">into_automation_cycle_info</a>(details: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_into_automation_cycle_info">into_automation_cycle_info</a>(details: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+    <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+        index: details.index,
+        state: details.state,
+        start_time: details.start_time,
+        duration_secs: details.duration_secs
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_cycle_transition_state_from_suspended"></a>
+
+## Function `update_cycle_transition_state_from_suspended`
+
+Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
+moves to the next state.
+As transition happens from suspended state and while transition was in progress the feature was enabled back,
+then the transition will happend direclty to starated state, otherwise the transition will be done to the ready state.
+In both cases config will be updated. In this case we will make sure to keep the consistency of state when transition to ready state happens
+through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} -> Ready or Started -> Finished -> {Started, Suspended}
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>, processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>,
+    processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) <b>acquires</b>  <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>  {
+    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+    <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(transition_state, processed_tasks);
+
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(transition_state)) {
+        <b>return</b>
+    };
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = 0;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = 0;
+
+    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+        <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info)
+    } <b>else</b> {
+        <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_update_cycle_transition_state_from_finished"></a>
+
+## Function `update_cycle_transition_state_from_finished`
+
+Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
+moves to the next state.
+First it moves to the next cycle. But if happened so that there was a suspension during cycle transition which was ignored,
+then immediately cycle state is updated to suspended.
+Expectation will be that native layer catches this double transition and will issue refunds for the new cycle
+which will not proceeded farther in any case.
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>, processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>,
+    processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+) {
+    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+    // TODO maybe do this via <b>native</b> function <b>where</b> duplicates will be avoided
+    <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(transition_state, processed_tasks);
+    <b>let</b> transition_finalized = <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(transition_state);
+
+    <b>if</b> (transition_finalized) {
+        <a href="automation_registry.md#0x1_automation_registry_on_cycle_start_internal">on_cycle_start_internal</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info);
+    };
+    <b>if</b> (transition_finalized  && !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+        <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info)
+    }
 }
 </code></pre>
 
@@ -2806,15 +4298,13 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 </details>
 
-<a id="0x1_automation_registry_initialize"></a>
+<a id="0x1_automation_registry_on_cycle_start_internal"></a>
 
-## Function `initialize`
-
-Initialization of Automation Registry with configuration parameters is expected metrics.
-Deprecated in favor of initialize_v2
+## Function `on_cycle_start_internal`
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_start_internal">on_cycle_start_internal</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -2823,235 +4313,27 @@ Deprecated in favor of initialize_v2
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    epoch_interval_secs: u64,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_start_internal">on_cycle_start_internal</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>
 ) {
-    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
-}
-</code></pre>
+    // Indicates that moving <b>to</b> cycle start from transition state.
+    <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
 
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (transition_state.gas_committed_for_this_cycle <b>as</b> u256);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = transition_state.locked_fees;
 
-
-</details>
-
-<a id="0x1_automation_registry_initialize_refund_bookkeeping_resource"></a>
-
-## Function `initialize_refund_bookkeeping_resource`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-        total_deposited_automation_fee: 0
-    });
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_initialize_v2"></a>
-
-## Function `initialize_v2`
-
-Initialization of Automation Registry with configuration parameters for SUPRA_NATIVE_AUTOMATION_V2 version.
-Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
-automation feature is being introduced very first time.
-In case if framework upgrade is happening on the chain where automation feature is already released and
-is in ongoing state, then migrate_v2 function should be utilized instead.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    cycle_duration_secs: u64,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
-) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry_validate_configuration_parameters_common">validate_configuration_parameters_common</a>(
-        cycle_duration_secs,
-        task_duration_cap_in_secs,
-        registry_max_gas_cap,
-        congestion_threshold_percentage,
-        congestion_exponent);
-
-    <b>let</b> (registry_fee_resource_signer, registry_fee_address_signer_cap) = <a href="automation_registry.md#0x1_automation_registry_create_registry_resource_account">create_registry_resource_account</a>(
-        supra_framework
-    );
-
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-        tasks: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_new_map">enumerable_map::new_map</a>(),
-        current_index: 0,
-        gas_committed_for_next_epoch: 0,
-        epoch_locked_fees: 0,
-        gas_committed_for_this_epoch: 0,
-        registry_fee_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&registry_fee_resource_signer),
-        registry_fee_address_signer_cap,
-        epoch_active_task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-    });
-
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-        main_config: <a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a> {
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            automation_base_fee_in_quants_per_sec,
-            flat_registration_fee_in_quants,
-            congestion_threshold_percentage,
-            congestion_base_fee_in_quants_per_sec,
-            congestion_exponent,
-            task_capacity,
-        },
-        next_epoch_registry_max_gas_cap: registry_max_gas_cap,
-        registration_enabled: <b>true</b>,
-    });
-
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
-        start_time: 0,
-        index: 0,
-        duration_secs: cycle_duration_secs,
-        state: <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>
-    });
-
-    <a href="automation_registry.md#0x1_automation_registry_initialize_refund_bookkeeping_resource">initialize_refund_bookkeeping_resource</a>(supra_framework)
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_migrate_v2"></a>
-
-## Function `migrate_v2`
-
-API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
-detached from epoch-change.
-IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
-end-up in inconsistent state.
-
-TODO: Think of having native fucntion as means to identify that binary is not updated and lets have it called from
-monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
-thus not causing any inconcistensy in the chain
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_migrate_v2">migrate_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64
-    ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
-    assert_supra_framework(supra_framework);
-
-    // Prepare the state for migration
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_epoch_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationEpochInfo">AutomationEpochInfo</a>&gt;(@supra_framework);
-
-    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
-        @supra_framework
-    ).main_config;
-
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    // Refund the epoch fees <b>as</b> epoch will be cut short and on_new_epoch will be dummy due <b>to</b> migration,
-    // so this is the only place <b>to</b> do the refunds
-    <a href="automation_registry.md#0x1_automation_registry_update_state_for_migration">update_state_for_migration</a>(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
-        &automation_registry_config,
-        automation_epoch_info,
-        current_time
-    );
-
-    // Start migration by enabling feature, initializing the cycle releated resouces
-    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_next_epoch">features::change_feature_flags_for_next_epoch</a>(
-        supra_framework,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_get_supra_native_automation_v2_feature">features::get_supra_native_automation_v2_feature</a>()],
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
-    <b>let</b> id = 0;
-    <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
-        start_time: current_time,
-        index: id,
-        duration_secs: cycle_duration_secs,
-        state: <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>
-    });
-    // Emit cycle end which will lead the <b>native</b> layer <b>to</b> start preparation <b>to</b> the new cycle.
-    <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>();
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_on_new_epoch"></a>
-
-## Function `on_new_epoch`
-
-On new epoch caused by reconfiguration this function will be triggered and update the automation registry state
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>()
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
-        // If the lifecycle <b>has</b> been suspended and we are recovering from it, then we <b>update</b> config from buffer and
-        // then start a new cycle directly
-        <b>if</b> ( cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_LIFECYCLE_SUSPENDED">LIFECYCLE_SUSPENDED</a>) {
-            <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
-            <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
-        };
-        <b>return</b>
-    };
-    // We do not <b>update</b> config here, <b>as</b> due <b>to</b> feature being disabled, cycle ends early so it is expected
-    // that <b>native</b> layer will detect this state and generate refund transactions for a cycle that <b>has</b> been kept short.
-    // So the confing should remain intact.
-    <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(cycle_info);
+    // Set current <a href="timestamp.md#0x1_timestamp">timestamp</a> <b>as</b> cycle start_time
+    // Increase cycle and <b>update</b> the state <b>to</b> Started
+    <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids)) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
+            task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
+        });
+    }
 }
 </code></pre>
 
@@ -3065,7 +4347,7 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>()
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -3074,9 +4356,22 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>();
-    <a href="automation_registry.md#0x1_automation_registry_move_to_finished_state">move_to_finished_state</a>()
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_end_internal">on_cycle_end_internal</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
+    <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
+        new_cycle_duration: cycle_info.duration_secs,
+        automation_fee_per_sec: 0,
+        gas_committed_for_this_cycle: 0,
+        gas_committed_for_next_cycle: 0,
+        locked_fees: 0,
+        expected_tasks_to_be_processed: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks),
+        actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+    };
+    cycle_info.transition_state = std::option::some(transition_state);
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>);
+    // During cycle transition we <b>update</b> config only after transition state is created in order <b>to</b> have new cycle
+    // duration <b>as</b> transition parameter.
+    <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
 }
 </code></pre>
 
@@ -3084,13 +4379,13 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 
 </details>
 
-<a id="0x1_automation_registry_move_to_finished_state"></a>
+<a id="0x1_automation_registry_update_cycle_state_to"></a>
 
-## Function `move_to_finished_state`
+## Function `update_cycle_state_to`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_finished_state">move_to_finished_state</a>()
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>, state: u8)
 </code></pre>
 
 
@@ -3099,12 +4394,15 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_finished_state">move_to_finished_state</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
-    <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
-    cycle_info.state = <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>;
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_AutomationCycleFinished">AutomationCycleFinished</a> {
-        cycle_id: cycle_info.index,
-    });
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, state: u8) {
+    <b>let</b> old_state = cycle_info.state;
+    cycle_info.state = state;
+    <b>let</b> <a href="event.md#0x1_event">event</a> = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleEvent">AutomationCycleEvent</a> {
+        cycle_state_info: <a href="automation_registry.md#0x1_automation_registry_into_automation_cycle_info">into_automation_cycle_info</a>(cycle_info),
+        old_state,
+        event_time: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+    };
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="event.md#0x1_event">event</a>)
 }
 </code></pre>
 
@@ -3112,13 +4410,13 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 
 </details>
 
-<a id="0x1_automation_registry_move_to_suspended_state"></a>
+<a id="0x1_automation_registry_move_to_ready_state"></a>
 
-## Function `move_to_suspended_state`
+## Function `move_to_ready_state`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -3127,11 +4425,9 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>) {
-    cycle_info.state = <a href="automation_registry.md#0x1_automation_registry_LIFECYCLE_SUSPENDED">LIFECYCLE_SUSPENDED</a>;
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_AutomationCycleFinished">AutomationCycleFinished</a> {
-        cycle_id: cycle_info.index,
-    });
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_ready_state">move_to_ready_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) {
+    cycle_info.transition_state = std::option::none&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>&gt;();
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_READY_TO_START_NEW_CYCLE">READY_TO_START_NEW_CYCLE</a>)
 }
 </code></pre>
 
@@ -3145,7 +4441,7 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -3154,14 +4450,59 @@ On new epoch caused by reconfiguration this function will be triggered and updat
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>) {
-    cycle_info.state = <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>;
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) {
     cycle_info.index = cycle_info.index + 1;
     cycle_info.start_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_AutomationCycleStarted">AutomationCycleStarted</a> {
-        cycle_id: cycle_info.index,
-        <a href="timestamp.md#0x1_timestamp">timestamp</a>: cycle_info.start_time
-    });
+    <b>if</b> (std::option::is_some(&cycle_info.transition_state)) {
+        <b>let</b> transition_state = std::option::extract(&<b>mut</b> cycle_info.transition_state);
+        cycle_info.duration_secs = transition_state.new_cycle_duration;
+    };
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_move_to_suspended_state"></a>
+
+## Function `move_to_suspended_state`
+
+Transition to suspended state is expected
+a) when cycle is active and in progress
+- here we do simply move to suspended state so native layer can start requesting refunds and cleanup actions
+b) when cycle has just finished and there was another transaction causing feature suspension
+- as this both events happen in scope of the same block, then we will simply update the state to suspended
+and the native layer should identify this and request refund and cleanup with 0 fee and 0 duration,
+which will lead to simply deposit refund and cleanup.
+c) when cycle transition was in progress and there was a feature suspension, but it could not be applied,
+and postponed till the cycle transition concluded
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_move_to_suspended_state">move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) {
+    <b>if</b> (std::option::is_none(&cycle_info.transition_state)) {
+        <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
+            new_cycle_duration: cycle_info.duration_secs,
+            automation_fee_per_sec: 0,
+            gas_committed_for_this_cycle: 0,
+            gas_committed_for_next_cycle: 0,
+            locked_fees: 0,
+            expected_tasks_to_be_processed: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks),
+            actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+        };
+        cycle_info.transition_state = std::option::some(transition_state);
+    };
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>)
 }
 </code></pre>
 
@@ -3771,6 +5112,87 @@ would allow the congestion fee to increase in a non-linear fashion.
 
 </details>
 
+<a id="0x1_automation_registry_try_charge_tasks_automation_fees"></a>
+
+## Function `try_charge_tasks_automation_fees`
+
+Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
+- If the user has sufficient balance, deducts the fee and emits a success event.
+- If the balance is insufficient, removes the task and emits a cancellation event.
+- If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
+Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_fee_per_sec: u256, cycle_duration: u64, current_time: u64, task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
+    refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
+    automation_fee_per_sec: u256,
+    cycle_duration: u64,
+    current_time: u64,
+    task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;,
+    intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
+): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
+    <b>let</b> processed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+
+    <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
+        &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
+    );
+    <b>let</b> current_cycle_end_time = current_time + cycle_duration;
+
+    // Sort task indexes <b>to</b> charge automation fees in the tasks chronological order
+    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
+
+    // Process each active task and calculate fee for the epoch for the tasks
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
+        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> processed_tasks, task_index);
+            <b>let</b> task = {
+                <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
+                <b>let</b> fee= <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, cycle_duration, current_time, automation_fee_per_sec);
+                // If the task reached this phase that means it is valid active task for the new epoch.
+                // During cleanup all expired tasks <b>has</b> been removed from the registry but the state of the tasks is not updated.
+                // As here we need <b>to</b> distinguish new tasks from already existing active tasks,
+                // <b>as</b> the fee calculation for them will be different based on their active duration in the epoch.
+                // For more details see calculate_task_fee function.
+                task_meta.state = <a href="automation_registry.md#0x1_automation_registry_ACTIVE">ACTIVE</a>;
+                <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a> {
+                    task_index,
+                    owner: task_meta.owner,
+                    fee,
+                    expiry_time: task_meta.expiry_time,
+                    automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                    max_gas_amount: task_meta.max_gas_amount,
+                    locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+                }
+            };
+            <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(
+                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
+                refund_bookkeeping,
+                &resource_signer,
+                task,
+                current_cycle_end_time,
+                intermediate_state
+            );
+        };
+    });
+    processed_tasks
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_try_withdraw_task_automation_fees"></a>
 
 ## Function `try_withdraw_task_automation_fees`
@@ -3941,7 +5363,7 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>()
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -3950,7 +5372,7 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> {
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;()) {
         <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>&gt;();
         <b>let</b> automation_registry_config = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(
@@ -3967,42 +5389,13 @@ The function updates the ActiveAutomationRegistryConfig structure with values ex
     };
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a>&gt;()) {
         <b>let</b> buffer = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a>&gt;();
-        <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(
-            @supra_framework
-        );
-        cycle_info.duration_secs = buffer.duration_secs;
+        <b>if</b> (std::option::is_some(&cycle_info.transition_state)) {
+            <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+            transition_state.new_cycle_duration = buffer.duration_secs;
+        } <b>else</b> {
+            cycle_info.duration_secs = buffer.duration_secs;
+        }
     };
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_withdraw_automation_task_fees"></a>
-
-## Function `withdraw_automation_task_fees`
-
-Withdraw accumulated automation task fees from the resource account - access by admin
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_withdraw_automation_task_fees">withdraw_automation_task_fees</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    <b>to</b>: <b>address</b>,
-    amount: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <a href="automation_registry.md#0x1_automation_registry_transfer_fee_to_account_internal">transfer_fee_to_account_internal</a>(<b>to</b>, amount);
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RegistryFeeWithdraw">RegistryFeeWithdraw</a> { <b>to</b>, amount });
 }
 </code></pre>
 
@@ -4041,99 +5434,6 @@ Transfers the specified fee amount from the resource account to the target accou
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
     <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, <b>to</b>, amount);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_update_config"></a>
-
-## Function `update_config`
-
-Update Automation Registry Config
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
-) {
-    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_update_config_v2"></a>
-
-## Function `update_config_v2`
-
-Update Automation Registry Config along with cycle duration.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_v2">update_config_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, cycle_duration_secs: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config_v2">update_config_v2</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
-    cycle_duration_secs: u64,
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-
-
-    <a href="automation_registry.md#0x1_automation_registry_update_registration_config_internal">update_registration_config_internal</a>(
-        supra_framework,
-        task_duration_cap_in_secs,
-        registry_max_gas_cap,
-        automation_base_fee_in_quants_per_sec,
-        flat_registration_fee_in_quants,
-        congestion_threshold_percentage,
-        congestion_base_fee_in_quants_per_sec,
-        congestion_exponent,
-        task_capacity,
-        cycle_duration_secs,
-    );
-
-    // Update cycle duration in buffer
-    <b>assert</b>!(cycle_duration_secs &gt; 0, <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>);
-    <b>let</b> new_cycle_duration = <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDuration">AutomationCycleDuration</a> {
-        duration_secs: cycle_duration_secs
-    };
-    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<b>copy</b> new_cycle_duration);
-    <a href="event.md#0x1_event_emit">event::emit</a>(new_cycle_duration);
 }
 </code></pre>
 
@@ -4209,182 +5509,13 @@ Update Automation Registry Config releated to registration.
 
 </details>
 
-<a id="0x1_automation_registry_enable_registration"></a>
-
-## Function `enable_registration`
-
-Enables the registration process in the automation registry.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_enable_registration">enable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_enable_registration">enable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
-    automation_registry_config.registration_enabled = <b>true</b>;
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_EnabledRegistrationEvent">EnabledRegistrationEvent</a> {});
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_disable_registration"></a>
-
-## Function `disable_registration`
-
-Disables the registration process in the automation registry.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_disable_registration">disable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_disable_registration">disable_registration</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <b>let</b> automation_registry_config = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
-    automation_registry_config.registration_enabled = <b>false</b>;
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_DisabledRegistrationEvent">DisabledRegistrationEvent</a> {});
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_register"></a>
-
-## Function `register`
-
-Registers a new automation task entry.
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_register">register</a>(owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, expiry_time: u64, max_gas_amount: u64, gas_price_cap: u64, automation_fee_cap_for_epoch: u64, tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, aux_data: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_register">register</a>(
-    owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    payload_tx: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    expiry_time: u64,
-    max_gas_amount: u64,
-    gas_price_cap: u64,
-    automation_fee_cap_for_epoch: u64,
-    tx_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    aux_data: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-    // Guarding registration <b>if</b> feature is not enabled.
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>(), <a href="automation_registry.md#0x1_automation_registry_EDISABLED_AUTOMATION_FEATURE">EDISABLED_AUTOMATION_FEATURE</a>);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&aux_data), <a href="automation_registry.md#0x1_automation_registry_ENO_AUX_DATA_SUPPORTED">ENO_AUX_DATA_SUPPORTED</a>);
-
-    <b>let</b> automation_registry_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
-    <b>assert</b>!(automation_registry_config.registration_enabled, <a href="automation_registry.md#0x1_automation_registry_ETASK_REGISTRATION_DISABLED">ETASK_REGISTRATION_DISABLED</a>);
-
-    // If registry is full, reject task registration
-    <b>assert</b>!((<a href="automation_registry.md#0x1_automation_registry_get_task_count">get_task_count</a>() <b>as</b> u16) &lt; automation_registry_config.main_config.task_capacity, <a href="automation_registry.md#0x1_automation_registry_EREGISTRY_IS_FULL">EREGISTRY_IS_FULL</a>);
-
-    <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> automation_cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
-
-    //Well-formedness check of payload_tx is done in <b>native</b> layer beforehand.
-
-    <b>let</b> registration_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <a href="automation_registry.md#0x1_automation_registry_check_registration_task_duration">check_registration_task_duration</a>(
-        expiry_time,
-        registration_time,
-        &automation_registry_config.main_config,
-        automation_cycle_info
-    );
-
-    <b>assert</b>!(gas_price_cap &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>);
-    <b>assert</b>!(max_gas_amount &gt; 0, <a href="automation_registry.md#0x1_automation_registry_EINVALID_MAX_GAS_AMOUNT">EINVALID_MAX_GAS_AMOUNT</a>);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&tx_hash) == <a href="automation_registry.md#0x1_automation_registry_TXN_HASH_LENGTH">TXN_HASH_LENGTH</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_TXN_HASH">EINVALID_TXN_HASH</a>);
-
-    <b>let</b> committed_gas = (<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch <b>as</b> u128) + (max_gas_amount <b>as</b> u128);
-    <b>assert</b>!(committed_gas &lt;= <a href="automation_registry.md#0x1_automation_registry_MAX_U64">MAX_U64</a>, <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_OVERFLOW">EGAS_COMMITTEED_VALUE_OVERFLOW</a>);
-
-    <b>let</b> committed_gas = (committed_gas <b>as</b> u64);
-    <b>assert</b>!(committed_gas &lt;= automation_registry_config.next_epoch_registry_max_gas_cap, <a href="automation_registry.md#0x1_automation_registry_EGAS_AMOUNT_UPPER">EGAS_AMOUNT_UPPER</a>);
-
-    // Check the automation fee capacity
-    <b>let</b> estimated_automation_fee_for_epoch = <a href="automation_registry.md#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy_internal">estimate_automation_fee_with_committed_occupancy_internal</a>(
-        max_gas_amount,
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch,
-        automation_cycle_info.duration_secs,
-        automation_registry_config);
-    <b>assert</b>!(automation_fee_cap_for_epoch &gt;= estimated_automation_fee_for_epoch,
-        <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH">EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH</a>
-    );
-
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = committed_gas;
-    <b>let</b> task_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index;
-
-    <b>let</b> automation_task_metadata = <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">AutomationTaskMetaData</a> {
-        task_index,
-        owner,
-        payload_tx,
-        expiry_time,
-        max_gas_amount,
-        gas_price_cap,
-        automation_fee_cap_for_epoch,
-        aux_data,
-        state: <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>,
-        registration_time,
-        tx_hash,
-        locked_fee_for_next_epoch: automation_fee_cap_for_epoch
-    };
-
-    <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_add_value">enumerable_map::add_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index, automation_task_metadata);
-    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.current_index + 1;
-
-    // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
-    <b>let</b> fee = automation_registry_config.main_config.flat_registration_fee_in_quants + automation_fee_cap_for_epoch;
-
-    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-    refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + automation_fee_cap_for_epoch;
-
-    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(owner_signer, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, fee);
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskRegistrationDepositFeeWithdraw">TaskRegistrationDepositFeeWithdraw</a> {
-        task_index,
-        owner,
-        registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
-        locked_deposit_fee: automation_fee_cap_for_epoch
-    });
-    <a href="event.md#0x1_event_emit">event::emit</a>(automation_task_metadata);
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_automation_registry_check_registration_task_duration"></a>
 
 ## Function `check_registration_task_duration`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_check_registration_task_duration">check_registration_task_duration</a>(expiry_time: u64, registration_time: u64, automation_registry_config: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_cycle_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">automation_registry::AutomationCycleInfo</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_check_registration_task_duration">check_registration_task_duration</a>(expiry_time: u64, registration_time: u64, automation_registry_config: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_cycle_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -4397,7 +5528,7 @@ Registers a new automation task entry.
     expiry_time: u64,
     registration_time: u64,
     automation_registry_config: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
-    automation_cycle_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>
+    automation_cycle_info: &<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>
 ) {
     <b>assert</b>!(expiry_time &gt; registration_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_EXPIRY_TIME">EINVALID_EXPIRY_TIME</a>);
     <b>let</b> task_duration = expiry_time - registration_time;
@@ -4408,276 +5539,6 @@ Registers a new automation task entry.
         expiry_time &gt; (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
         <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_CYCLE">EEXPIRY_BEFORE_NEXT_CYCLE</a>
     );
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_cancel_task"></a>
-
-## Function `cancel_task`
-
-Cancel Automation task with specified task_index.
-Only existing task, which is PENDING or ACTIVE, can be cancelled and only by task owner.
-If the task is
-- active, its state is updated to be CANCELLED.
-- pending, it is removed form the list.
-- cancelled, an error is reported
-Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_index: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_cancel_task">cancel_task</a>(
-    owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_index: u64
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> , <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>{
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-    <b>assert</b>!(<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index), <a href="automation_registry.md#0x1_automation_registry_EAUTOMATION_TASK_NOT_FOUND">EAUTOMATION_TASK_NOT_FOUND</a>);
-
-    <b>let</b> automation_task_metadata = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value">enumerable_map::get_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-    <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
-    <b>assert</b>!(automation_task_metadata.owner == owner, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
-    <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>, <a href="automation_registry.md#0x1_automation_registry_EALREADY_CANCELLED">EALREADY_CANCELLED</a>);
-    <b>if</b> (automation_task_metadata.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
-        <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-            &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-        );
-        // When Pending tasks are cancelled, refund of the deposit fee is done <b>with</b> penalty
-        <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_deposit_refund">safe_deposit_refund</a>(
-            refund_bookkeeping,
-            &resource_signer,
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address,
-            automation_task_metadata.task_index,
-            owner,
-            automation_task_metadata.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FACTOR">REFUND_FACTOR</a>,
-        automation_task_metadata.locked_fee_for_next_epoch);
-        <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>);
-        <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-    } <b>else</b> { // it is safe not <b>to</b> check the state <b>as</b> above, the cancelled tasks are already rejected.
-        // Active tasks will be refunded the deposited amount fully at the end of the epoch
-        <b>let</b> automation_task_metadata_mut = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(
-            &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks,
-            task_index
-        );
-        automation_task_metadata_mut.state = <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>;
-    };
-
-    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
-    // This check means the task was expected <b>to</b> be executed in the next cycle, but it <b>has</b> been cancelled.
-    // We need <b>to</b> remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
-    <b>if</b> (automation_task_metadata.expiry_time &gt; (cycle_info.start_time + cycle_info.duration_secs)) {
-        <b>assert</b>!(
-            <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &gt;= automation_task_metadata.max_gas_amount,
-            <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_UNDERFLOW">EGAS_COMMITTEED_VALUE_UNDERFLOW</a>
-        );
-        // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
-    };
-
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TaskCancelled">TaskCancelled</a> { task_index: automation_task_metadata.task_index, owner });
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_stop_tasks"></a>
-
-## Function `stop_tasks`
-
-Immediately stops automation tasks for the specified <code>task_indexes</code>.
-Only tasks that exist and are owned by the sender can be stopped.
-If any of the specified tasks are not owned by the sender, the transaction will abort.
-When a task is stopped, the committed gas for the next epoch is reduced
-by the max gas amount of the stopped task. Half of the remaining task fee is refunded.
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_stop_tasks">stop_tasks</a>(owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_stop_tasks">stop_tasks</a>(
-    owner_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
-) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a> {
-    // Ensure that task indexes are provided
-    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes), <a href="automation_registry.md#0x1_automation_registry_EEMPTY_TASK_INDEXES">EEMPTY_TASK_INDEXES</a>);
-
-    <b>let</b> owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner_signer);
-    <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
-    <b>let</b> arc = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework).main_config;
-    <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a>&gt;(@supra_framework);
-    <b>let</b> refund_bookkeeping = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>&gt;(@supra_framework);
-
-    <b>let</b> tcmg = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch;
-
-    // Compute the automation fee multiplier for epoch
-    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(&arc, tcmg, arc.registry_max_gas_cap);
-
-    <b>let</b> stopped_task_details = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> total_refund_fee = 0;
-    <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
-
-    // Calculate refundable fee for this remaining time task in current epoch
-    <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-    <b>let</b> cycle_end_time = cycle_info.duration_secs + cycle_info.start_time;
-    <b>let</b> residual_interval = <b>if</b> (cycle_end_time &lt;= current_time) {
-        0
-    } <b>else</b> {
-        cycle_end_time - current_time
-    };
-
-    // Loop through each task index <b>to</b> validate and stop the task
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
-        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            // Remove task from registry
-            <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
-
-            // Ensure only the task owner can stop it
-            <b>assert</b>!(task.owner == owner, <a href="automation_registry.md#0x1_automation_registry_EUNAUTHORIZED_TASK_OWNER">EUNAUTHORIZED_TASK_OWNER</a>);
-
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_remove_value">vector::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids, &task_index);
-
-            // This check means the task was expected <b>to</b> be executed in the next epoch, but it <b>has</b> been stopped.
-            // We need <b>to</b> remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
-            // Also it checks that task should not be cancelled.
-            <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> && task.expiry_time &gt; cycle_end_time) {
-                // Prevent underflow in gas committed
-                <b>assert</b>!(
-                    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &gt;= task.max_gas_amount,
-                    <a href="automation_registry.md#0x1_automation_registry_EGAS_COMMITTEED_VALUE_UNDERFLOW">EGAS_COMMITTEED_VALUE_UNDERFLOW</a>
-                );
-
-                // Reduce committed gas by the stopped task's max gas
-                <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch - task.max_gas_amount;
-            };
-
-            <b>let</b> (epoch_fee_refund, deposit_refund) = <b>if</b> (task.state != <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
-                <b>let</b> task_fee = <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(
-                    &arc,
-                    &task,
-                    residual_interval,
-                    current_time,
-                    automation_fee_per_sec
-                );
-                // Refund full deposit and the half of the remaining run-time fee when task is active or cancelled stage
-                (task_fee / <a href="automation_registry.md#0x1_automation_registry_REFUND_FRACTION">REFUND_FRACTION</a>, task.locked_fee_for_next_epoch)
-            } <b>else</b> {
-                (0, (task.locked_fee_for_next_epoch / <a href="automation_registry.md#0x1_automation_registry_REFUND_FRACTION">REFUND_FRACTION</a>))
-            };
-            <b>let</b> result = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_deposit">safe_unlock_locked_deposit</a>(
-                refund_bookkeeping,
-                task.locked_fee_for_next_epoch,
-                task.task_index);
-            <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EDEPOSIT_REFUND">EDEPOSIT_REFUND</a>);
-            <b>let</b> (result, remaining_epoch_locked_fees) = <a href="automation_registry.md#0x1_automation_registry_safe_unlock_locked_epoch_fee">safe_unlock_locked_epoch_fee</a>(
-                epoch_locked_fees,
-                epoch_fee_refund,
-                task.task_index);
-            <b>assert</b>!(result, <a href="automation_registry.md#0x1_automation_registry_EEPOCH_FEE_REFUND">EEPOCH_FEE_REFUND</a>);
-            epoch_locked_fees = remaining_epoch_locked_fees;
-
-            total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
-
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(
-                &<b>mut</b> stopped_task_details,
-                <a href="automation_registry.md#0x1_automation_registry_TaskStopped">TaskStopped</a> { task_index, deposit_refund, epoch_fee_refund }
-            );
-        }
-    });
-
-    // Refund and emit <a href="event.md#0x1_event">event</a> <b>if</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> tasks were stopped
-    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&stopped_task_details)) {
-        <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
-            &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
-        );
-
-        <b>let</b> resource_account_balance = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;SupraCoin&gt;(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address);
-        <b>assert</b>!(resource_account_balance &gt;= total_refund_fee, <a href="automation_registry.md#0x1_automation_registry_EINSUFFICIENT_BALANCE_FOR_REFUND">EINSUFFICIENT_BALANCE_FOR_REFUND</a>);
-        <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;SupraCoin&gt;(&resource_signer, owner, total_refund_fee);
-
-        // Emit task stopped <a href="event.md#0x1_event">event</a>
-        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_TasksStopped">TasksStopped</a> {
-            tasks: stopped_task_details,
-            owner
-        });
-    };
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_update_epoch_interval_in_registry"></a>
-
-## Function `update_epoch_interval_in_registry`
-
-Update epoch interval in registry while actually update happens in block module
-Deprecated since SUPRA_NATIVE_AUTOMATION_V2 feature release in favor of monitor_cycle_end
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64) {
-    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_monitor_cycle_end"></a>
-
-## Function `monitor_cycle_end`
-
-Checks the cycle end and emit an event on it.
-Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>()
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>() {
-    // TODO: check is initialized, <b>if</b> not emit <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> but do not fail.
-    // check <b>if</b> SUPRA_NATIVE_AUTOMATION feature is disabled, do nothing
-    // call dummy <b>native</b> function which should be available <b>if</b> SUPRA_NATIVE_AUTOMATION_V2 is enabled.
-    //    - It does nothing , <b>if</b> binary is also updated, otherwise VM will panic causing <a href="block.md#0x1_block">block</a>-prologue <b>to</b>
-    //      fail resulting in node failure <b>as</b> well.
-    // Otherwise <b>if</b> cycle_start + cycle_duration &gt;= current time, mark the cycle <b>as</b> finished:
-    // on_cycle_end_internal
-    <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>();
 }
 </code></pre>
 
@@ -4834,7 +5695,7 @@ Insertion sort implementation for vector
 
 ## Function `assert_cycle_based_automation_registry_management_support`
 
-If SUPRA_NATIVE_AUTOMATION_V2 is enabled then call native function to assert full support of cycle based
+If SUPRA_CYCLE_BASED_AUTOMATION is enabled then call native function to assert full support of cycle based
 automation registry management.
 
 
@@ -4848,7 +5709,7 @@ automation registry management.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_assert_cycle_based_automation_registry_management_support">assert_cycle_based_automation_registry_management_support</a>() {
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_v2_enabled">features::supra_native_automation_v2_enabled</a>()) {
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_cycle_based_automation_enabled">features::supra_cycle_based_automation_enabled</a>()) {
         <a href="automation_registry.md#0x1_automation_registry_native_cycle_based_automation_registry_management_support">native_cycle_based_automation_registry_management_support</a>();
     }
 }

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -48,7 +48,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Constants](#@Constants_0)
 -  [Function `is_transition_finalized`](#0x1_automation_registry_is_transition_finalized)
 -  [Function `is_transition_in_progress`](#0x1_automation_registry_is_transition_in_progress)
--  [Function `update_processed_tasks`](#0x1_automation_registry_update_processed_tasks)
 -  [Function `append_processed_task`](#0x1_automation_registry_append_processed_task)
 -  [Function `already_processed`](#0x1_automation_registry_already_processed)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
@@ -72,7 +71,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `estimate_automation_fee`](#0x1_automation_registry_estimate_automation_fee)
 -  [Function `estimate_automation_fee_with_committed_occupancy`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy)
 -  [Function `calculate_automation_fee_multiplier_for_committed_occupancy`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy)
--  [Function `calculate_automation_fee_unit_for_current_cycle`](#0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle)
+-  [Function `calculate_automation_fee_multiplier_for_current_cycle`](#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle)
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
 -  [Function `get_cycle_duration`](#0x1_automation_registry_get_cycle_duration)
 -  [Function `get_cycle_info`](#0x1_automation_registry_get_cycle_info)
@@ -86,7 +85,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `initialize_refund_bookkeeping_resource`](#0x1_automation_registry_initialize_refund_bookkeeping_resource)
 -  [Function `migrate_v2`](#0x1_automation_registry_migrate_v2)
 -  [Function `initialize`](#0x1_automation_registry_initialize)
--  [Function `initialize_v2`](#0x1_automation_registry_initialize_v2)
 -  [Function `monitor_cycle_end`](#0x1_automation_registry_monitor_cycle_end)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
 -  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
@@ -346,6 +344,7 @@ It tracks entries both pending and completed, organized by unique indices.
 ## Struct `TransitionState`
 
 It tracks entries both pending and completed, organized by unique indices.
+Holds intermediate state data of the automation cycle transition from END->STARTED, or SUSPENDED->READY
 
 
 <pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> <b>has</b> <b>copy</b>, drop, store
@@ -362,19 +361,19 @@ It tracks entries both pending and completed, organized by unique indices.
 <code>refund_duration: u64</code>
 </dt>
 <dd>
- Remaining duration if cycle was kept short. Actual only in case of suspention.
+ Refund duration of automation fees when automation feature/cycle is suspended.
 </dd>
 <dt>
 <code>new_cycle_duration: u64</code>
 </dt>
 <dd>
- Duration of the new cycle.
+ Duration of the new cycle to charge fees for.
 </dd>
 <dt>
 <code>automation_fee_per_sec: u64</code>
 </dt>
 <dd>
- Calculated automation fee per second for the new cycle.
+ Calculated automation fee per second for a new cycle or for refund period.
 </dd>
 <dt>
 <code>gas_committed_for_new_cycle: u64</code>
@@ -386,19 +385,19 @@ It tracks entries both pending and completed, organized by unique indices.
 <code>gas_committed_for_next_cycle: u64</code>
 </dt>
 <dd>
- Gas committed for next cycle
+ Gas committed for the next cycle.
 </dd>
 <dt>
 <code>locked_fees: u64</code>
 </dt>
 <dd>
- Total fee charged to users during the cycle, which is not withdrawable
+ Total fee charged from users for the new cycle, which is not withdrawable.
 </dd>
 <dt>
 <code>expected_tasks_to_be_processed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
 </dt>
 <dd>
- Number of the tasks to be processed during transition.
+ List of the tasks to be processed during transition.
 </dd>
 <dt>
 <code>actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
@@ -491,7 +490,7 @@ Cycle Duration wrapper to store in the config-buffer.
 
 ## Struct `AutomationCycleInfo`
 
-Cycle state.
+Provides information of the current cycle state.
 
 
 <pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>has</b> <b>copy</b>, drop, store
@@ -508,7 +507,7 @@ Cycle state.
 <code>index: u64</code>
 </dt>
 <dd>
- Current cycle id. Incremented when a start of the new cycle is processed.
+ Current cycle id. Incremented when a start of a new cycle is given.
 </dd>
 <dt>
 <code>state: u8</code>
@@ -537,7 +536,7 @@ Cycle state.
 
 ## Struct `AutomationCycleEvent`
 
-Event emitted in the cycle-state.
+Event emitted for cycle state transition.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
@@ -614,7 +613,7 @@ Cycle state.
 <code>duration_secs: u64</code>
 </dt>
 <dd>
- Automation cycle duration in seconds.
+ Automation cycle duration in seconds for the current cycle.
 </dd>
 <dt>
 <code>transition_state: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>&gt;</code>
@@ -1790,11 +1789,11 @@ Triggered when cycle end is identified.
 <a id="0x1_automation_registry_CYCLE_READY"></a>
 
 Constants describing CYCLE state.
-State transition flaw is:
+State transition flow is:
 CYCLE_READY -> CYCLE_STARTED
 CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
-CYCLE_FINISHED ->  { CYCLE_STARTED}
-CYCLE_SUSPENDED ->  {CYCLE_READY, STARTED}
+CYCLE_FINISHED ->  CYCLE_STARTED
+CYCLE_SUSPENDED -> { CYCLE_READY, STARTED }
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>: u8 = 0;
@@ -1804,7 +1803,7 @@ CYCLE_SUSPENDED ->  {CYCLE_READY, STARTED}
 
 <a id="0x1_automation_registry_CYCLE_STARTED"></a>
 
-Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by autoamtion cycle manager in native layer.
+Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by registry when cycle transition is completed.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>: u8 = 1;
@@ -1875,7 +1874,7 @@ Congestion exponent must be non-zero.
 
 <a id="0x1_automation_registry_ECYCLE_DURATION_NON_ZERO"></a>
 
-Automation registry max gas capacity cannot be zero.
+Automation cycle duration cannot be zero.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_ECYCLE_DURATION_NON_ZERO">ECYCLE_DURATION_NON_ZERO</a>: u64 = 30;
@@ -2013,26 +2012,6 @@ Resource Account does not have sufficient balance to process the refund for the 
 
 
 
-<a id="0x1_automation_registry_EINVALID_CHARGE_ACTION"></a>
-
-Attempt to run charge action with inconsistent input values compared to internal state, or with cancelled task.
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_CHARGE_ACTION">EINVALID_CHARGE_ACTION</a>: u64 = 34;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EINVALID_DROP_ACTION"></a>
-
-Attempt to drop task which is still valid
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_DROP_ACTION">EINVALID_DROP_ACTION</a>: u64 = 36;
-</code></pre>
-
-
-
 <a id="0x1_automation_registry_EINVALID_EXPIRY_TIME"></a>
 
 Invalid expiry time: it cannot be earlier than the current time
@@ -2069,16 +2048,6 @@ Attempt to do migration to cycle based automation which is already enabled.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_MIGRATION_ACTION">EINVALID_MIGRATION_ACTION</a>: u64 = 31;
-</code></pre>
-
-
-
-<a id="0x1_automation_registry_EINVALID_REFUND_DURATION"></a>
-
-Attempt to run refund action with duration more than cycle duration is.
-
-
-<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_REFUND_DURATION">EINVALID_REFUND_DURATION</a>: u64 = 35;
 </code></pre>
 
 
@@ -2313,30 +2282,6 @@ The length of the transaction hash.
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>): bool {
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.actual_processed_tasks) != 0
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_update_processed_tasks"></a>
-
-## Function `update_processed_tasks`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> state.actual_processed_tasks, task_indexes);
 }
 </code></pre>
 
@@ -3002,9 +2947,9 @@ maximum allowed occupancy.
 
 </details>
 
-<a id="0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle"></a>
+<a id="0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle"></a>
 
-## Function `calculate_automation_fee_unit_for_current_cycle`
+## Function `calculate_automation_fee_multiplier_for_current_cycle`
 
 Calculates automation fee per second for the current cycle
 referencing the current automation registry fee parameters, and committed gas for this cycle stored in
@@ -3012,7 +2957,7 @@ the automation registry and current maximum allowed occupancy.
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle">calculate_automation_fee_unit_for_current_cycle</a>(): u64
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle">calculate_automation_fee_multiplier_for_current_cycle</a>(): u64
 </code></pre>
 
 
@@ -3021,7 +2966,7 @@ the automation registry and current maximum allowed occupancy.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_current_cycle">calculate_automation_fee_unit_for_current_cycle</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle">calculate_automation_fee_multiplier_for_current_cycle</a>(): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
     // Compute the automation fee multiplier for this cycle
     <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
@@ -3089,7 +3034,7 @@ Returns the current duration of the automation cycle.
 
 ## Function `get_cycle_info`
 
-Returns the current status of the registration in the automation registry.
+Returns the current cycle info.
 
 
 <pre><code>#[view]
@@ -3225,7 +3170,7 @@ Update Automation Registry Config along with cycle duration.
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a> = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>&gt;(@supra_framework);
 
     <b>assert</b>!(
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &lt; registry_max_gas_cap,
+        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch &lt;= registry_max_gas_cap,
         <a href="automation_registry.md#0x1_automation_registry_EUNACCEPTABLE_AUTOMATION_GAS_LIMIT">EUNACCEPTABLE_AUTOMATION_GAS_LIMIT</a>
     );
 
@@ -3559,7 +3504,7 @@ Public entry function to initialize bookeeping resource when feature enabling au
 
 API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
 detached from epoch-change and cycle based lifecycle of the automation registry is enabled.
-IMPORTANT: Should alwasy be followed by <code>SUPRA_AUTOMATION_CYCLE</code> feature flag being enabled and
+IMPORTANT: Should always be followed by <code>SUPRA_AUTOMATION_CYCLE</code> feature flag being enabled and
 supra_governance::reconfiguration otherwise registry/chain will end-up in inconsistent state.
 
 monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
@@ -3599,7 +3544,7 @@ thus not causing any inconcistensy in the chain
         current_time
     );
 
-    // Start migration by enabling feature, initializing the cycle releated resouces
+    // Initializing the cycle releated resouces
     <b>let</b> id = 0;
     <b>move_to</b>(supra_framework, <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
         start_time: current_time,
@@ -3608,7 +3553,7 @@ thus not causing any inconcistensy in the chain
         state: <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>,
         transition_state: std::option::none()
     });
-    // Remain in <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a> statey <b>if</b> feature is not enabled or registry is not fully initialized
+    // Remain in <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a> state <b>if</b> feature is not enabled or registry is not fully initialized
     <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_feature_enabled_and_initialized">is_feature_enabled_and_initialized</a>()) {
         <b>return</b>
     };
@@ -3626,11 +3571,14 @@ thus not causing any inconcistensy in the chain
 
 ## Function `initialize`
 
-Initialization of Automation Registry with configuration parameters is expected metrics.
-Deprecated in favor of initialize_v2
+Initialization of Automation Registry with configuration parameters for SUPRA_AUTOMATION_CYCLE version.
+Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
+automation feature is being introduced very first time utilizing <code><a href="genesis.md#0x1_genesis_initialize_supra_native_automation_v2">genesis::initialize_supra_native_automation_v2</a></code>.
+In case if framework upgrade is happening on the chain where automation feature with epoch based lifecycle is
+already released and is in ongoing state, then <code>migrate_v2</code> function should be utilized instead.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(_supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _epoch_interval_secs: u64, _task_duration_cap_in_secs: u64, _registry_max_gas_cap: u64, _automation_base_fee_in_quants_per_sec: u64, _flat_registration_fee_in_quants: u64, _congestion_threshold_percentage: u8, _congestion_base_fee_in_quants_per_sec: u64, _congestion_exponent: u8, _task_capacity: u16)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
 </code></pre>
 
 
@@ -3640,46 +3588,6 @@ Deprecated in favor of initialize_v2
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(
-    _supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    _epoch_interval_secs: u64,
-    _task_duration_cap_in_secs: u64,
-    _registry_max_gas_cap: u64,
-    _automation_base_fee_in_quants_per_sec: u64,
-    _flat_registration_fee_in_quants: u64,
-    _congestion_threshold_percentage: u8,
-    _congestion_base_fee_in_quants_per_sec: u64,
-    _congestion_exponent: u8,
-    _task_capacity: u16,
-) {
-    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_initialize_v2"></a>
-
-## Function `initialize_v2`
-
-Initialization of Automation Registry with configuration parameters for SUPRA_AUTOMATION_CYCLE version.
-Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
-automation feature is being introduced very first time.
-In case if framework upgrade is happening on the chain where automation feature is already released and
-is in ongoing state, then migrate_v2 function should be utilized instead.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_duration_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize_v2">initialize_v2</a>(
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     cycle_duration_secs: u64,
     task_duration_cap_in_secs: u64,
@@ -3758,7 +3666,7 @@ is in ongoing state, then migrate_v2 function should be utilized instead.
 ## Function `monitor_cycle_end`
 
 Checks the cycle end and emit an event on it.
-Does nothig if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
+Does nothing if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">monitor_cycle_end</a>()
@@ -3792,14 +3700,20 @@ Does nothig if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
 
 ## Function `on_new_epoch`
 
-On new epoch caused by reconfiguration this function will be triggered and update the automation registry state.
-If registry is not fully initialized nothing is done. Epoch change can be caused by governance action or by DKG
-finalization. In case of the later case execution should not fail.
+On new epoch will be triggered for automation registry caused by <code>supra_governance::reconfiguration</code> or DKG finalization
+to update the automation registry state depending on SUPRA_NATIVE_AUTOMATION feature flag state.
 
-If native automation feature is disabled then automation lifecycle is suspended. And detached managment will
-initiate refund and cealnup actions.
+If registry is not fully initialized nothing is done.
 
-If native automation feature is enabled and automation lifecycle has been in suspended state,
+If native automation feature is disabled and automation cycle in CYCLE_STARTED state,
+then automation lifecycle is suspended immediately. And detached managment will
+initiate reprocessing of the available tasks which will end up in refund and cealnup actions.
+
+Otherwise suspention is postponed untill the end of the transition state.
+
+Nothing will be done if automation cycle was already suspneded, i.e. in CYCLE_READY state.
+
+If native automation feature is enabled and automation lifecycle has been in CYCLE_READY state,
 then lifecycle is restarted.
 
 
@@ -3836,7 +3750,8 @@ then lifecycle is restarted.
     };
 
     // We do not <b>update</b> config here, <b>as</b> due <b>to</b> feature being disabled, cycle ends early so it is expected
-    // that <b>native</b> layer will detect this state and generate refund transactions for a cycle that <b>has</b> been kept short.
+    // that the current fee-parameters will be used <b>to</b> calculate automation-fee for refund for a cycle
+    // that <b>has</b> been kept short.
     // So the confing should remain intact.
     <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>) {
         <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(registry_data, cycle_info);
@@ -4018,11 +3933,11 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
     <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>) {
-        <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(vm, task_indexes);
+        <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(task_indexes);
         <b>return</b>
     };
     <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
-    <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(vm, task_indexes);
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(task_indexes);
 }
 </code></pre>
 
@@ -4034,9 +3949,21 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
 
 ## Function `on_cycle_transition`
 
+Traverses the list of the tasks and based on the task state and expiry information either charges or drops
+the task after refunding eligable fees
+
+Tasks are cheked not to be processed more than once.
+This function should be called only if registry is in CYCLE_FINISHED state, meaning a normal cycle transition is
+happening.
+
+After processing all input tasks, intermediate transition state is updated and transition end is check
+(whether all expected tasks has been processed already).
+
+In case if transition end is detected a start of the new cycle is given
+(if during trasition period suspention is not requested) and corresponding event is emitted.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4045,11 +3972,8 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    // Operational constraint: can only be invoked by the VM
-    <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
-
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
         <b>return</b>
     };
@@ -4108,9 +4032,16 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
 
 ## Function `on_cycle_suspend`
 
+Traverses the list of the tasks and refunds automation(if not PENDING) and depoist fees for all tasks
+and removes from registry.
+
+This function is called only if automation feature is disabled, i.e. CYCLE_SUSPENDED state.
+
+After processing input set of tasks the end of suspention process is checked(i.e. all expected tasks has been processed).
+In case if end is identified the registry state is update to CYCLE_READY and corresponding event is emitted.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4119,10 +4050,8 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
-    // Operational constraint: can only be invoked by the VM
-    <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
 
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
         <b>return</b>
@@ -4250,6 +4179,7 @@ Traverses all input task indexes and either drops or tries to charge automation 
 ## Function `drop_or_charge_task`
 
 Drops or charges the input task.
+If the task is already processed or missing from the registry then nothing is done.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_drop_or_charge_task">drop_or_charge_task</a>(task_index: u64, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, current_time: u64, current_cycle_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
@@ -4393,12 +4323,17 @@ Refunds the deposit fee of the task and removes from registry.
 
 ## Function `update_cycle_transition_state_from_suspended`
 
-Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
-moves to the next state.
-As transition happens from suspended state and while transition was in progress the feature was enabled back,
-then the transition will happend direclty to starated state, otherwise the transition will be done to the ready state.
-In both cases config will be updated. In this case we will make sure to keep the consistency of state when transition to ready state happens
-through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} -> Ready or Started -> Finished -> {Started, Suspended}
+Updates the cycle state if the transition is identified to be finalized.
+
+As transition happens from suspended state and while transition was in progress
+- if the feature was enabled back, then the transition will happend direclty to starated state,
+- otherwise the transition will be done to the ready state.
+
+In both cases config will be updated. In this case we will make sure to keep the consistency of state
+when transition to ready state happens through paths
+- Started -> Suspended -> Ready
+- or Started-> {Finished, Suspended} -> Ready
+- or Started -> Finished -> {Started, Suspended}
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
@@ -4442,11 +4377,14 @@ through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} ->
 
 ## Function `update_cycle_transition_state_from_finished`
 
-Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
-moves to the next state.
-First it moves to the next cycle. But if happened so that there was a suspension during cycle transition which was ignored,
+Updates the cycle state if the transition is identified to be finalized.
+
+From CYCLE_FINALIZED state we always move to the next cycle and in CYCLE_STARTED state.
+
+But if it happened so that there was a suspension during cycle transition which was ignored,
 then immediately cycle state is updated to suspended.
-Expectation will be that native layer catches this double transition and will issue refunds for the new cycle
+
+Expectation will be that native layer catches this double transition and issues refunds for the new cycle fees
 which will not proceeded farther in any case.
 
 
@@ -4468,22 +4406,24 @@ which will not proceeded farther in any case.
     <b>let</b> transition_state = std::option::borrow(&cycle_info.transition_state);
     <b>let</b> transition_finalized = <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(transition_state);
 
-    <b>if</b> (transition_finalized) {
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (transition_state.gas_committed_for_new_cycle <b>as</b> u256);
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-        <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = transition_state.locked_fees;
-
-        // Set current <a href="timestamp.md#0x1_timestamp">timestamp</a> <b>as</b> cycle start_time
-        // Increase cycle and <b>update</b> the state <b>to</b> Started
-        <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
-        <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids)) {
-            <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
-                task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
-            });
-        }
+    <b>if</b> (!transition_finalized) {
+        <b>return</b>
     };
-    <b>if</b> (transition_finalized  && !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
+
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_this_epoch = (transition_state.gas_committed_for_new_cycle <b>as</b> u256);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees = transition_state.locked_fees;
+
+    // Set current <a href="timestamp.md#0x1_timestamp">timestamp</a> <b>as</b> cycle start_time
+    // Increase cycle and <b>update</b> the state <b>to</b> Started
+    <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids)) {
+        <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_ActiveTasks">ActiveTasks</a> {
+            task_indexes: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_active_task_ids
+        });
+    };
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_native_automation_enabled">features::supra_native_automation_enabled</a>()) {
         <a href="automation_registry.md#0x1_automation_registry_try_move_to_suspended_state">try_move_to_suspended_state</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info)
     }
 }
@@ -4640,10 +4580,12 @@ Note it is expected that committed_occupancy does not include currnet task's occ
     };
     cycle_info.transition_state = std::option::some(transition_state);
     // During cycle transition we <b>update</b> config only after transition state is created in order <b>to</b> have new cycle
-    // duration <b>as</b> transition parameter.
+    // duration <b>as</b> transition state parameter.
     <a href="automation_registry.md#0x1_automation_registry_update_config_from_buffer">update_config_from_buffer</a>(cycle_info);
     // Calculate automation fee per second for the new epoch only after configuration is updated.
     <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
+    // As we already know the committed gas for the new cycle it is being calculated using updated fee-parameters
+    // and will be used <b>to</b> charge tasks during transition process.
     transition_state.automation_fee_per_sec =
         <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_committed_occupancy">calculate_automation_fee_multiplier_for_committed_occupancy</a>(transition_state.gas_committed_for_new_cycle);
     <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>);
@@ -4746,7 +4688,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
 
 Transition to suspended state is expected to be called
 a) when cycle is active and in progress
-- here we do simply move to suspended state so native layer can start requesting tasks processing
+- here we simply move to suspended state so native layer can start requesting tasks processing
 which will end up in  refunds and cleanup. Note that refund will be done based on total gas-committed
 for the current cycle defined at the begining for the cycle, and using current automation fee parameters
 b) when cycle has just finished and there was another transaction causing feature suspension
@@ -4777,11 +4719,23 @@ In all cases if there are no tasks in registry the state will be updated directl
         <b>return</b>
     };
     <b>if</b> (std::option::is_none(&cycle_info.transition_state)) {
-        <b>assert</b>!(<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt;= cycle_info.start_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+        // Indicates that cycle was in STARTED state when suspention <b>has</b> been identified.
+        // It is safe <b>to</b> <b>assert</b> that cycle_end_time will always be greater than current chain time <b>as</b>
+        // the cycle end is check in the <a href="block.md#0x1_block">block</a> metadata txn execution which proceeds <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> other transaction in the <a href="block.md#0x1_block">block</a>.
+        // Including the transaction which caused transition <b>to</b> suspended state.
+        // So in case <b>if</b> cycle_end_time &lt; current_time then cycle end would have been identified
+        // and we would have enterend <b>else</b> branch instead.
+        // This holds <b>true</b> even <b>if</b> we identified suspention when moving from FINALIZED-&gt;STARTED state.
+        // As in this case we will first transition <b>to</b> the STARTED state and only then <b>to</b> SUSPENDED.
+        // And when transition <b>to</b> STARTED state we <b>update</b> the cycle start-time <b>to</b> be the current-chain-time.
+        <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+        <b>let</b> cycle_end_time = cycle_info.start_time + cycle_info.duration_secs;
+        <b>assert</b>!(current_time &gt;= cycle_info.start_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+        <b>assert</b>!(current_time &lt; cycle_end_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
         <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
         <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
         <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
-            refund_duration: cycle_info.duration_secs + cycle_info.start_time - <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
+            refund_duration: cycle_end_time - current_time,
             new_cycle_duration: cycle_info.duration_secs,
             automation_fee_per_sec: <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_current_cycle_internal">calculate_automation_fee_multiplier_for_current_cycle_internal</a>(active_config, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>),
             gas_committed_for_new_cycle: 0,
@@ -5407,7 +5361,7 @@ would allow the congestion fee to increase in a non-linear fashion.
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_epoch_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_withdraw_task_automation_fee">try_withdraw_task_automation_fee</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">automation_registry::AutomationTaskFeeMeta</a>, current_cycle_end_time: u64, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
 </code></pre>
 
 
@@ -5421,7 +5375,7 @@ would allow the congestion fee to increase in a non-linear fashion.
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
     resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskFeeMeta">AutomationTaskFeeMeta</a>,
-    current_epoch_end_time: u64,
+    current_cycle_end_time: u64,
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>) {
     // Remove the automation task <b>if</b> the epoch fee cap is exceeded
     // It might happen that task <b>has</b> been expired by the time charging is being done.
@@ -5472,7 +5426,7 @@ would allow the congestion fee to increase in a non-linear fashion.
     });
 
     // Calculate gas commitment for the next epoch only for valid active tasks
-    <b>if</b> (task.expiry_time &gt; current_epoch_end_time) {
+    <b>if</b> (task.expiry_time &gt; current_cycle_end_time) {
         intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task.max_gas_amount;
     };
 }
@@ -5592,7 +5546,7 @@ Transfers the specified fee amount from the resource account to the target accou
     <b>let</b> task_duration = expiry_time - registration_time;
     <b>assert</b>!(task_duration &lt;= automation_registry_config.task_duration_cap_in_secs, <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_TIME_UPPER">EEXPIRY_TIME_UPPER</a>);
 
-    // Check that task is valid at least in the next epoch
+    // Check that task is valid at least in the next cycle
     <b>assert</b>!(
         expiry_time &gt; (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
         <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_CYCLE">EEXPIRY_BEFORE_NEXT_CYCLE</a>

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -49,6 +49,8 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `is_transition_finalized`](#0x1_automation_registry_is_transition_finalized)
 -  [Function `is_transition_in_progress`](#0x1_automation_registry_is_transition_in_progress)
 -  [Function `update_processed_tasks`](#0x1_automation_registry_update_processed_tasks)
+-  [Function `append_processed_tasks`](#0x1_automation_registry_append_processed_tasks)
+-  [Function `already_processed`](#0x1_automation_registry_already_processed)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
@@ -69,6 +71,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `get_automation_epoch_info`](#0x1_automation_registry_get_automation_epoch_info)
 -  [Function `estimate_automation_fee`](#0x1_automation_registry_estimate_automation_fee)
 -  [Function `estimate_automation_fee_with_committed_occupancy`](#0x1_automation_registry_estimate_automation_fee_with_committed_occupancy)
+-  [Function `calculate_automation_fee_unit_for_committed_occupancy`](#0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy)
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
 -  [Function `get_cycle_duration`](#0x1_automation_registry_get_cycle_duration)
 -  [Function `get_cycle_info`](#0x1_automation_registry_get_cycle_info)
@@ -453,6 +456,7 @@ Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
 
 ## Struct `AutomationCycleDuration`
 
+Cycle Duration wrapper to store in the config-buffer.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
@@ -2324,6 +2328,55 @@ The length of the transaction hash.
 
 </details>
 
+<a id="0x1_automation_registry_append_processed_tasks"></a>
+
+## Function `append_processed_tasks`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64) {
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> state.actual_processed_tasks, task_index);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_already_processed"></a>
+
+## Function `already_processed`
+
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64): bool {
+    // TODO: maybe <b>use</b> <b>native</b> function <b>if</b> too expensive
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_contains">vector::contains</a>(&state.actual_processed_tasks, &task_index)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_is_initialized"></a>
 
 ## Function `is_initialized`
@@ -2897,6 +2950,42 @@ maximum allowed occupancy for the next epoch.
 
 </details>
 
+<a id="0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy"></a>
+
+## Function `calculate_automation_fee_unit_for_committed_occupancy`
+
+Calculates automation fee per second for the specified task occupancy
+referencing the current automation registry fee parameters, specified total/committed occupancy and current registry
+maximum allowed occupancy.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy">calculate_automation_fee_unit_for_committed_occupancy</a>(total_committed_max_gas: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_unit_for_committed_occupancy">calculate_automation_fee_unit_for_committed_occupancy</a>(
+    total_committed_max_gas: u64
+): u64 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
+    // Compute the automation fee multiplier for epoch
+    <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+    <b>let</b> automation_fee_per_sec = <a href="automation_registry.md#0x1_automation_registry_calculate_automation_fee_multiplier_for_epoch">calculate_automation_fee_multiplier_for_epoch</a>(
+        &active_config.main_config,
+        (total_committed_max_gas <b>as</b> u256),
+        active_config.main_config.registry_max_gas_cap);
+    (automation_fee_per_sec <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_automation_registry_is_registration_enabled"></a>
 
 ## Function `is_registration_enabled`
@@ -3014,7 +3103,7 @@ Withdraw accumulated automation task fees from the resource account - access by 
 Update Automation Registry Config
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+<pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(_supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _task_duration_cap_in_secs: u64, _registry_max_gas_cap: u64, _automation_base_fee_in_quants_per_sec: u64, _flat_registration_fee_in_quants: u64, _congestion_threshold_percentage: u8, _congestion_base_fee_in_quants_per_sec: u64, _congestion_exponent: u8, _task_capacity: u16)
 </code></pre>
 
 
@@ -3024,15 +3113,15 @@ Update Automation Registry Config
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_config">update_config</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
+    _supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _task_duration_cap_in_secs: u64,
+    _registry_max_gas_cap: u64,
+    _automation_base_fee_in_quants_per_sec: u64,
+    _flat_registration_fee_in_quants: u64,
+    _congestion_threshold_percentage: u8,
+    _congestion_base_fee_in_quants_per_sec: u64,
+    _congestion_exponent: u8,
+    _task_capacity: u16,
 ) {
     <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
 }
@@ -3476,7 +3565,7 @@ Initialization of Automation Registry with configuration parameters is expected 
 Deprecated in favor of initialize_v2
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_interval_secs: u64, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(_supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _epoch_interval_secs: u64, _task_duration_cap_in_secs: u64, _registry_max_gas_cap: u64, _automation_base_fee_in_quants_per_sec: u64, _flat_registration_fee_in_quants: u64, _congestion_threshold_percentage: u8, _congestion_base_fee_in_quants_per_sec: u64, _congestion_exponent: u8, _task_capacity: u16)
 </code></pre>
 
 
@@ -3486,16 +3575,16 @@ Deprecated in favor of initialize_v2
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_initialize">initialize</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    epoch_interval_secs: u64,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
+    _supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _epoch_interval_secs: u64,
+    _task_duration_cap_in_secs: u64,
+    _registry_max_gas_cap: u64,
+    _automation_base_fee_in_quants_per_sec: u64,
+    _flat_registration_fee_in_quants: u64,
+    _congestion_threshold_percentage: u8,
+    _congestion_base_fee_in_quants_per_sec: u64,
+    _congestion_exponent: u8,
+    _task_capacity: u16,
 ) {
     <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
 }
@@ -3874,6 +3963,7 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitte
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
 
+    <b>let</b> transaction_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
         <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
@@ -3888,10 +3978,11 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Drop</code> action emitte
                 task.locked_fee_for_next_epoch,
                 task.locked_fee_for_next_epoch);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
+            <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(transaction_state, task_index);
         };
     });
 
-    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info, removed_tasks);
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info);
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
         task_indexes: removed_tasks
     });
@@ -3951,19 +4042,22 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emit
         epoch_locked_fees: <a href="coin.md#0x1_coin_zero">coin::zero</a>()
     };
 
-    <b>let</b> processed_tasks = <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
+    <b>let</b> charge_duration = transition_state.new_cycle_duration;
+
+    <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
         <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>,
         refund_bookkeeping,
+        transition_state,
         &automation_registry_config.main_config,
         (automation_fee_per_sec <b>as</b> u256),
-    transition_state.new_cycle_duration,
+    charge_duration,
     <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>(),
         task_indexes,
         &<b>mut</b> intermedate_result
     );
     <b>let</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a> {
         removed_tasks,
-        gas_committed_for_new_epoch,
+        gas_committed_for_new_epoch: _,
         gas_committed_for_next_epoch,
         epoch_locked_fees
     } = intermedate_result;
@@ -3972,7 +4066,7 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Charge</code> action emit
     transition_state.gas_committed_for_next_cycle = transition_state.gas_committed_for_next_cycle + gas_committed_for_next_epoch;
     <a href="coin.md#0x1_coin_deposit">coin::deposit</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address, epoch_locked_fees);
 
-    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info, processed_tasks);
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info);
 
     <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&removed_tasks)) {
         <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a>{
@@ -4026,6 +4120,7 @@ Action from native layer will be tiggered by move layer when automation registy 
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
     );
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
     <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
         <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
@@ -4057,10 +4152,11 @@ Action from native layer will be tiggered by move layer when automation registy 
                 task.locked_fee_for_next_epoch,
                 task.locked_fee_for_next_epoch);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
+            <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(transition_state, task_index);
         };
     });
 
-    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info, removed_tasks);
+    <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, cycle_info);
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="automation_registry.md#0x1_automation_registry_RemovedTasks">RemovedTasks</a> {
         task_indexes: removed_tasks
     });
@@ -4112,7 +4208,7 @@ In both cases config will be updated. In this case we will make sure to keep the
 through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} -> Ready or Started -> Finished -> {Started, Suspended}
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>, processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -4124,10 +4220,9 @@ through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} ->
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_suspended">update_cycle_transition_state_from_suspended</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>,
-    processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) <b>acquires</b>  <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>  {
+) <b>acquires</b>  <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>  {
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
     <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
-    <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(transition_state, processed_tasks);
 
     <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(transition_state)) {
         <b>return</b>
@@ -4162,7 +4257,7 @@ Expectation will be that native layer catches this double transition and will is
 which will not proceeded farther in any case.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>, processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">automation_registry::AutomationCycleDetails</a>)
 </code></pre>
 
 
@@ -4174,13 +4269,10 @@ which will not proceeded farther in any case.
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_cycle_transition_state_from_finished">update_cycle_transition_state_from_finished</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     cycle_info: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>,
-    processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
 ) {
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
 
     <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
-    // TODO maybe do this via <b>native</b> function <b>where</b> duplicates will be avoided
-    <a href="automation_registry.md#0x1_automation_registry_update_processed_tasks">update_processed_tasks</a>(transition_state, processed_tasks);
     <b>let</b> transition_finalized = <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(transition_state);
 
     <b>if</b> (transition_finalized) {
@@ -5132,7 +5224,7 @@ Processes automation task fees by checking user balances and task's commitment o
 Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_fee_per_sec: u256, cycle_duration: u64, current_time: u64, task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">automation_registry::AutomationRegistryConfig</a>, automation_fee_per_sec: u256, cycle_duration: u64, current_time: u64, task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">automation_registry::IntermediateStateOfEpochChange</a>)
 </code></pre>
 
 
@@ -5144,14 +5236,14 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_try_charge_tasks_automation_fees">try_charge_tasks_automation_fees</a>(
     <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>,
     refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>,
+    transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>,
     arc: &<a href="automation_registry.md#0x1_automation_registry_AutomationRegistryConfig">AutomationRegistryConfig</a>,
     automation_fee_per_sec: u256,
     cycle_duration: u64,
     current_time: u64,
     task_ids: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;,
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
-): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
-    <b>let</b> processed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+) {
 
     <b>let</b> resource_signer = <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(
         &<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.registry_fee_address_signer_cap
@@ -5163,8 +5255,8 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
 
     // Process each active task and calculate fee for the epoch for the tasks
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
-        <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> processed_tasks, task_index);
+        <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(transition_state, task_index) && <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+            <a href="automation_registry.md#0x1_automation_registry_append_processed_tasks">append_processed_tasks</a>(transition_state, task_index);
             <b>let</b> task = {
                 <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
                 <b>let</b> fee= <a href="automation_registry.md#0x1_automation_registry_calculate_task_fee">calculate_task_fee</a>(arc, task_meta, cycle_duration, current_time, automation_fee_per_sec);
@@ -5194,7 +5286,6 @@ Return estimated committed gas for the next epoch, locked automation fee amount 
             );
         };
     });
-    processed_tasks
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/block.md
+++ b/aptos-move/framework/supra-framework/doc/block.md
@@ -510,9 +510,6 @@ Can only be called as part of the Supra governance proposal process established 
     <b>let</b> old_epoch_interval = block_resource.epoch_interval;
     block_resource.epoch_interval = new_epoch_interval;
 
-    // <b>update</b> epoch interval in registry contract
-    <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">automation_registry::update_epoch_interval_in_registry</a>(new_epoch_interval);
-
     <b>if</b> (std::features::module_event_migration_enabled()) {
         <a href="event.md#0x1_event_emit">event::emit</a>(
             <a href="block.md#0x1_block_UpdateEpochInterval">UpdateEpochInterval</a> { old_epoch_interval, new_epoch_interval },
@@ -633,6 +630,8 @@ Return epoch interval in seconds.
     // transition is the last <a href="block.md#0x1_block">block</a> in the previous epoch.
     <a href="stake.md#0x1_stake_update_performance_statistics">stake::update_performance_statistics</a>(proposer_index, failed_proposer_indices);
     <a href="state_storage.md#0x1_state_storage_on_new_block">state_storage::on_new_block</a>(<a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>());
+
+    <a href="automation_registry.md#0x1_automation_registry_monitor_cycle_end">automation_registry::monitor_cycle_end</a>();
 
     block_metadata_ref.epoch_interval
 }

--- a/aptos-move/framework/supra-framework/doc/coin.md
+++ b/aptos-move/framework/supra-framework/doc/coin.md
@@ -1034,16 +1034,6 @@ The value of aggregatable coin used for transaction fees redistribution does not
 
 
 
-<a id="0x1_coin_EAPT_PAIRING_IS_NOT_ENABLED"></a>
-
-SUPRA pairing is not eanbled yet.
-
-
-<pre><code><b>const</b> <a href="coin.md#0x1_coin_EAPT_PAIRING_IS_NOT_ENABLED">EAPT_PAIRING_IS_NOT_ENABLED</a>: u64 = 28;
-</code></pre>
-
-
-
 <a id="0x1_coin_EBURN_REF_NOT_FOUND"></a>
 
 The BurnRef does not exist.
@@ -1254,6 +1244,16 @@ PairedFungibleAssetRefs resource does not exist.
 
 
 
+<a id="0x1_coin_ESUP_PAIRING_IS_NOT_ENABLED"></a>
+
+SUPRA pairing is not eanbled yet.
+
+
+<pre><code><b>const</b> <a href="coin.md#0x1_coin_ESUP_PAIRING_IS_NOT_ENABLED">ESUP_PAIRING_IS_NOT_ENABLED</a>: u64 = 28;
+</code></pre>
+
+
+
 <a id="0x1_coin_ETRANSFER_REF_NOT_FOUND"></a>
 
 The TransferRef does not exist.
@@ -1375,6 +1375,9 @@ Create SUPRA pairing by passing <code>SupraCoin</code>.
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
 ) <b>acquires</b> <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_coin_to_fungible_asset_migration_feature_enabled">features::coin_to_fungible_asset_migration_feature_enabled</a>()) {
+        <b>abort</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="coin.md#0x1_coin_ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED">ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED</a>)
+    };
     <a href="coin.md#0x1_coin_create_and_return_paired_metadata_if_not_exist">create_and_return_paired_metadata_if_not_exist</a>&lt;CoinType&gt;(<b>true</b>);
 }
 </code></pre>
@@ -1413,7 +1416,7 @@ Create SUPRA pairing by passing <code>SupraCoin</code>.
 
 
 
-<pre><code><b>fun</b> <a href="coin.md#0x1_coin_create_and_return_paired_metadata_if_not_exist">create_and_return_paired_metadata_if_not_exist</a>&lt;CoinType&gt;(allow_apt_creation: bool): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;
+<pre><code><b>fun</b> <a href="coin.md#0x1_coin_create_and_return_paired_metadata_if_not_exist">create_and_return_paired_metadata_if_not_exist</a>&lt;CoinType&gt;(allow_sup_creation: bool): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;
 </code></pre>
 
 
@@ -1422,7 +1425,7 @@ Create SUPRA pairing by passing <code>SupraCoin</code>.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="coin.md#0x1_coin_create_and_return_paired_metadata_if_not_exist">create_and_return_paired_metadata_if_not_exist</a>&lt;CoinType&gt;(allow_apt_creation: bool): Object&lt;Metadata&gt; {
+<pre><code>inline <b>fun</b> <a href="coin.md#0x1_coin_create_and_return_paired_metadata_if_not_exist">create_and_return_paired_metadata_if_not_exist</a>&lt;CoinType&gt;(allow_sup_creation: bool): Object&lt;Metadata&gt; {
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_coin_to_fungible_asset_migration_feature_enabled">features::coin_to_fungible_asset_migration_feature_enabled</a>(),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="coin.md#0x1_coin_EMIGRATION_FRAMEWORK_NOT_ENABLED">EMIGRATION_FRAMEWORK_NOT_ENABLED</a>)
@@ -1432,13 +1435,13 @@ Create SUPRA pairing by passing <code>SupraCoin</code>.
     <b>let</b> type = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_of">type_info::type_of</a>&lt;CoinType&gt;();
     <b>if</b> (!<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(&map.coin_to_fungible_asset_map, type)) {
         <b>let</b> is_sup = <a href="coin.md#0x1_coin_is_sup">is_sup</a>&lt;CoinType&gt;();
-        <b>assert</b>!(!is_sup || allow_apt_creation, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="coin.md#0x1_coin_EAPT_PAIRING_IS_NOT_ENABLED">EAPT_PAIRING_IS_NOT_ENABLED</a>));
+        <b>assert</b>!(!is_sup || allow_sup_creation, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="coin.md#0x1_coin_ESUP_PAIRING_IS_NOT_ENABLED">ESUP_PAIRING_IS_NOT_ENABLED</a>));
         <b>let</b> metadata_object_cref =
             <b>if</b> (is_sup) {
-                <a href="object.md#0x1_object_create_sticky_object_at_address">object::create_sticky_object_at_address</a>(@supra_framework, @aptos_fungible_asset)
+                <a href="object.md#0x1_object_create_sticky_object_at_address">object::create_sticky_object_at_address</a>(@supra_framework, @supra_fungible_asset)
             } <b>else</b> {
                 <a href="object.md#0x1_object_create_named_object">object::create_named_object</a>(
-                    &<a href="create_signer.md#0x1_create_signer_create_signer">create_signer::create_signer</a>(@aptos_fungible_asset),
+                    &<a href="create_signer.md#0x1_create_signer_create_signer">create_signer::create_signer</a>(@supra_fungible_asset),
                     *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(&<a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;CoinType&gt;())
                 )
             };
@@ -1558,16 +1561,10 @@ Conversion from coin to fungible asset
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_coin_to_fungible_asset">coin_to_fungible_asset</a>&lt;CoinType&gt;(
     <a href="coin.md#0x1_coin">coin</a>: <a href="coin.md#0x1_coin_Coin">Coin</a>&lt;CoinType&gt;
 ): FungibleAsset <b>acquires</b> <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
-    // TODO: Replace the below <a href="code.md#0x1_code">code</a> <b>with</b> a call <b>to</b> `coin_to_fungible_asset_internal`
-    // once we fully support `FungibleAsset`s. The below guard is used because we need <b>to</b>
-    // preserve the function signature but want <b>to</b> keep the feature flag active <b>to</b> avoid
-    // breaking the tests. The `<b>else</b>` branch will never be taken in the production <a href="code.md#0x1_code">code</a>
-    // <b>as</b> this feature is set by default.
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_coin_to_fungible_asset_migration_feature_enabled">features::coin_to_fungible_asset_migration_feature_enabled</a>()) {
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_coin_to_fungible_asset_migration_feature_enabled">features::coin_to_fungible_asset_migration_feature_enabled</a>()) {
         <b>abort</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="coin.md#0x1_coin_ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED">ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED</a>)
-    } <b>else</b> {
-        <a href="coin.md#0x1_coin_coin_to_fungible_asset_internal">coin_to_fungible_asset_internal</a>(<a href="coin.md#0x1_coin">coin</a>)
-    }
+    };
+    <a href="coin.md#0x1_coin_coin_to_fungible_asset_internal">coin_to_fungible_asset_internal</a>(<a href="coin.md#0x1_coin">coin</a>)
 }
 </code></pre>
 
@@ -2367,16 +2364,10 @@ Voluntarily migrate to fungible store for <code>CoinType</code> if not yet.
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x1_coin_migrate_to_fungible_store">migrate_to_fungible_store</a>&lt;CoinType&gt;(
     <a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
 ) <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
-    // TODO: Replace the below <a href="code.md#0x1_code">code</a> <b>with</b> a call <b>to</b> `migrate_to_fungible_store_internal`
-    // once we fully support `FungibleAsset`s. The below guard is used because we need <b>to</b>
-    // preserve the function signature but want <b>to</b> keep the feature flag active <b>to</b> avoid
-    // breaking the tests. The `<b>else</b>` branch will never be taken in the production <a href="code.md#0x1_code">code</a>
-    // <b>as</b> this feature is set by default.
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_coin_to_fungible_asset_migration_feature_enabled">features::coin_to_fungible_asset_migration_feature_enabled</a>()) {
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_coin_to_fungible_asset_migration_feature_enabled">features::coin_to_fungible_asset_migration_feature_enabled</a>()) {
         <b>abort</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="coin.md#0x1_coin_ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED">ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED</a>)
-    } <b>else</b> {
-        <a href="coin.md#0x1_coin_migrate_to_fungible_store_internal">migrate_to_fungible_store_internal</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>)
-    }
+    };
+    <a href="coin.md#0x1_coin_migrate_to_fungible_store_internal">migrate_to_fungible_store_internal</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/supra-framework/doc/fungible_asset.md
@@ -802,16 +802,6 @@ Cannot destroy non-empty fungible assets.
 
 
 
-<a id="0x1_fungible_asset_EAPT_NOT_DISPATCHABLE"></a>
-
-Cannot register dispatch hook for SUPRA.
-
-
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EAPT_NOT_DISPATCHABLE">EAPT_NOT_DISPATCHABLE</a>: u64 = 31;
-</code></pre>
-
-
-
 <a id="0x1_fungible_asset_EBALANCE_IS_NOT_ZERO"></a>
 
 Cannot destroy fungible stores with a non-zero balance.
@@ -1039,6 +1029,16 @@ The fungible asset's supply will be negative which should be impossible.
 
 
 <pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_ESUPPLY_UNDERFLOW">ESUPPLY_UNDERFLOW</a>: u64 = 20;
+</code></pre>
+
+
+
+<a id="0x1_fungible_asset_ESUP_NOT_DISPATCHABLE"></a>
+
+Cannot register dispatch hook for SUPRA.
+
+
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_ESUP_NOT_DISPATCHABLE">ESUP_NOT_DISPATCHABLE</a>: u64 = 31;
 </code></pre>
 
 
@@ -1406,8 +1406,8 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
 
     // Cannot register hook for SUPRA.
     <b>assert</b>!(
-        <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref) != @aptos_fungible_asset,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_EAPT_NOT_DISPATCHABLE">EAPT_NOT_DISPATCHABLE</a>)
+        <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref) != @supra_fungible_asset,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESUP_NOT_DISPATCHABLE">ESUP_NOT_DISPATCHABLE</a>)
     );
     <b>assert</b>!(
         !<a href="object.md#0x1_object_can_generate_delete_ref">object::can_generate_delete_ref</a>(constructor_ref),
@@ -2143,7 +2143,7 @@ Return whether a fungible asset type is dispatchable.
 <pre><code><b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_has_deposit_dispatch_function">has_deposit_dispatch_function</a>(metadata: Object&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;): bool <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
     <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
     // Short circuit on SUPRA for better perf
-    <b>if</b>(metadata_addr != @aptos_fungible_asset && <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)) {
+    <b>if</b>(metadata_addr != @supra_fungible_asset && <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)) {
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<b>borrow_global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr).deposit_function)
     } <b>else</b> {
         <b>false</b>
@@ -2203,7 +2203,7 @@ Return whether a fungible asset type is dispatchable.
 <pre><code><b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_has_withdraw_dispatch_function">has_withdraw_dispatch_function</a>(metadata: Object&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;): bool <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
     <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
     // Short circuit on SUPRA for better perf
-    <b>if</b> (metadata_addr != @aptos_fungible_asset && <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)) {
+    <b>if</b> (metadata_addr != @supra_fungible_asset && <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)) {
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<b>borrow_global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr).withdraw_function)
     } <b>else</b> {
         <b>false</b>

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -16,6 +16,7 @@
 -  [Function `initialize`](#0x1_genesis_initialize)
 -  [Function `initialize_supra_coin`](#0x1_genesis_initialize_supra_coin)
 -  [Function `initialize_supra_native_automation`](#0x1_genesis_initialize_supra_native_automation)
+-  [Function `initialize_supra_native_automation_v2`](#0x1_genesis_initialize_supra_native_automation_v2)
 -  [Function `initialize_core_resources_and_supra_coin`](#0x1_genesis_initialize_core_resources_and_supra_coin)
 -  [Function `create_accounts`](#0x1_genesis_create_accounts)
 -  [Function `create_account`](#0x1_genesis_create_account)
@@ -682,6 +683,7 @@ Genesis step 2: Initialize Supra coin.
 ## Function `initialize_supra_native_automation`
 
 Genesis step 3: Initialize Supra Native Automation.
+DEPRECATED in favoor of initialize_supra_native_automation_v2. It calls deprectead API.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
@@ -708,6 +710,53 @@ Genesis step 3: Initialize Supra Native Automation.
     <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
         supra_framework,
         epoch_interval_secs,
+        task_duration_cap_in_secs,
+        registry_max_gas_cap,
+        automation_base_fee_in_quants_per_sec,
+        flat_registration_fee_in_quants,
+        congestion_threshold_percentage,
+        congestion_base_fee_in_quants_per_sec,
+        congestion_exponent,
+        task_capacity,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_genesis_initialize_supra_native_automation_v2"></a>
+
+## Function `initialize_supra_native_automation_v2`
+
+Genesis step 3: Initialize Supra Native Automation.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation_v2">initialize_supra_native_automation_v2</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16, cycle_duration: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation_v2">initialize_supra_native_automation_v2</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    task_duration_cap_in_secs: u64,
+    registry_max_gas_cap: u64,
+    automation_base_fee_in_quants_per_sec: u64,
+    flat_registration_fee_in_quants: u64,
+    congestion_threshold_percentage: u8,
+    congestion_base_fee_in_quants_per_sec: u64,
+    congestion_exponent: u8,
+    task_capacity: u16,
+    cycle_duration: u64
+) {
+    <a href="automation_registry.md#0x1_automation_registry_initialize_v2">automation_registry::initialize_v2</a>(
+        supra_framework,
+        cycle_duration,
         task_duration_cap_in_secs,
         registry_max_gas_cap,
         automation_base_fee_in_quants_per_sec,

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -682,11 +682,12 @@ Genesis step 2: Initialize Supra coin.
 
 ## Function `initialize_supra_native_automation`
 
-Genesis step 3: Initialize Supra Native Automation.
-DEPRECATED in favoor of initialize_supra_native_automation_v2. It calls deprectead API.
+DEPRECATED
+
+Deprecated in favoor of initialize_supra_native_automation_v2.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_duration_cap_in_secs: u64, registry_max_gas_cap: u64, automation_base_fee_in_quants_per_sec: u64, flat_registration_fee_in_quants: u64, congestion_threshold_percentage: u8, congestion_base_fee_in_quants_per_sec: u64, congestion_exponent: u8, task_capacity: u16)
+<pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(_supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _task_duration_cap_in_secs: u64, _registry_max_gas_cap: u64, _automation_base_fee_in_quants_per_sec: u64, _flat_registration_fee_in_quants: u64, _congestion_threshold_percentage: u8, _congestion_base_fee_in_quants_per_sec: u64, _congestion_exponent: u8, _task_capacity: u16)
 </code></pre>
 
 
@@ -696,29 +697,16 @@ DEPRECATED in favoor of initialize_supra_native_automation_v2. It calls deprecte
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="genesis.md#0x1_genesis_initialize_supra_native_automation">initialize_supra_native_automation</a>(
-    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    task_duration_cap_in_secs: u64,
-    registry_max_gas_cap: u64,
-    automation_base_fee_in_quants_per_sec: u64,
-    flat_registration_fee_in_quants: u64,
-    congestion_threshold_percentage: u8,
-    congestion_base_fee_in_quants_per_sec: u64,
-    congestion_exponent: u8,
-    task_capacity: u16,
+    _supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _task_duration_cap_in_secs: u64,
+    _registry_max_gas_cap: u64,
+    _automation_base_fee_in_quants_per_sec: u64,
+    _flat_registration_fee_in_quants: u64,
+    _congestion_threshold_percentage: u8,
+    _congestion_base_fee_in_quants_per_sec: u64,
+    _congestion_exponent: u8,
+    _task_capacity: u16,
 ) {
-    <b>let</b> epoch_interval_secs = <a href="block.md#0x1_block_get_epoch_interval_secs">block::get_epoch_interval_secs</a>();
-    <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
-        supra_framework,
-        epoch_interval_secs,
-        task_duration_cap_in_secs,
-        registry_max_gas_cap,
-        automation_base_fee_in_quants_per_sec,
-        flat_registration_fee_in_quants,
-        congestion_threshold_percentage,
-        congestion_base_fee_in_quants_per_sec,
-        congestion_exponent,
-        task_capacity,
-    )
 }
 </code></pre>
 
@@ -754,7 +742,7 @@ Genesis step 3: Initialize Supra Native Automation.
     task_capacity: u16,
     cycle_duration: u64
 ) {
-    <a href="automation_registry.md#0x1_automation_registry_initialize_v2">automation_registry::initialize_v2</a>(
+    <a href="automation_registry.md#0x1_automation_registry_initialize">automation_registry::initialize</a>(
         supra_framework,
         cycle_duration,
         task_duration_cap_in_secs,

--- a/aptos-move/framework/supra-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/supra-framework/doc/reconfiguration.md
@@ -34,7 +34,6 @@ to synchronize configuration changes for the validators.
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
-<b>use</b> <a href="automation_registry.md#0x1_automation_registry">0x1::automation_registry</a>;
 <b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
@@ -423,7 +422,6 @@ Signal validators to start using new configuration. Must be called from friend c
     <b>spec</b> {
         <b>assume</b> config_ref.epoch + 1 &lt;= MAX_U64;
     };
-    <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>();
     config_ref.epoch = config_ref.epoch + 1;
 
     <b>if</b> (std::features::module_event_migration_enabled()) {

--- a/aptos-move/framework/supra-framework/doc/reconfiguration_with_dkg.md
+++ b/aptos-move/framework/supra-framework/doc/reconfiguration_with_dkg.md
@@ -18,6 +18,7 @@ Reconfiguration with DKG helper functions.
 <pre><code><b>use</b> <a href="automation_registry.md#0x1_automation_registry">0x1::automation_registry</a>;
 <b>use</b> <a href="consensus_config.md#0x1_consensus_config">0x1::consensus_config</a>;
 <b>use</b> <a href="dkg.md#0x1_dkg">0x1::dkg</a>;
+<b>use</b> <a href="evm_config.md#0x1_evm_config">0x1::evm_config</a>;
 <b>use</b> <a href="execution_config.md#0x1_execution_config">0x1::execution_config</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="gas_schedule.md#0x1_gas_schedule">0x1::gas_schedule</a>;
@@ -114,6 +115,7 @@ Run the default reconfiguration to enter the new epoch.
     <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_on_new_epoch">randomness_config_seqnum::on_new_epoch</a>(framework);
     <a href="randomness_config.md#0x1_randomness_config_on_new_epoch">randomness_config::on_new_epoch</a>(framework);
     <a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_on_new_epoch">randomness_api_v0_config::on_new_epoch</a>(framework);
+    <a href="evm_config.md#0x1_evm_config_on_new_epoch">evm_config::on_new_epoch</a>(framework);
     <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/doc/reconfiguration_with_dkg.md
+++ b/aptos-move/framework/supra-framework/doc/reconfiguration_with_dkg.md
@@ -15,7 +15,8 @@ Reconfiguration with DKG helper functions.
     -  [Function `finish_with_dkg_result`](#@Specification_0_finish_with_dkg_result)
 
 
-<pre><code><b>use</b> <a href="consensus_config.md#0x1_consensus_config">0x1::consensus_config</a>;
+<pre><code><b>use</b> <a href="automation_registry.md#0x1_automation_registry">0x1::automation_registry</a>;
+<b>use</b> <a href="consensus_config.md#0x1_consensus_config">0x1::consensus_config</a>;
 <b>use</b> <a href="dkg.md#0x1_dkg">0x1::dkg</a>;
 <b>use</b> <a href="execution_config.md#0x1_execution_config">0x1::execution_config</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
@@ -106,6 +107,7 @@ Run the default reconfiguration to enter the new epoch.
     <a href="gas_schedule.md#0x1_gas_schedule_on_new_epoch">gas_schedule::on_new_epoch</a>(framework);
     std::version::on_new_epoch(framework);
     <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_on_new_epoch">features::on_new_epoch</a>(framework);
+    <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">automation_registry::on_new_epoch</a>();
     <a href="jwk_consensus_config.md#0x1_jwk_consensus_config_on_new_epoch">jwk_consensus_config::on_new_epoch</a>(framework);
     <a href="jwks.md#0x1_jwks_on_new_epoch">jwks::on_new_epoch</a>(framework);
     <a href="keyless_account.md#0x1_keyless_account_on_new_epoch">keyless_account::on_new_epoch</a>(framework);

--- a/aptos-move/framework/supra-framework/doc/supra_account.md
+++ b/aptos-move/framework/supra-framework/doc/supra_account.md
@@ -718,7 +718,7 @@ Ensure that SUPRA Primary FungibleStore exists (and create if it doesn't)
     <b>if</b> (<a href="fungible_asset.md#0x1_fungible_asset_store_exists">fungible_asset::store_exists</a>(store_addr)) {
         store_addr
     } <b>else</b> {
-        <a href="object.md#0x1_object_object_address">object::object_address</a>(&<a href="primary_fungible_store.md#0x1_primary_fungible_store_create_primary_store">primary_fungible_store::create_primary_store</a>(owner, <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(@aptos_fungible_asset)))
+        <a href="object.md#0x1_object_object_address">object::object_address</a>(&<a href="primary_fungible_store.md#0x1_primary_fungible_store_create_primary_store">primary_fungible_store::create_primary_store</a>(owner, <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Metadata&gt;(@supra_fungible_asset)))
     }
 }
 </code></pre>
@@ -744,7 +744,7 @@ Address of SUPRA Primary Fungible Store
 
 
 <pre><code>inline <b>fun</b> <a href="supra_account.md#0x1_supra_account_primary_fungible_store_address">primary_fungible_store_address</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>): <b>address</b> {
-    <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(<a href="account.md#0x1_account">account</a>, @aptos_fungible_asset)
+    <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(<a href="account.md#0x1_account">account</a>, @supra_fungible_asset)
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -90,6 +90,12 @@ module supra_framework::automation_registry {
     const ECYCLE_DURATION_NON_ZERO: u64 = 30;
     /// Attempt to do migration to cycle based automation which is already enabled.
     const EINVALID_MIGRATION_ACTION: u64 = 31;
+    /// Attempt to register an automation task while cycle transition is in progress.
+    const ECYCLE_TRANSITION_IN_PROGRESS: u64 = 32;
+    /// Attempt to run operation in invalid registry state.
+    const EINVALID_REGISTRY_STATE: u64 = 33;
+    /// Attempt to run charge action with inconsistent input values compared to internal state.
+    const EINVALID_CHARGE_ACTION: u64 = 34;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -112,10 +118,19 @@ module supra_framework::automation_registry {
     const CANCELLED: u8 = 2;
 
     /// Constants describing CYCLE state.
-    const CYCLE_FINISHED: u8 = 0;
+    /// State transition flaw is:
+    /// READY_TO_START -> CYCLE_STARTED
+    /// CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
+    /// CYCLE_FINISHED ->  { CYCLE_STARTED}
+    /// CYCLE_SUSPENDED ->  {READY_TO_START, STARTED}
+    const READY_TO_START_NEW_CYCLE: u8 = 0;
+    /// Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by autoamtion cycle manager in native layer.
     const CYCLE_STARTED: u8 = 1;
-    // State describing the entire lifecycle of automation being suspended due to feature being disabled at all.
-    const LIFECYCLE_SUSPENDED: u8 = 2;
+    /// Triggered when cycle end is identified.
+    const CYCLE_FINISHED: u8 = 2;
+    /// State describing the entire lifecycle of automation being suspended.
+    /// Triggered when SUPRA_NATIVE_AUTOMATION feature is disabled.
+    const CYCLE_SUSPENDED: u8 = 3;
 
     /// Constants describing REFUND TYPE
     const DEPOSIT_EPOCH_FEE: u8 = 0;
@@ -182,6 +197,37 @@ module supra_framework::automation_registry {
         epoch_active_task_ids: vector<u64>
     }
 
+    /// It tracks entries both pending and completed, organized by unique indices.
+    struct TransitionState has key, copy, drop, store {
+        /// Duration of the new cycle.
+        new_cycle_duration: u64,
+        /// Calculated automation fee per second for the new cycle.
+        automation_fee_per_sec: u64,
+        /// Gas committed for the new cycle being transitioned.
+        gas_committed_for_this_cycle: u64,
+        /// Gas committed for next cycle
+        gas_committed_for_next_cycle: u64,
+        /// Total fee charged to users during the cycle, which is not withdrawable
+        locked_fees: u64,
+        /// Number of the tasks to be processed during transition.
+        expected_tasks_to_be_processed: vector<u64>,
+        /// So far processed tasks during transition
+        /// In case if transition spans between multiple blocks then
+        /// upon recovery execution component will know the breaking point and can recover from it.
+        actual_processed_tasks: vector<u64>
+    }
+
+    fun is_transition_finalized(state: &TransitionState): bool {
+        vector::length(&state.expected_tasks_to_be_processed) == vector::length(&state.actual_processed_tasks)
+    }
+    fun is_transition_in_progress(state: &TransitionState): bool {
+        vector::length(&state.actual_processed_tasks) != 0
+    }
+
+    fun update_processed_tasks(state: &mut TransitionState, task_indexes: vector<u64>) {
+        vector::append(&mut state.actual_processed_tasks, task_indexes);
+    }
+
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Epoch state. Deprecated since SUPRA_CYCLE_BASED_AUTOMATION version.
     struct AutomationEpochInfo has key, copy {
@@ -204,18 +250,42 @@ module supra_framework::automation_registry {
         duration_secs: u64,
     }
 
-    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Cycle state.
-    struct AutomationCycleInfo has key, copy {
+    struct AutomationCycleInfo has key, copy, drop, store {
         /// Current cycle id. Incremented when a start of the new cycle is processed.
         index: u64,
-        /// State of the current cycle, CYCLE_FINISHED, CYCLE_STARTED. If state is FINISHED, means transition to the next cycle
-        /// is in progress.
+        /// State of the current cycle.
         state: u8,
         /// Current cycle start time which is updated with the current chain time when a cycle is increamented.
         start_time: u64,
         /// Automation cycle duration in seconds.
         duration_secs: u64,
+    }
+
+    #[event]
+    /// Event emitted in the cycle-state.
+    struct AutomationCycleEvent has key, copy, drop, store {
+        /// Updated cycle state information.
+        cycle_state_info: AutomationCycleInfo,
+        /// The state transitioned from
+        old_state: u8,
+        /// Timestamp of the state transition event registration
+        event_time: u64,
+    }
+
+    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
+    /// Cycle state.
+    struct AutomationCycleDetails has key, copy, drop, store {
+        /// Cycle index corresponding to the current state. Incremented when a transition to the new cycle is finalized.
+        index: u64,
+        /// State of the current cycle.
+        state: u8,
+        /// Current cycle start time which is updated with the current chain time when a cycle is increamented.
+        start_time: u64,
+        /// Automation cycle duration in seconds.
+        duration_secs: u64,
+        /// Intermediate state of cycle transition to next one or suspended state.
+        transition_state: std::option::Option<TransitionState>,
     }
 
 
@@ -260,22 +330,6 @@ module supra_framework::automation_registry {
         /// and partially if a pending task is cancelled by user or an active task is cancelled by the system due to
         /// insufficient balance to  pay the automation fee for the epoch
         locked_fee_for_next_epoch: u64,
-    }
-
-    #[event]
-    /// Event emitted at automation cycle end.
-    struct AutomationCycleFinished has drop, store {
-        /// Finished Cycle id.
-        cycle_id: u64,
-    }
-
-    #[event]
-    /// Event emitted at automation cycle end.
-    struct AutomationCycleStarted has drop, store {
-        /// Started Cycle id.
-        cycle_id: u64,
-        /// Cycle start timestamp.
-        timestamp: u64,
     }
 
     #[event]
@@ -418,6 +472,10 @@ module supra_framework::automation_registry {
         owner: address,
         amount: u64,
     }
+    #[event]
+    /// Event emitted when on new epoch inconsistent state of the registry has been identified.
+    /// When automation is in suspended state, there are no tasks expected.
+    struct ErrorInconsistentSuspendedState has drop, store {}
 
     #[event]
     /// Emitted when the registration in the automation registry is enabled.
@@ -461,7 +519,7 @@ module supra_framework::automation_registry {
         exists<AutomationRegistry>(@supra_framework)
             && exists<AutomationRefundBookkeeping>(@supra_framework)
             && exists<ActiveAutomationRegistryConfig>(@supra_framework)
-            && exists<AutomationCycleInfo>(@supra_framework)
+            && exists<AutomationCycleDetails>(@supra_framework)
     }
 
     #[view]
@@ -605,7 +663,7 @@ module supra_framework::automation_registry {
     /// occupancy for the next epoch.
     public fun estimate_automation_fee(
         task_occupancy: u64
-    ): u64 acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig {
+    ): u64 acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig {
         let registry = borrow_global<AutomationRegistry>(@supra_framework);
         estimate_automation_fee_with_committed_occupancy(task_occupancy, registry.gas_committed_for_next_epoch)
     }
@@ -617,8 +675,8 @@ module supra_framework::automation_registry {
     public fun estimate_automation_fee_with_committed_occupancy(
         task_occupancy: u64,
         committed_occupancy: u64
-    ): u64 acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
-        let cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
+    ): u64 acquires AutomationCycleDetails, ActiveAutomationRegistryConfig {
+        let cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
         let config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         estimate_automation_fee_with_committed_occupancy_internal(
             task_occupancy,
@@ -636,67 +694,338 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Returns the current duration of the automation cycle.
-    public fun get_cycle_duration(): u64 acquires AutomationCycleInfo {
-        borrow_global<AutomationCycleInfo>(@supra_framework).duration_secs
+    public fun get_cycle_duration(): u64 acquires AutomationCycleDetails {
+        borrow_global<AutomationCycleDetails>(@supra_framework).duration_secs
     }
 
     #[view]
     /// Returns the current status of the registration in the automation registry.
-    public fun get_cycle_info(): AutomationCycleInfo acquires AutomationCycleInfo {
-        *borrow_global<AutomationCycleInfo>(@supra_framework)
+    public fun get_cycle_info(): AutomationCycleInfo acquires AutomationCycleDetails {
+        let details = borrow_global<AutomationCycleDetails>(@supra_framework);
+        into_automation_cycle_info(details)
     }
 
-    /// Estimates automation fee the next epoch for specified task occupancy for the configured epoch-interval
-    /// referencing the current automation registry fee parameters, specified total/committed occupancy and registry
-    /// maximum allowed occupancy for the next epoch.
-    /// Note it is expected that committed_occupancy does not include currnet task's occupancy.
-    fun estimate_automation_fee_with_committed_occupancy_internal(
-        task_occupancy: u64,
-        committed_occupancy: u64,
-        duration: u64,
-        active_config: &ActiveAutomationRegistryConfig
-    ): u64 {
-        let total_committed_max_gas = committed_occupancy + task_occupancy;
+    // Public entry functions
 
-        // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
-            &active_config.main_config,
-            (total_committed_max_gas as u256),
-            active_config.next_epoch_registry_max_gas_cap);
-
-        if (automation_fee_per_sec == 0) {
-            return 0
-        };
-
-        calculate_automation_fee_for_interval(
-            duration,
-            task_occupancy,
-            automation_fee_per_sec,
-            active_config.next_epoch_registry_max_gas_cap)
+    /// Withdraw accumulated automation task fees from the resource account - access by admin
+    public fun withdraw_automation_task_fees(
+        supra_framework: &signer,
+        to: address,
+        amount: u64
+    ) acquires AutomationRegistry , AutomationRefundBookkeeping {
+        system_addresses::assert_supra_framework(supra_framework);
+        transfer_fee_to_account_internal(to, amount);
+        event::emit(RegistryFeeWithdraw { to, amount });
     }
 
-    fun validate_configuration_parameters_common(
-        cycle_duration_secs: u64,
+    /// Update Automation Registry Config
+    public fun update_config(
+        supra_framework: &signer,
         task_duration_cap_in_secs: u64,
         registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
         congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
+        task_capacity: u16,
     ) {
-        assert!(congestion_threshold_percentage <= MAX_PERCENTAGE, EMAX_CONGESTION_THRESHOLD);
-        assert!(congestion_exponent > 0, ECONGESTION_EXP_NON_ZERO);
-        assert!(task_duration_cap_in_secs > cycle_duration_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
-        assert!(registry_max_gas_cap > 0, EREGISTRY_MAX_GAS_CAP_NON_ZERO);
+        assert!(false, EDEPRECATED_SINCE_V2);
     }
 
-    fun create_registry_resource_account(supra_framework: &signer): (signer, SignerCapability) {
-        let (registry_fee_resource_signer, registry_fee_address_signer_cap) = account::create_resource_account(
+    /// Update Automation Registry Config along with cycle duration.
+    public fun update_config_v2(
+        supra_framework: &signer,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+        cycle_duration_secs: u64,
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
+        system_addresses::assert_supra_framework(supra_framework);
+
+
+        update_registration_config_internal(
             supra_framework,
-            REGISTRY_RESOURCE_SEED
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+            cycle_duration_secs,
         );
-        coin::register<SupraCoin>(&registry_fee_resource_signer);
-        (registry_fee_resource_signer, registry_fee_address_signer_cap)
+
+        // Update cycle duration in buffer
+        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
+        let new_cycle_duration = AutomationCycleDuration {
+            duration_secs: cycle_duration_secs
+        };
+        config_buffer::upsert(copy new_cycle_duration);
+        event::emit(new_cycle_duration);
     }
 
+    /// Enables the registration process in the automation registry.
+    public fun enable_registration(supra_framework: &signer) acquires ActiveAutomationRegistryConfig {
+        system_addresses::assert_supra_framework(supra_framework);
+        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
+        automation_registry_config.registration_enabled = true;
+        event::emit(EnabledRegistrationEvent {});
+    }
+
+    /// Disables the registration process in the automation registry.
+    public fun disable_registration(supra_framework: &signer) acquires ActiveAutomationRegistryConfig {
+        system_addresses::assert_supra_framework(supra_framework);
+        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
+        automation_registry_config.registration_enabled = false;
+        event::emit(DisabledRegistrationEvent {});
+    }
+
+    /// Cancel Automation task with specified task_index.
+    /// Only existing task, which is PENDING or ACTIVE, can be cancelled and only by task owner.
+    /// If the task is
+    ///   - active, its state is updated to be CANCELLED.
+    ///   - pending, it is removed form the list.
+    ///   - cancelled, an error is reported
+    /// Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
+    public entry fun cancel_task(
+        owner_signer: &signer,
+        task_index: u64
+    ) acquires AutomationRegistry, AutomationCycleDetails, AutomationRefundBookkeeping{
+        assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
+        let cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
+        assert!(cycle_info.state == CYCLE_STARTED, ECYCLE_TRANSITION_IN_PROGRESS);
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_registry.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
+
+        let automation_task_metadata = enumerable_map::get_value(&mut automation_registry.tasks, task_index);
+        let owner = signer::address_of(owner_signer);
+        assert!(automation_task_metadata.owner == owner, EUNAUTHORIZED_TASK_OWNER);
+        assert!(automation_task_metadata.state != CANCELLED, EALREADY_CANCELLED);
+        if (automation_task_metadata.state == PENDING) {
+            let resource_signer = account::create_signer_with_capability(
+                &automation_registry.registry_fee_address_signer_cap
+            );
+            // When Pending tasks are cancelled, refund of the deposit fee is done with penalty
+            let result = safe_deposit_refund(
+                refund_bookkeeping,
+                &resource_signer,
+                automation_registry.registry_fee_address,
+                automation_task_metadata.task_index,
+                owner,
+                automation_task_metadata.locked_fee_for_next_epoch / REFUND_FACTOR,
+                automation_task_metadata.locked_fee_for_next_epoch);
+            assert!(result, EDEPOSIT_REFUND);
+            enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+        } else { // it is safe not to check the state as above, the cancelled tasks are already rejected.
+            // Active tasks will be refunded the deposited amount fully at the end of the epoch
+            let automation_task_metadata_mut = enumerable_map::get_value_mut(
+                &mut automation_registry.tasks,
+                task_index
+            );
+            automation_task_metadata_mut.state = CANCELLED;
+        };
+
+        // This check means the task was expected to be executed in the next cycle, but it has been cancelled.
+        // We need to remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
+        if (automation_task_metadata.expiry_time > (cycle_info.start_time + cycle_info.duration_secs)) {
+            assert!(
+                automation_registry.gas_committed_for_next_epoch >= automation_task_metadata.max_gas_amount,
+                EGAS_COMMITTEED_VALUE_UNDERFLOW
+            );
+            // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
+            automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
+        };
+
+        event::emit(TaskCancelled { task_index: automation_task_metadata.task_index, owner });
+    }
+
+    /// Immediately stops automation tasks for the specified `task_indexes`.
+    /// Only tasks that exist and are owned by the sender can be stopped.
+    /// If any of the specified tasks are not owned by the sender, the transaction will abort.
+    /// When a task is stopped, the committed gas for the next epoch is reduced
+    /// by the max gas amount of the stopped task. Half of the remaining task fee is refunded.
+    public entry fun stop_tasks(
+        owner_signer: &signer,
+        task_indexes: vector<u64>
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationCycleDetails, AutomationRefundBookkeeping {
+        assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
+        let cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
+        assert!(cycle_info.state == CYCLE_STARTED, ECYCLE_TRANSITION_IN_PROGRESS);
+        // Ensure that task indexes are provided
+        assert!(!vector::is_empty(&task_indexes), EEMPTY_TASK_INDEXES);
+
+        let owner = signer::address_of(owner_signer);
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let arc = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).main_config;
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+
+        let tcmg = automation_registry.gas_committed_for_this_epoch;
+
+        // Compute the automation fee multiplier for epoch
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(&arc, tcmg, arc.registry_max_gas_cap);
+
+        let stopped_task_details = vector[];
+        let total_refund_fee = 0;
+        let epoch_locked_fees = automation_registry.epoch_locked_fees;
+
+        // Calculate refundable fee for this remaining time task in current epoch
+        let current_time = timestamp::now_seconds();
+        let cycle_end_time = cycle_info.duration_secs + cycle_info.start_time;
+        let residual_interval = if (cycle_end_time <= current_time) {
+            0
+        } else {
+            cycle_end_time - current_time
+        };
+
+        // Loop through each task index to validate and stop the task
+        vector::for_each(task_indexes, |task_index| {
+            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                // Remove task from registry
+                let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+
+                // Ensure only the task owner can stop it
+                assert!(task.owner == owner, EUNAUTHORIZED_TASK_OWNER);
+
+                vector::remove_value(&mut automation_registry.epoch_active_task_ids, &task_index);
+
+                // This check means the task was expected to be executed in the next epoch, but it has been stopped.
+                // We need to remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
+                // Also it checks that task should not be cancelled.
+                if (task.state != CANCELLED && task.expiry_time > cycle_end_time) {
+                    // Prevent underflow in gas committed
+                    assert!(
+                        automation_registry.gas_committed_for_next_epoch >= task.max_gas_amount,
+                        EGAS_COMMITTEED_VALUE_UNDERFLOW
+                    );
+
+                    // Reduce committed gas by the stopped task's max gas
+                    automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - task.max_gas_amount;
+                };
+
+                let (epoch_fee_refund, deposit_refund) = if (task.state != PENDING) {
+                    let task_fee = calculate_task_fee(
+                        &arc,
+                        &task,
+                        residual_interval,
+                        current_time,
+                        automation_fee_per_sec
+                    );
+                    // Refund full deposit and the half of the remaining run-time fee when task is active or cancelled stage
+                    (task_fee / REFUND_FRACTION, task.locked_fee_for_next_epoch)
+                } else {
+                    (0, (task.locked_fee_for_next_epoch / REFUND_FRACTION))
+                };
+                let result = safe_unlock_locked_deposit(
+                    refund_bookkeeping,
+                    task.locked_fee_for_next_epoch,
+                    task.task_index);
+                assert!(result, EDEPOSIT_REFUND);
+                let (result, remaining_epoch_locked_fees) = safe_unlock_locked_epoch_fee(
+                    epoch_locked_fees,
+                    epoch_fee_refund,
+                    task.task_index);
+                assert!(result, EEPOCH_FEE_REFUND);
+                epoch_locked_fees = remaining_epoch_locked_fees;
+
+                total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
+
+                vector::push_back(
+                    &mut stopped_task_details,
+                    TaskStopped { task_index, deposit_refund, epoch_fee_refund }
+                );
+            }
+        });
+
+        // Refund and emit event if any tasks were stopped
+        if (!vector::is_empty(&stopped_task_details)) {
+            let resource_signer = account::create_signer_with_capability(
+                &automation_registry.registry_fee_address_signer_cap
+            );
+
+            let resource_account_balance = coin::balance<SupraCoin>(automation_registry.registry_fee_address);
+            assert!(resource_account_balance >= total_refund_fee, EINSUFFICIENT_BALANCE_FOR_REFUND);
+            coin::transfer<SupraCoin>(&resource_signer, owner, total_refund_fee);
+
+            // Emit task stopped event
+            event::emit(TasksStopped {
+                tasks: stopped_task_details,
+                owner
+            });
+        };
+    }
+
+    // Public transition functions from version to version
+
+    /// Public entry function to initialize bookeeping resource when feature enabling automation deposit fee charges is released.
+    public fun initialize_refund_bookkeeping_resource(supra_framework: &signer) {
+        system_addresses::assert_supra_framework(supra_framework);
+        move_to(supra_framework, AutomationRefundBookkeeping {
+            total_deposited_automation_fee: 0
+        });
+    }
+
+    /// API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
+    /// detached from epoch-change.
+    /// IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
+    /// end-up in inconsistent state.
+    ///
+    /// monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
+    /// thus not causing any inconcistensy in the chain
+    public fun migrate_v2(supra_framework: &signer, cycle_duration_secs: u64
+    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleDetails {
+        assert_supra_framework(supra_framework);
+        assert!(!features::supra_cycle_based_automation_enabled(), EINVALID_MIGRATION_ACTION);
+
+        // Prepare the state for migration
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
+
+        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(
+            @supra_framework
+        ).main_config;
+
+        let current_time = timestamp::now_seconds();
+        // Refund the epoch fees as epoch will be cut short and on_new_epoch will be dummy due to migration,
+        // so this is the only place to do the refunds
+        update_state_for_migration(
+            automation_registry,
+            &automation_registry_config,
+            automation_epoch_info,
+            current_time
+        );
+
+        // Start migration by enabling feature, initializing the cycle releated resouces
+        features::change_feature_flags_for_next_epoch(
+            supra_framework,
+            vector[features::get_supra_cycle_based_automation_feature()],
+            vector[]);
+        let id = 0;
+        move_to(supra_framework, AutomationCycleDetails {
+            start_time: current_time,
+            index: id,
+            duration_secs: cycle_duration_secs,
+            state: READY_TO_START_NEW_CYCLE,
+            transition_state: std::option::none()
+        });
+        // Remain in READY_TO_START statey if feature is not enabled or registry is not fully initialized
+        if (!is_feature_enabled_and_initialized()) {
+            return
+        };
+        // Emit cycle end which will lead the native layer to start preparation to the new cycle.
+        assert_cycle_based_automation_registry_management_support();
+        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        on_cycle_end_internal(cycle_info)
+    }
+
+    // Public friend api
 
     /// Initialization of Automation Registry with configuration parameters is expected metrics.
     /// Deprecated in favor of initialize_v2
@@ -713,13 +1042,6 @@ module supra_framework::automation_registry {
         task_capacity: u16,
     ) {
         assert!(false, EDEPRECATED_SINCE_V2);
-    }
-
-    public fun initialize_refund_bookkeeping_resource(supra_framework: &signer) {
-        system_addresses::assert_supra_framework(supra_framework);
-        move_to(supra_framework, AutomationRefundBookkeeping {
-            total_deposited_automation_fee: 0
-        });
     }
 
     /// Initialization of Automation Registry with configuration parameters for SUPRA_CYCLE_BASED_AUTOMATION version.
@@ -777,61 +1099,37 @@ module supra_framework::automation_registry {
             registration_enabled: true,
         });
 
-        move_to(supra_framework, AutomationCycleInfo {
-            start_time: 0,
-            index: 0,
+        let (cycle_state, cycle_id) = if (features::supra_cycle_based_automation_enabled()) {
+            (CYCLE_STARTED, 1)
+        } else {
+            (READY_TO_START_NEW_CYCLE, 0)
+        };
+
+        move_to(supra_framework, AutomationCycleDetails {
+            start_time: timestamp::now_seconds(),
+            index: cycle_id,
             duration_secs: cycle_duration_secs,
-            state: CYCLE_STARTED
+            state: cycle_state,
+            transition_state: std::option::none<TransitionState>(),
         });
 
-        initialize_refund_bookkeeping_resource(supra_framework)
+        initialize_refund_bookkeeping_resource(supra_framework);
+
     }
 
-    /// API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
-    /// detached from epoch-change.
-    /// IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
-    /// end-up in inconsistent state.
-    ///
-    /// TODO: Think of having native fucntion as means to identify that binary is not updated and lets have it called from
-    /// monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
-    /// thus not causing any inconcistensy in the chain
-    public fun migrate_v2(supra_framework: &signer, cycle_duration_secs: u64
-        ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleInfo {
-        assert_supra_framework(supra_framework);
-        assert!(!features::supra_cycle_based_automation_enabled(), EINVALID_MIGRATION_ACTION);
-
-        // Prepare the state for migration
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
-
-        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(
-            @supra_framework
-        ).main_config;
-
-        let current_time = timestamp::now_seconds();
-        // Refund the epoch fees as epoch will be cut short and on_new_epoch will be dummy due to migration,
-        // so this is the only place to do the refunds
-        update_state_for_migration(
-            automation_registry,
-            &automation_registry_config,
-            automation_epoch_info,
-            current_time
-        );
-
-        // Start migration by enabling feature, initializing the cycle releated resouces
-        features::change_feature_flags_for_next_epoch(
-            supra_framework,
-            vector[features::get_supra_cycle_based_automation_feature()],
-            vector[]);
-        let id = 0;
-        move_to(supra_framework, AutomationCycleInfo {
-            start_time: current_time,
-            index: id,
-            duration_secs: cycle_duration_secs,
-            state: CYCLE_FINISHED
-        });
-        // Emit cycle end which will lead the native layer to start preparation to the new cycle.
-        on_cycle_end_internal();
+    /// Checks the cycle end and emit an event on it.
+    /// Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
+    public(friend) fun monitor_cycle_end() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
+        if (!is_feature_enabled_and_initialized()) {
+            return
+        };
+        assert_cycle_based_automation_registry_management_support();
+        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        if (cycle_info.state != CYCLE_STARTED
+            || cycle_info.start_time + cycle_info.duration_secs < timestamp::now_seconds()) {
+            return
+        };
+        on_cycle_end_internal(cycle_info)
     }
 
     /// On new epoch caused by reconfiguration this function will be triggered and update the automation registry state.
@@ -843,55 +1141,523 @@ module supra_framework::automation_registry {
     ///
     /// If native automation feature is enabled and automation lifecycle has been in suspended state,
     /// then lifecycle is restarted.
-    public(friend) fun on_new_epoch() acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
+    public(friend) fun on_new_epoch() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
         if (!is_initialized()) {
             return
         };
-        let cycle_info = borrow_global_mut<AutomationCycleInfo>(@supra_framework);
+        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        let registry_data = borrow_global<AutomationRegistry>(@supra_framework);
         if (features::supra_native_automation_enabled()) {
             // If the lifecycle has been suspended and we are recovering from it, then we update config from buffer and
-            // then start a new cycle directly
-            // TODO: check automation registry to be in empty state, otherwise emit an error event and remain in suspended state.
-            if (cycle_info.state == LIFECYCLE_SUSPENDED) {
+            // then start a new cycle directly.
+            // Unless we are in READY_TO_START state feature flag being enabled will not have any effect.
+            // All the other states mean that we are in the middle of previous transition, which should end
+            // before reenabling the feature.
+            if (cycle_info.state == READY_TO_START_NEW_CYCLE) {
+                if (enumerable_map::length(&registry_data.tasks) != 0) {
+                    event::emit(ErrorInconsistentSuspendedState {});
+                    return
+                };
+                update_config_from_buffer(cycle_info);
                 move_to_started_state(cycle_info);
-                update_config_from_buffer();
             };
             return
         };
         // We do not update config here, as due to feature being disabled, cycle ends early so it is expected
         // that native layer will detect this state and generate refund transactions for a cycle that has been kept short.
         // So the confing should remain intact.
-        move_to_suspended_state(cycle_info);
+        if (cycle_info.state == CYCLE_STARTED) {
+            move_to_suspended_state(registry_data, cycle_info);
+        } else if (cycle_info.state == CYCLE_FINISHED && std::option::is_some(&cycle_info.transition_state)) {
+            let trasition_state = std::option::borrow(&cycle_info.transition_state);
+            if (!is_transition_in_progress(trasition_state)) {
+                // Just entered cycle-end phase, and meanwhile also feature has been disabled so it is safe to move to suspended state.
+                move_to_suspended_state(registry_data, cycle_info);
+            }
+            // Otherwise wait of the cycle transition to end and then feature flag value will be taken into account.
+        }
+        // If in already SUSPENED state or in READY state then do nothing.
     }
 
-    fun on_cycle_end_internal() acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
-        update_config_from_buffer();
-        move_to_finished_state()
+    /// Update epoch interval in registry while actually update happens in block module
+    /// Deprecated since SUPRA_CYCLE_BASED_AUTOMATION feature release in favor of monitor_cycle_end
+    public(friend) fun update_epoch_interval_in_registry(_epoch_interval_microsecs: u64) {
+        assert!(false, EDEPRECATED_SINCE_V2);
     }
 
-    fun move_to_finished_state() acquires AutomationCycleInfo {
-        let cycle_info = borrow_global_mut<AutomationCycleInfo>(@supra_framework);
-        cycle_info.state = CYCLE_FINISHED;
-        event::emit(AutomationCycleFinished {
-            cycle_id: cycle_info.index,
+    // Private Native VM referenced api
+
+    /// Registers a new automation task entry.
+    fun register(
+        owner_signer: &signer,
+        payload_tx: vector<u8>,
+        expiry_time: u64,
+        max_gas_amount: u64,
+        gas_price_cap: u64,
+        automation_fee_cap_for_epoch: u64,
+        tx_hash: vector<u8>,
+        aux_data: vector<vector<u8>>
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        // Guarding registration if feature is not enabled.
+        assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
+        assert!(vector::is_empty(&aux_data), ENO_AUX_DATA_SUPPORTED);
+
+        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
+        let automation_cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
+        assert!(automation_registry_config.registration_enabled, ETASK_REGISTRATION_DISABLED);
+        assert!(automation_cycle_info.state == CYCLE_STARTED, ECYCLE_TRANSITION_IN_PROGRESS);
+
+        // If registry is full, reject task registration
+        assert!((get_task_count() as u16) < automation_registry_config.main_config.task_capacity, EREGISTRY_IS_FULL);
+
+        let owner = signer::address_of(owner_signer);
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+
+        //Well-formedness check of payload_tx is done in native layer beforehand.
+
+        let registration_time = timestamp::now_seconds();
+        check_registration_task_duration(
+            expiry_time,
+            registration_time,
+            &automation_registry_config.main_config,
+            automation_cycle_info
+        );
+
+        assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
+        assert!(max_gas_amount > 0, EINVALID_MAX_GAS_AMOUNT);
+        assert!(vector::length(&tx_hash) == TXN_HASH_LENGTH, EINVALID_TXN_HASH);
+
+        let committed_gas = (automation_registry.gas_committed_for_next_epoch as u128) + (max_gas_amount as u128);
+        assert!(committed_gas <= MAX_U64, EGAS_COMMITTEED_VALUE_OVERFLOW);
+
+        let committed_gas = (committed_gas as u64);
+        assert!(committed_gas <= automation_registry_config.next_epoch_registry_max_gas_cap, EGAS_AMOUNT_UPPER);
+
+        // Check the automation fee capacity
+        let estimated_automation_fee_for_epoch = estimate_automation_fee_with_committed_occupancy_internal(
+            max_gas_amount,
+            automation_registry.gas_committed_for_next_epoch,
+            automation_cycle_info.duration_secs,
+            automation_registry_config);
+        assert!(automation_fee_cap_for_epoch >= estimated_automation_fee_for_epoch,
+            EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH
+        );
+
+        automation_registry.gas_committed_for_next_epoch = committed_gas;
+        let task_index = automation_registry.current_index;
+
+        let automation_task_metadata = AutomationTaskMetaData {
+            task_index,
+            owner,
+            payload_tx,
+            expiry_time,
+            max_gas_amount,
+            gas_price_cap,
+            automation_fee_cap_for_epoch,
+            aux_data,
+            state: PENDING,
+            registration_time,
+            tx_hash,
+            locked_fee_for_next_epoch: automation_fee_cap_for_epoch
+        };
+
+        enumerable_map::add_value(&mut automation_registry.tasks, task_index, automation_task_metadata);
+        automation_registry.current_index = automation_registry.current_index + 1;
+
+        // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
+        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + automation_fee_cap_for_epoch;
+
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + automation_fee_cap_for_epoch;
+
+        coin::transfer<SupraCoin>(owner_signer, automation_registry.registry_fee_address, fee);
+
+        event::emit(TaskRegistrationDepositFeeWithdraw {
+            task_index,
+            owner,
+            registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
+            locked_deposit_fee: automation_fee_cap_for_epoch
+        });
+        event::emit(automation_task_metadata);
+    }
+
+    /// Called by MoveVm on `AutomationBookkeepingAction::Drop` action emitted by native layer ahead of cycle transition
+    fun on_drop(vm: signer, task_indexes: vector<u64> ) acquires AutomationCycleDetails, AutomationRegistry, AutomationRefundBookkeeping {
+        // Operational constraint: can only be invoked by the VM
+        system_addresses::assert_vm(&vm);
+        if (vector::is_empty(&task_indexes)) {
+            return;
+        };
+
+        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        assert!(cycle_info.state == CYCLE_FINISHED, EINVALID_REGISTRY_STATE);
+        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+
+        let removed_tasks = vector[];
+        vector::for_each(task_indexes, |task_index| {
+            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+
+                safe_deposit_refund(
+                    refund_bookkeeping,
+                    &resource_signer,
+                    automation_registry.registry_fee_address,
+                    task_index,
+                    task.owner,
+                    task.locked_fee_for_next_epoch,
+                    task.locked_fee_for_next_epoch);
+                vector::push_back(&mut removed_tasks, task_index);
+            };
+        });
+
+        update_cycle_transition_state_from_finished(automation_registry, cycle_info, removed_tasks);
+        event::emit(RemovedTasks {
+            task_indexes: removed_tasks
+        });
+
+    }
+
+    /// Called by MoveVm on `AutomationBookkeepingAction::Charge` action emitted by native layer ahead of cycle transition
+    fun on_charge(vm: signer, automation_fee_per_sec: u64, task_indexes: vector<u64>, gas_committed_for_new_cycle: u64)
+    acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
+        // Operational constraint: can only be invoked by the VM
+        system_addresses::assert_vm(&vm);
+
+        if (vector::is_empty(&task_indexes)) {
+            return
+        };
+
+        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        assert!(cycle_info.state == CYCLE_FINISHED, EINVALID_REGISTRY_STATE);
+        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+
+        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+        if (transition_state.gas_committed_for_this_cycle == 0) {
+            transition_state.gas_committed_for_this_cycle = gas_committed_for_new_cycle;
+            transition_state.automation_fee_per_sec = automation_fee_per_sec;
+        } else {
+            assert!(transition_state.gas_committed_for_this_cycle == gas_committed_for_new_cycle, EINVALID_CHARGE_ACTION);
+            assert!(transition_state.automation_fee_per_sec == automation_fee_per_sec, EINVALID_CHARGE_ACTION);
+        };
+
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
+        let intermedate_result = IntermediateStateOfEpochChange {
+            removed_tasks: vector[],
+            gas_committed_for_new_epoch: gas_committed_for_new_cycle,
+            gas_committed_for_next_epoch: 0,
+            epoch_locked_fees: coin::zero()
+        };
+
+        let processed_tasks = try_charge_tasks_automation_fees(
+            automation_registry,
+            refund_bookkeeping,
+            &automation_registry_config.main_config,
+            (automation_fee_per_sec as u256),
+        transition_state.new_cycle_duration,
+        timestamp::now_seconds(),
+            task_indexes,
+            &mut intermedate_result
+        );
+        let IntermediateStateOfEpochChange {
+            removed_tasks,
+            gas_committed_for_new_epoch,
+            gas_committed_for_next_epoch,
+            epoch_locked_fees
+        } = intermedate_result;
+
+        transition_state.locked_fees = transition_state.locked_fees + coin::value(&epoch_locked_fees);
+        transition_state.gas_committed_for_next_cycle = transition_state.gas_committed_for_next_cycle + gas_committed_for_next_epoch;
+        coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
+
+        update_cycle_transition_state_from_finished(automation_registry, cycle_info, processed_tasks);
+
+        if (!vector::is_empty(&removed_tasks)) {
+            event::emit(RemovedTasks{
+                task_indexes: removed_tasks
+            })
+        }
+    }
+
+    /// Called by MoveVm on `AutomationBookkeepingAction::RefundAndCleanup` action.
+    /// Action from native layer will be tiggered by move layer when automation registy cycle is updated to SUSPENDED.
+    fun on_refund_and_cleanup(vm: signer, duration: u64, automation_fee_per_sec: u64, task_indexes: vector<u64> )
+    acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
+        // Operational constraint: can only be invoked by the VM
+        system_addresses::assert_vm(&vm);
+
+        if (vector::is_empty(&task_indexes)) {
+            return
+        };
+
+        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
+        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+
+        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
+        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        let arc = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
+        let current_time = timestamp::now_seconds();
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        let removed_tasks = vector[];
+        let epoch_locked_fees = automation_registry.epoch_locked_fees;
+        vector::for_each(task_indexes, |task_index| {
+            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+
+                if (task.state != PENDING) {
+                    let refund = calculate_task_fee(
+                        &arc.main_config,
+                        &task,
+                        duration,
+                        current_time,
+                        (automation_fee_per_sec as u256));
+                    let (_, remaining_epoch_locked_fees) = safe_fee_refund(
+                        epoch_locked_fees,
+                        &resource_signer,
+                        automation_registry.registry_fee_address,
+                        task.task_index,
+                        task.owner,
+                        refund);
+                    epoch_locked_fees = remaining_epoch_locked_fees;
+                };
+
+                safe_deposit_refund(
+                    refund_bookkeeping,
+                    &resource_signer,
+                    automation_registry.registry_fee_address,
+                    task.task_index,
+                    task.owner,
+                    task.locked_fee_for_next_epoch,
+                    task.locked_fee_for_next_epoch);
+                vector::push_back(&mut removed_tasks, task_index);
+            };
+        });
+
+        update_cycle_transition_state_from_suspended(automation_registry, cycle_info, removed_tasks);
+        event::emit(RemovedTasks {
+            task_indexes: removed_tasks
         });
     }
 
-    fun move_to_suspended_state(cycle_info: &mut AutomationCycleInfo) {
-        cycle_info.state = LIFECYCLE_SUSPENDED;
-        event::emit(AutomationCycleFinished {
-            cycle_id: cycle_info.index,
-        });
+    // Private helper functions
+
+    fun into_automation_cycle_info(details: &AutomationCycleDetails): AutomationCycleInfo {
+        AutomationCycleInfo {
+            index: details.index,
+            state: details.state,
+            start_time: details.start_time,
+            duration_secs: details.duration_secs
+        }
     }
 
-    fun move_to_started_state(cycle_info: &mut AutomationCycleInfo) {
-        cycle_info.state = CYCLE_STARTED;
+    /// Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
+    /// moves to the next state.
+    /// As transition happens from suspended state and while transition was in progress the feature was enabled back,
+    /// then the transition will happend direclty to starated state, otherwise the transition will be done to the ready state.
+    /// In both cases config will be updated. In this case we will make sure to keep the consistency of state when transition to ready state happens
+    /// through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} -> Ready or Started -> Finished -> {Started, Suspended}
+    fun update_cycle_transition_state_from_suspended(
+        automation_registry: &mut AutomationRegistry,
+        cycle_info: &mut AutomationCycleDetails,
+        processed_tasks: vector<u64>) acquires  ActiveAutomationRegistryConfig  {
+        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+        update_processed_tasks(transition_state, processed_tasks);
+
+        if (!is_transition_finalized(transition_state)) {
+            return
+        };
+        automation_registry.gas_committed_for_next_epoch = 0;
+        automation_registry.gas_committed_for_this_epoch = 0;
+        automation_registry.epoch_active_task_ids = vector[];
+        automation_registry.epoch_locked_fees = 0;
+
+        update_config_from_buffer(cycle_info);
+        if (features::supra_native_automation_enabled()) {
+            move_to_started_state(cycle_info)
+        } else {
+            move_to_ready_state(cycle_info)
+        }
+    }
+
+    /// Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
+    /// moves to the next state.
+    /// First it moves to the next cycle. But if happened so that there was a suspension during cycle transition which was ignored,
+    /// then immediately cycle state is updated to suspended.
+    /// Expectation will be that native layer catches this double transition and will issue refunds for the new cycle
+    /// which will not proceeded farther in any case.
+    fun update_cycle_transition_state_from_finished(
+        automation_registry: &mut AutomationRegistry,
+        cycle_info: &mut AutomationCycleDetails,
+        processed_tasks: vector<u64>
+    ) {
+        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+
+        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+        // TODO maybe do this via native function where duplicates will be avoided
+        update_processed_tasks(transition_state, processed_tasks);
+        let transition_finalized = is_transition_finalized(transition_state);
+
+        if (transition_finalized) {
+            on_cycle_start_internal(automation_registry, cycle_info);
+        };
+        if (transition_finalized  && !features::supra_native_automation_enabled()) {
+            move_to_suspended_state(automation_registry, cycle_info)
+        }
+    }
+
+    /// Estimates automation fee the next epoch for specified task occupancy for the configured epoch-interval
+    /// referencing the current automation registry fee parameters, specified total/committed occupancy and registry
+    /// maximum allowed occupancy for the next epoch.
+    /// Note it is expected that committed_occupancy does not include currnet task's occupancy.
+    fun estimate_automation_fee_with_committed_occupancy_internal(
+        task_occupancy: u64,
+        committed_occupancy: u64,
+        duration: u64,
+        active_config: &ActiveAutomationRegistryConfig
+    ): u64 {
+        let total_committed_max_gas = committed_occupancy + task_occupancy;
+
+        // Compute the automation fee multiplier for epoch
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
+            &active_config.main_config,
+            (total_committed_max_gas as u256),
+            active_config.next_epoch_registry_max_gas_cap);
+
+        if (automation_fee_per_sec == 0) {
+            return 0
+        };
+
+        calculate_automation_fee_for_interval(
+            duration,
+            task_occupancy,
+            automation_fee_per_sec,
+            active_config.next_epoch_registry_max_gas_cap)
+    }
+
+    fun validate_configuration_parameters_common(
+        cycle_duration_secs: u64,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        congestion_threshold_percentage: u8,
+        congestion_exponent: u8,
+    ) {
+        assert!(congestion_threshold_percentage <= MAX_PERCENTAGE, EMAX_CONGESTION_THRESHOLD);
+        assert!(congestion_exponent > 0, ECONGESTION_EXP_NON_ZERO);
+        assert!(task_duration_cap_in_secs > cycle_duration_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
+        assert!(registry_max_gas_cap > 0, EREGISTRY_MAX_GAS_CAP_NON_ZERO);
+    }
+
+    fun create_registry_resource_account(supra_framework: &signer): (signer, SignerCapability) {
+        let (registry_fee_resource_signer, registry_fee_address_signer_cap) = account::create_resource_account(
+            supra_framework,
+            REGISTRY_RESOURCE_SEED
+        );
+        coin::register<SupraCoin>(&registry_fee_resource_signer);
+        (registry_fee_resource_signer, registry_fee_address_signer_cap)
+    }
+
+    fun on_cycle_start_internal(
+        automation_registry: &mut AutomationRegistry,
+        cycle_info: &mut AutomationCycleDetails
+    ) {
+        // Indicates that moving to cycle start from transition state.
+        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+
+        automation_registry.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
+        automation_registry.gas_committed_for_this_epoch = (transition_state.gas_committed_for_this_cycle as u256);
+        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
+        automation_registry.epoch_locked_fees = transition_state.locked_fees;
+
+        // Set current timestamp as cycle start_time
+        // Increase cycle and update the state to Started
+        move_to_started_state(cycle_info);
+        if (!vector::is_empty(&automation_registry.epoch_active_task_ids)) {
+            event::emit(ActiveTasks {
+                task_indexes: automation_registry.epoch_active_task_ids
+            });
+        }
+    }
+
+    fun on_cycle_end_internal(cycle_info: &mut AutomationCycleDetails) acquires ActiveAutomationRegistryConfig, AutomationRegistry {
+        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
+        let transition_state = TransitionState {
+            new_cycle_duration: cycle_info.duration_secs,
+            automation_fee_per_sec: 0,
+            gas_committed_for_this_cycle: 0,
+            gas_committed_for_next_cycle: 0,
+            locked_fees: 0,
+            expected_tasks_to_be_processed: enumerable_map::get_map_list(&automation_registry.tasks),
+            actual_processed_tasks: vector[]
+        };
+        cycle_info.transition_state = std::option::some(transition_state);
+        update_cycle_state_to(cycle_info, CYCLE_FINISHED);
+        // During cycle transition we update config only after transition state is created in order to have new cycle
+        // duration as transition parameter.
+        update_config_from_buffer(cycle_info);
+    }
+
+    fun update_cycle_state_to(cycle_info: &mut AutomationCycleDetails, state: u8) {
+        let old_state = cycle_info.state;
+        cycle_info.state = state;
+        let event = AutomationCycleEvent {
+            cycle_state_info: into_automation_cycle_info(cycle_info),
+            old_state,
+            event_time: timestamp::now_seconds(),
+        };
+        event::emit(event)
+    }
+
+    fun move_to_ready_state(cycle_info: &mut AutomationCycleDetails) {
+        cycle_info.transition_state = std::option::none<TransitionState>();
+        update_cycle_state_to(cycle_info, READY_TO_START_NEW_CYCLE)
+    }
+
+    fun move_to_started_state(cycle_info: &mut AutomationCycleDetails) {
         cycle_info.index = cycle_info.index + 1;
         cycle_info.start_time = timestamp::now_seconds();
-        event::emit(AutomationCycleStarted {
-            cycle_id: cycle_info.index,
-            timestamp: cycle_info.start_time
-        });
+        if (std::option::is_some(&cycle_info.transition_state)) {
+            let transition_state = std::option::extract(&mut cycle_info.transition_state);
+            cycle_info.duration_secs = transition_state.new_cycle_duration;
+        };
+        update_cycle_state_to(cycle_info, CYCLE_STARTED)
+    }
+
+    /// Transition to suspended state is expected
+    ///   a) when cycle is active and in progress
+    ///     - here we do simply move to suspended state so native layer can start requesting refunds and cleanup actions
+    ///   b) when cycle has just finished and there was another transaction causing feature suspension
+    ///     - as this both events happen in scope of the same block, then we will simply update the state to suspended
+    ///       and the native layer should identify this and request refund and cleanup with 0 fee and 0 duration,
+    ///       which will lead to simply deposit refund and cleanup.
+    ///   c) when cycle transition was in progress and there was a feature suspension, but it could not be applied,
+    ///      and postponed till the cycle transition concluded
+    fun move_to_suspended_state(automation_registry: &AutomationRegistry, cycle_info: &mut AutomationCycleDetails) {
+        if (std::option::is_none(&cycle_info.transition_state)) {
+            let transition_state = TransitionState {
+                new_cycle_duration: cycle_info.duration_secs,
+                automation_fee_per_sec: 0,
+                gas_committed_for_this_cycle: 0,
+                gas_committed_for_next_cycle: 0,
+                locked_fees: 0,
+                expected_tasks_to_be_processed: enumerable_map::get_map_list(&automation_registry.tasks),
+                actual_processed_tasks: vector[]
+            };
+            cycle_info.transition_state = std::option::some(transition_state);
+        };
+        update_cycle_state_to(cycle_info, CYCLE_SUSPENDED)
     }
 
     /// Checks all tasks for epoch fee refunds.
@@ -1242,6 +2008,67 @@ module supra_framework::automation_registry {
     /// - If the balance is insufficient, removes the task and emits a cancellation event.
     /// - If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
     /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
+    fun try_charge_tasks_automation_fees(
+        automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        arc: &AutomationRegistryConfig,
+        automation_fee_per_sec: u256,
+        cycle_duration: u64,
+        current_time: u64,
+        task_ids: vector<u64>,
+        intermediate_state: &mut IntermediateStateOfEpochChange,
+    ): vector<u64> {
+        let processed_tasks = vector[];
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        let current_cycle_end_time = current_time + cycle_duration;
+
+        // Sort task indexes to charge automation fees in the tasks chronological order
+        sort_vector(&mut task_ids);
+
+        // Process each active task and calculate fee for the epoch for the tasks
+        vector::for_each(task_ids, |task_index| {
+            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                vector::push_back(&mut processed_tasks, task_index);
+                let task = {
+                    let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+                    let fee= calculate_task_fee(arc, task_meta, cycle_duration, current_time, automation_fee_per_sec);
+                    // If the task reached this phase that means it is valid active task for the new epoch.
+                    // During cleanup all expired tasks has been removed from the registry but the state of the tasks is not updated.
+                    // As here we need to distinguish new tasks from already existing active tasks,
+                    // as the fee calculation for them will be different based on their active duration in the epoch.
+                    // For more details see calculate_task_fee function.
+                    task_meta.state = ACTIVE;
+                    AutomationTaskFeeMeta {
+                        task_index,
+                        owner: task_meta.owner,
+                        fee,
+                        expiry_time: task_meta.expiry_time,
+                        automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+                        max_gas_amount: task_meta.max_gas_amount,
+                        locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+                    }
+                };
+                try_withdraw_task_automation_fee(
+                    automation_registry,
+                    refund_bookkeeping,
+                    &resource_signer,
+                    task,
+                    current_cycle_end_time,
+                    intermediate_state
+                );
+            };
+        });
+        processed_tasks
+    }
+
+    /// Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
+    /// - If the user has sufficient balance, deducts the fee and emits a success event.
+    /// - If the balance is insufficient, removes the task and emits a cancellation event.
+    /// - If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
+    /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
     fun try_withdraw_task_automation_fees(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
@@ -1361,7 +2188,7 @@ module supra_framework::automation_registry {
     }
 
     /// The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
-    fun update_config_from_buffer() acquires ActiveAutomationRegistryConfig, AutomationCycleInfo {
+    fun update_config_from_buffer(cycle_info: &mut AutomationCycleDetails) acquires ActiveAutomationRegistryConfig {
         if (config_buffer::does_exist<AutomationRegistryConfig>()) {
             let buffer = config_buffer::extract<AutomationRegistryConfig>();
             let automation_registry_config = &mut borrow_global_mut<ActiveAutomationRegistryConfig>(
@@ -1378,22 +2205,13 @@ module supra_framework::automation_registry {
         };
         if (config_buffer::does_exist<AutomationCycleDuration>()) {
             let buffer = config_buffer::extract<AutomationCycleDuration>();
-            let cycle_info = borrow_global_mut<AutomationCycleInfo>(
-                @supra_framework
-            );
-            cycle_info.duration_secs = buffer.duration_secs;
+            if (std::option::is_some(&cycle_info.transition_state)) {
+                let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+                transition_state.new_cycle_duration = buffer.duration_secs;
+            } else {
+                cycle_info.duration_secs = buffer.duration_secs;
+            }
         };
-    }
-
-    /// Withdraw accumulated automation task fees from the resource account - access by admin
-    public fun withdraw_automation_task_fees(
-        supra_framework: &signer,
-        to: address,
-        amount: u64
-    ) acquires AutomationRegistry , AutomationRefundBookkeeping {
-        system_addresses::assert_supra_framework(supra_framework);
-        transfer_fee_to_account_internal(to, amount);
-        event::emit(RegistryFeeWithdraw { to, amount });
     }
 
     /// Transfers the specified fee amount from the resource account to the target account.
@@ -1412,59 +2230,6 @@ module supra_framework::automation_registry {
             &automation_registry.registry_fee_address_signer_cap
         );
         coin::transfer<SupraCoin>(&resource_signer, to, amount);
-    }
-
-    /// Update Automation Registry Config
-    public fun update_config(
-        supra_framework: &signer,
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
-    ) {
-        assert!(false, EDEPRECATED_SINCE_V2);
-    }
-
-    /// Update Automation Registry Config along with cycle duration.
-    public fun update_config_v2(
-        supra_framework: &signer,
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
-        cycle_duration_secs: u64,
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
-        system_addresses::assert_supra_framework(supra_framework);
-
-
-        update_registration_config_internal(
-            supra_framework,
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            automation_base_fee_in_quants_per_sec,
-            flat_registration_fee_in_quants,
-            congestion_threshold_percentage,
-            congestion_base_fee_in_quants_per_sec,
-            congestion_exponent,
-            task_capacity,
-            cycle_duration_secs,
-        );
-
-        // Update cycle duration in buffer
-        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
-        let new_cycle_duration = AutomationCycleDuration {
-            duration_secs: cycle_duration_secs
-        };
-        config_buffer::upsert(copy new_cycle_duration);
-        event::emit(new_cycle_duration);
     }
 
     /// Update Automation Registry Config releated to registration.
@@ -1515,120 +2280,11 @@ module supra_framework::automation_registry {
         event::emit(new_automation_registry_config);
     }
 
-    /// Enables the registration process in the automation registry.
-    public fun enable_registration(supra_framework: &signer) acquires ActiveAutomationRegistryConfig {
-        system_addresses::assert_supra_framework(supra_framework);
-        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
-        automation_registry_config.registration_enabled = true;
-        event::emit(EnabledRegistrationEvent {});
-    }
-
-    /// Disables the registration process in the automation registry.
-    public fun disable_registration(supra_framework: &signer) acquires ActiveAutomationRegistryConfig {
-        system_addresses::assert_supra_framework(supra_framework);
-        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
-        automation_registry_config.registration_enabled = false;
-        event::emit(DisabledRegistrationEvent {});
-    }
-
-    /// Registers a new automation task entry.
-    fun register(
-        owner_signer: &signer,
-        payload_tx: vector<u8>,
-        expiry_time: u64,
-        max_gas_amount: u64,
-        gas_price_cap: u64,
-        automation_fee_cap_for_epoch: u64,
-        tx_hash: vector<u8>,
-        aux_data: vector<vector<u8>>
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        // Guarding registration if feature is not enabled.
-        assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
-        assert!(vector::is_empty(&aux_data), ENO_AUX_DATA_SUPPORTED);
-
-        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
-        assert!(automation_registry_config.registration_enabled, ETASK_REGISTRATION_DISABLED);
-
-        // If registry is full, reject task registration
-        assert!((get_task_count() as u16) < automation_registry_config.main_config.task_capacity, EREGISTRY_IS_FULL);
-
-        let owner = signer::address_of(owner_signer);
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
-
-        //Well-formedness check of payload_tx is done in native layer beforehand.
-
-        let registration_time = timestamp::now_seconds();
-        check_registration_task_duration(
-            expiry_time,
-            registration_time,
-            &automation_registry_config.main_config,
-            automation_cycle_info
-        );
-
-        assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
-        assert!(max_gas_amount > 0, EINVALID_MAX_GAS_AMOUNT);
-        assert!(vector::length(&tx_hash) == TXN_HASH_LENGTH, EINVALID_TXN_HASH);
-
-        let committed_gas = (automation_registry.gas_committed_for_next_epoch as u128) + (max_gas_amount as u128);
-        assert!(committed_gas <= MAX_U64, EGAS_COMMITTEED_VALUE_OVERFLOW);
-
-        let committed_gas = (committed_gas as u64);
-        assert!(committed_gas <= automation_registry_config.next_epoch_registry_max_gas_cap, EGAS_AMOUNT_UPPER);
-
-        // Check the automation fee capacity
-        let estimated_automation_fee_for_epoch = estimate_automation_fee_with_committed_occupancy_internal(
-            max_gas_amount,
-            automation_registry.gas_committed_for_next_epoch,
-            automation_cycle_info.duration_secs,
-            automation_registry_config);
-        assert!(automation_fee_cap_for_epoch >= estimated_automation_fee_for_epoch,
-            EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH
-        );
-
-        automation_registry.gas_committed_for_next_epoch = committed_gas;
-        let task_index = automation_registry.current_index;
-
-        let automation_task_metadata = AutomationTaskMetaData {
-            task_index,
-            owner,
-            payload_tx,
-            expiry_time,
-            max_gas_amount,
-            gas_price_cap,
-            automation_fee_cap_for_epoch,
-            aux_data,
-            state: PENDING,
-            registration_time,
-            tx_hash,
-            locked_fee_for_next_epoch: automation_fee_cap_for_epoch
-        };
-
-        enumerable_map::add_value(&mut automation_registry.tasks, task_index, automation_task_metadata);
-        automation_registry.current_index = automation_registry.current_index + 1;
-
-        // Charge flat registration fee from the user at the time of registration and deposit for automation_fee for epoch.
-        let fee = automation_registry_config.main_config.flat_registration_fee_in_quants + automation_fee_cap_for_epoch;
-
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-        refund_bookkeeping.total_deposited_automation_fee = refund_bookkeeping.total_deposited_automation_fee + automation_fee_cap_for_epoch;
-
-        coin::transfer<SupraCoin>(owner_signer, automation_registry.registry_fee_address, fee);
-
-        event::emit(TaskRegistrationDepositFeeWithdraw {
-            task_index,
-            owner,
-            registration_fee: automation_registry_config.main_config.flat_registration_fee_in_quants ,
-            locked_deposit_fee: automation_fee_cap_for_epoch
-        });
-        event::emit(automation_task_metadata);
-    }
-
     fun check_registration_task_duration(
         expiry_time: u64,
         registration_time: u64,
         automation_registry_config: &AutomationRegistryConfig,
-        automation_cycle_info: &AutomationCycleInfo
+        automation_cycle_info: &AutomationCycleDetails
     ) {
         assert!(expiry_time > registration_time, EINVALID_EXPIRY_TIME);
         let task_duration = expiry_time - registration_time;
@@ -1639,196 +2295,6 @@ module supra_framework::automation_registry {
             expiry_time > (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
             EEXPIRY_BEFORE_NEXT_CYCLE
         );
-    }
-
-    /// Cancel Automation task with specified task_index.
-    /// Only existing task, which is PENDING or ACTIVE, can be cancelled and only by task owner.
-    /// If the task is
-    ///   - active, its state is updated to be CANCELLED.
-    ///   - pending, it is removed form the list.
-    ///   - cancelled, an error is reported
-    /// Committed gas-limit is updated by reducing it with the max-gas-amount of the cancelled task.
-    public entry fun cancel_task(
-        owner_signer: &signer,
-        task_index: u64
-    ) acquires AutomationRegistry, AutomationCycleInfo , AutomationRefundBookkeeping{
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_registry.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
-
-        let automation_task_metadata = enumerable_map::get_value(&mut automation_registry.tasks, task_index);
-        let owner = signer::address_of(owner_signer);
-        assert!(automation_task_metadata.owner == owner, EUNAUTHORIZED_TASK_OWNER);
-        assert!(automation_task_metadata.state != CANCELLED, EALREADY_CANCELLED);
-        if (automation_task_metadata.state == PENDING) {
-            let resource_signer = account::create_signer_with_capability(
-                &automation_registry.registry_fee_address_signer_cap
-            );
-            // When Pending tasks are cancelled, refund of the deposit fee is done with penalty
-            let result = safe_deposit_refund(
-                refund_bookkeeping,
-                &resource_signer,
-                automation_registry.registry_fee_address,
-                automation_task_metadata.task_index,
-                owner,
-                automation_task_metadata.locked_fee_for_next_epoch / REFUND_FACTOR,
-            automation_task_metadata.locked_fee_for_next_epoch);
-            assert!(result, EDEPOSIT_REFUND);
-            enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-        } else { // it is safe not to check the state as above, the cancelled tasks are already rejected.
-            // Active tasks will be refunded the deposited amount fully at the end of the epoch
-            let automation_task_metadata_mut = enumerable_map::get_value_mut(
-                &mut automation_registry.tasks,
-                task_index
-            );
-            automation_task_metadata_mut.state = CANCELLED;
-        };
-
-        let cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
-        // This check means the task was expected to be executed in the next cycle, but it has been cancelled.
-        // We need to remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
-        if (automation_task_metadata.expiry_time > (cycle_info.start_time + cycle_info.duration_secs)) {
-            assert!(
-                automation_registry.gas_committed_for_next_epoch >= automation_task_metadata.max_gas_amount,
-                EGAS_COMMITTEED_VALUE_UNDERFLOW
-            );
-            // Adjust the gas committed for the next epoch by subtracting the gas amount of the cancelled task
-            automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - automation_task_metadata.max_gas_amount;
-        };
-
-        event::emit(TaskCancelled { task_index: automation_task_metadata.task_index, owner });
-    }
-
-    /// Immediately stops automation tasks for the specified `task_indexes`.
-    /// Only tasks that exist and are owned by the sender can be stopped.
-    /// If any of the specified tasks are not owned by the sender, the transaction will abort.
-    /// When a task is stopped, the committed gas for the next epoch is reduced
-    /// by the max gas amount of the stopped task. Half of the remaining task fee is refunded.
-    public entry fun stop_tasks(
-        owner_signer: &signer,
-        task_indexes: vector<u64>
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationCycleInfo, AutomationRefundBookkeeping {
-        // Ensure that task indexes are provided
-        assert!(!vector::is_empty(&task_indexes), EEMPTY_TASK_INDEXES);
-
-        let owner = signer::address_of(owner_signer);
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let arc = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).main_config;
-        let cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-
-        let tcmg = automation_registry.gas_committed_for_this_epoch;
-
-        // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(&arc, tcmg, arc.registry_max_gas_cap);
-
-        let stopped_task_details = vector[];
-        let total_refund_fee = 0;
-        let epoch_locked_fees = automation_registry.epoch_locked_fees;
-
-        // Calculate refundable fee for this remaining time task in current epoch
-        let current_time = timestamp::now_seconds();
-        let cycle_end_time = cycle_info.duration_secs + cycle_info.start_time;
-        let residual_interval = if (cycle_end_time <= current_time) {
-            0
-        } else {
-            cycle_end_time - current_time
-        };
-
-        // Loop through each task index to validate and stop the task
-        vector::for_each(task_indexes, |task_index| {
-            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                // Remove task from registry
-                let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-
-                // Ensure only the task owner can stop it
-                assert!(task.owner == owner, EUNAUTHORIZED_TASK_OWNER);
-
-                vector::remove_value(&mut automation_registry.epoch_active_task_ids, &task_index);
-
-                // This check means the task was expected to be executed in the next epoch, but it has been stopped.
-                // We need to remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
-                // Also it checks that task should not be cancelled.
-                if (task.state != CANCELLED && task.expiry_time > cycle_end_time) {
-                    // Prevent underflow in gas committed
-                    assert!(
-                        automation_registry.gas_committed_for_next_epoch >= task.max_gas_amount,
-                        EGAS_COMMITTEED_VALUE_UNDERFLOW
-                    );
-
-                    // Reduce committed gas by the stopped task's max gas
-                    automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - task.max_gas_amount;
-                };
-
-                let (epoch_fee_refund, deposit_refund) = if (task.state != PENDING) {
-                    let task_fee = calculate_task_fee(
-                        &arc,
-                        &task,
-                        residual_interval,
-                        current_time,
-                        automation_fee_per_sec
-                    );
-                    // Refund full deposit and the half of the remaining run-time fee when task is active or cancelled stage
-                    (task_fee / REFUND_FRACTION, task.locked_fee_for_next_epoch)
-                } else {
-                    (0, (task.locked_fee_for_next_epoch / REFUND_FRACTION))
-                };
-                let result = safe_unlock_locked_deposit(
-                    refund_bookkeeping,
-                    task.locked_fee_for_next_epoch,
-                    task.task_index);
-                assert!(result, EDEPOSIT_REFUND);
-                let (result, remaining_epoch_locked_fees) = safe_unlock_locked_epoch_fee(
-                    epoch_locked_fees,
-                    epoch_fee_refund,
-                    task.task_index);
-                assert!(result, EEPOCH_FEE_REFUND);
-                epoch_locked_fees = remaining_epoch_locked_fees;
-
-                total_refund_fee = total_refund_fee + (epoch_fee_refund + deposit_refund);
-
-                vector::push_back(
-                    &mut stopped_task_details,
-                    TaskStopped { task_index, deposit_refund, epoch_fee_refund }
-                );
-            }
-        });
-
-        // Refund and emit event if any tasks were stopped
-        if (!vector::is_empty(&stopped_task_details)) {
-            let resource_signer = account::create_signer_with_capability(
-                &automation_registry.registry_fee_address_signer_cap
-            );
-
-            let resource_account_balance = coin::balance<SupraCoin>(automation_registry.registry_fee_address);
-            assert!(resource_account_balance >= total_refund_fee, EINSUFFICIENT_BALANCE_FOR_REFUND);
-            coin::transfer<SupraCoin>(&resource_signer, owner, total_refund_fee);
-
-            // Emit task stopped event
-            event::emit(TasksStopped {
-                tasks: stopped_task_details,
-                owner
-            });
-        };
-    }
-
-    /// Update epoch interval in registry while actually update happens in block module
-    /// Deprecated since SUPRA_CYCLE_BASED_AUTOMATION feature release in favor of monitor_cycle_end
-    public(friend) fun update_epoch_interval_in_registry(_epoch_interval_microsecs: u64) {
-        assert!(false, EDEPRECATED_SINCE_V2);
-    }
-
-    /// Checks the cycle end and emit an event on it.
-    /// Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
-    public(friend) fun monitor_cycle_end() {
-        // TODO: check is initialized, if not emit error but do not fail.
-        // check if SUPRA_NATIVE_AUTOMATION feature is disabled or cycle state is suspended, do nothing
-        // call dummy native function which should be available if SUPRA_CYCLE_BASED_AUTOMATION is enabled.
-        //    - It does nothing , if binary is also updated, otherwise VM will panic causing block-prologue to
-        //      fail resulting in node failure as well.
-        // Otherwise if cycle_start + cycle_duration >= current time, mark the cycle as finished and update configs from buffer:
-        // on_cycle_end_internal
-        assert_cycle_based_automation_registry_management_support();
     }
 
     /// Insertion sort implementation for vector
@@ -2000,7 +2466,7 @@ module supra_framework::automation_registry {
         automation_fee_cap: u64,
         expiry_time: u64,
         state: u8,
-    ): u64 acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationCycleInfo, AutomationRefundBookkeeping {
+    ): u64 acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationCycleDetails, AutomationRefundBookkeeping {
         register(user,
             PAYLOAD,
             expiry_time,
@@ -2194,7 +2660,7 @@ module supra_framework::automation_registry {
     fun test_registry(
         supra_framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132";
@@ -2207,7 +2673,7 @@ module supra_framework::automation_registry {
     fun test_registration_with_partial_initialization(
         supra_framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test_partially(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132";
@@ -2218,7 +2684,7 @@ module supra_framework::automation_registry {
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_update_config_success_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2266,7 +2732,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EUNACCEPTABLE_AUTOMATION_GAS_LIMIT, location = Self)]
     fun check_automation_gas_limit_failed_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2381,7 +2847,7 @@ module supra_framework::automation_registry {
     fun check_task_registration(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let max_gas_amount = 10;
         let estimated_fee = estimate_automation_fee(max_gas_amount);
@@ -2431,7 +2897,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_full_tasks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         update_config_for_tests(
             framework,
@@ -2479,7 +2945,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         timestamp::update_global_time_for_test_secs(50);
@@ -2499,7 +2965,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time_before_next_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2518,7 +2984,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time_surpassing_task_duration_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2536,7 +3002,7 @@ module supra_framework::automation_registry {
     fun check_registration_valid_expiry_time_matches_task_duration_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2555,7 +3021,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_gas_price_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2574,7 +3040,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_max_gas_amount(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2592,7 +3058,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_parent_hash(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2610,7 +3076,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_aux_data(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let new_param1 = vector[0u8, 1, 2];
         let aux_data = vector[new_param1];
@@ -2630,7 +3096,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_overflow_gas_limit(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2659,7 +3125,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_insufficient_automation_fee_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2676,7 +3142,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2735,7 +3201,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_cancellation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2825,7 +3291,7 @@ module supra_framework::automation_registry {
     fun check_pending_task_cancellation_refunds(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -2859,7 +3325,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_non_existing_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         cancel_task(user, 1);
@@ -2871,7 +3337,7 @@ module supra_framework::automation_registry {
         framework: &signer,
         user: &signer,
         user2: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2891,7 +3357,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2914,7 +3380,7 @@ module supra_framework::automation_registry {
     fun check_normal_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 100_000;
 
@@ -2953,7 +3419,7 @@ module supra_framework::automation_registry {
     fun check_congestion_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 10_000_000;
 
@@ -3202,7 +3668,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_refund_is_done_with_old_config(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         config_buffer::initialize(framework);
         let t1_t2_max_gas = 44_000_000;
@@ -3292,7 +3758,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
 
@@ -3378,7 +3844,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation_for_short_tasks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let expiry_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
@@ -3458,7 +3924,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation_with_zero_multipliers(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
 
@@ -3577,7 +4043,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_withdrawal_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 10_000_000;
@@ -3666,7 +4132,7 @@ module supra_framework::automation_registry {
     fun check_estimate_api(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         let fwk_address = address_of(framework);
         let task_max_gas = 10_000_000;
@@ -3788,7 +4254,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = ETASK_REGISTRATION_DISABLED, location = Self)]
     fun test_register_fails_when_registration_disabled(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         disable_registration(framework);
@@ -3809,7 +4275,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_stopped(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -3939,7 +4405,7 @@ module supra_framework::automation_registry {
         framework: &signer,
         user: &signer,
         user2: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3958,7 +4424,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_stopped_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3982,7 +4448,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -4046,7 +4512,7 @@ module supra_framework::automation_registry {
     fun check_bookkeeping_refunds_and_unlocks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -4213,7 +4679,7 @@ module supra_framework::automation_registry {
     fun task_registration_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let count = 0;
         let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
@@ -4243,7 +4709,7 @@ module supra_framework::automation_registry {
     fun check_task_registration_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         task_registration_performance(framework, user);
     }
 
@@ -4258,7 +4724,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
@@ -4272,7 +4738,7 @@ module supra_framework::automation_registry {
     }
 
     #[test]
-    fun check_monitor_cycle_end() {
+    fun check_monitor_cycle_end() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
         monitor_cycle_end()
     }
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1807,11 +1807,11 @@ module supra_framework::automation_registry {
     /// Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
     public(friend) fun monitor_cycle_end() {
         // TODO: check is initialized, if not emit error but do not fail.
-        // check if SUPRA_NATIVE_AUTOMATION feature is disabled, do nothing
+        // check if SUPRA_NATIVE_AUTOMATION feature is disabled or cycle state is suspended, do nothing
         // call dummy native function which should be available if SUPRA_NATIVE_AUTOMATION_V2 is enabled.
         //    - It does nothing , if binary is also updated, otherwise VM will panic causing block-prologue to
         //      fail resulting in node failure as well.
-        // Otherwise if cycle_start + cycle_duration >= current time, mark the cycle as finished:
+        // Otherwise if cycle_start + cycle_duration >= current time, mark the cycle as finished and update configs from buffer:
         // on_cycle_end_internal
         assert_cycle_based_automation_registry_management_support();
     }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1,4 +1,4 @@
-/// Supra Automation Registry
+/// Supra Automation tegistry
 ///
 /// This contract is part of the Supra Framework and is designed to manage automated task entries
 module supra_framework::automation_registry {
@@ -7,6 +7,7 @@ module supra_framework::automation_registry {
     use std::signer;
     use std::vector;
     use aptos_std::math64;
+    use supra_framework::system_addresses::assert_supra_framework;
     use supra_framework::coin::{Coin, destroy_zero};
 
     use supra_std::enumerable_map::{Self, EnumerableMap};
@@ -24,15 +25,15 @@ module supra_framework::automation_registry {
     use std::signer::address_of;
 
     friend supra_framework::block;
-    friend supra_framework::reconfiguration;
     friend supra_framework::genesis;
+    friend supra_framework::reconfiguration_with_dkg;
 
     /// Invalid expiry time: it cannot be earlier than the current time
     const EINVALID_EXPIRY_TIME: u64 = 1;
     /// Expiry time does not go beyond upper cap duration
     const EEXPIRY_TIME_UPPER: u64 = 2;
-    /// Expiry time must be after the start of the next epoch
-    const EEXPIRY_BEFORE_NEXT_EPOCH: u64 = 3;
+    /// Expiry time must be after the start of the next cycle
+    const EEXPIRY_BEFORE_NEXT_CYCLE: u64 = 3;
     /// Invalid gas price: it cannot be zero
     const EINVALID_GAS_PRICE: u64 = 4;
     /// Invalid max gas amount for automated task: it cannot be zero
@@ -61,7 +62,7 @@ module supra_framework::automation_registry {
     const EINSUFFICIENT_BALANCE: u64 = 16;
     /// Requested amount exceeds the locked balance
     const EREQUEST_EXCEEDS_LOCKED_BALANCE: u64 = 17;
-    /// Current epoch interval is greater than specified task duration cap.
+    /// Current automation cycle interval is greater than specified task duration cap.
     const EUNACCEPTABLE_TASK_DURATION_CAP: u64 = 18;
     /// Congestion threshold should not exceed 100.
     const EMAX_CONGESTION_THRESHOLD: u64 = 19;
@@ -83,6 +84,10 @@ module supra_framework::automation_registry {
     const EDEPOSIT_REFUND: u64 = 27;
     /// Failed to unlock/refund epoch fee for a task. Internal error, for more details see emitted error events.
     const EEPOCH_FEE_REFUND: u64 = 28;
+    /// Deprecated function call since SUPRA_NATIVE_AUTOMATION_V2 release.
+    const EDEPRECATED_SINCE_V2: u64 = 29;
+    /// Automation registry max gas capacity cannot be zero.
+    const ECYCLE_DURATION_NON_ZERO: u64 = 30;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -103,6 +108,12 @@ module supra_framework::automation_registry {
     const PENDING: u8 = 0;
     const ACTIVE: u8 = 1;
     const CANCELLED: u8 = 2;
+
+    /// Constants describing CYCLE state.
+    const CYCLE_FINISHED: u8 = 0;
+    const CYCLE_STARTED: u8 = 1;
+    // State describing the entire lifecycle of automation being suspended due to feature being disabled at all.
+    const LIFECYCLE_SUSPENDED: u8 = 2;
 
     /// Constants describing REFUND TYPE
     const DEPOSIT_EPOCH_FEE: u8 = 0;
@@ -170,7 +181,7 @@ module supra_framework::automation_registry {
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
-    /// Epoch state
+    /// Epoch state. Deprecated since SUPRA_NATIVE_AUTOMATION_V2 version.
     struct AutomationEpochInfo has key, copy {
         /// Epoch expected duration at the beginning of the new epoch, Based on this and actual
         /// epoch_duration which will be (current_time - last_reconfiguration_time) automation tasks
@@ -183,6 +194,28 @@ module supra_framework::automation_registry {
         /// Current epoch start time which is the same as last_reconfiguration_time
         start_time: u64,
     }
+
+    /// Cycle Duration wrapper to store in the config-buffer.
+    #[event]
+    struct AutomationCycleDuration has drop, store, copy {
+        /// Automation cycle duration in seconds.
+        duration_secs: u64,
+    }
+
+    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
+    /// Cycle state.
+    struct AutomationCycleInfo has key, copy {
+        /// Current cycle id. Incremented when a start of the new cycle is processed.
+        index: u64,
+        /// State of the current cycle, CYCLE_FINISHED, CYCLE_STARTED. If state is FINISHED, means transition to the next cycle
+        /// is in progress.
+        state: u8,
+        /// Current cycle start time which is updated with the current chain time when a cycle is increamented.
+        start_time: u64,
+        /// Automation cycle duration in seconds.
+        duration_secs: u64,
+    }
+
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Automation Deposited fee bookkeeping configs
@@ -225,6 +258,22 @@ module supra_framework::automation_registry {
         /// and partially if a pending task is cancelled by user or an active task is cancelled by the system due to
         /// insufficient balance to  pay the automation fee for the epoch
         locked_fee_for_next_epoch: u64,
+    }
+
+    #[event]
+    /// Event emitted at automation cycle end.
+    struct AutomationCycleFinished has drop, store {
+        /// Finished Cycle id.
+        cycle_id: u64,
+    }
+
+    #[event]
+    /// Event emitted at automation cycle end.
+    struct AutomationCycleStarted has drop, store {
+        /// Started Cycle id.
+        cycle_id: u64,
+        /// Cycle start timestamp.
+        timestamp: u64,
     }
 
     #[event]
@@ -408,9 +457,9 @@ module supra_framework::automation_registry {
     /// Checks whether all required resources are created.
     public fun is_initialized(): bool {
         exists<AutomationRegistry>(@supra_framework)
-            && exists<AutomationEpochInfo>(@supra_framework)
-            && exists<ActiveAutomationRegistryConfig>(@supra_framework)
             && exists<AutomationRefundBookkeeping>(@supra_framework)
+            && exists<ActiveAutomationRegistryConfig>(@supra_framework)
+            && exists<AutomationCycleInfo>(@supra_framework)
     }
 
     #[view]
@@ -538,8 +587,14 @@ module supra_framework::automation_registry {
 
     #[view]
     /// Get automation epoch info
-    public fun get_automation_epoch_info(): AutomationEpochInfo acquires AutomationEpochInfo {
-        *borrow_global<AutomationEpochInfo>(@supra_framework)
+    public fun get_automation_epoch_info(): AutomationEpochInfo {
+        assert!(false, EDEPRECATED_SINCE_V2);
+        AutomationEpochInfo {
+            expected_epoch_duration: 0,
+            epoch_interval: 0,
+            start_time: 0,
+
+        }
     }
 
     #[view]
@@ -548,7 +603,7 @@ module supra_framework::automation_registry {
     /// occupancy for the next epoch.
     public fun estimate_automation_fee(
         task_occupancy: u64
-    ): u64 acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ): u64 acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig {
         let registry = borrow_global<AutomationRegistry>(@supra_framework);
         estimate_automation_fee_with_committed_occupancy(task_occupancy, registry.gas_committed_for_next_epoch)
     }
@@ -560,13 +615,13 @@ module supra_framework::automation_registry {
     public fun estimate_automation_fee_with_committed_occupancy(
         task_occupancy: u64,
         committed_occupancy: u64
-    ): u64 acquires AutomationEpochInfo, ActiveAutomationRegistryConfig {
-        let epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
+    ): u64 acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
+        let cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
         let config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         estimate_automation_fee_with_committed_occupancy_internal(
             task_occupancy,
             committed_occupancy,
-            epoch_info,
+            cycle_info.duration_secs,
             config
         )
     }
@@ -577,6 +632,18 @@ module supra_framework::automation_registry {
         borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).registration_enabled
     }
 
+    #[view]
+    /// Returns the current duration of the automation cycle.
+    public fun get_cycle_duration(): u64 acquires AutomationCycleInfo {
+        borrow_global<AutomationCycleInfo>(@supra_framework).duration_secs
+    }
+
+    #[view]
+    /// Returns the current status of the registration in the automation registry.
+    public fun get_cycle_info(): AutomationCycleInfo acquires AutomationCycleInfo {
+        *borrow_global<AutomationCycleInfo>(@supra_framework)
+    }
+
     /// Estimates automation fee the next epoch for specified task occupancy for the configured epoch-interval
     /// referencing the current automation registry fee parameters, specified total/committed occupancy and registry
     /// maximum allowed occupancy for the next epoch.
@@ -584,7 +651,7 @@ module supra_framework::automation_registry {
     fun estimate_automation_fee_with_committed_occupancy_internal(
         task_occupancy: u64,
         committed_occupancy: u64,
-        epoch_info: &AutomationEpochInfo,
+        duration: u64,
         active_config: &ActiveAutomationRegistryConfig
     ): u64 {
         let total_committed_max_gas = committed_occupancy + task_occupancy;
@@ -600,14 +667,14 @@ module supra_framework::automation_registry {
         };
 
         calculate_automation_fee_for_interval(
-            epoch_info.epoch_interval,
+            duration,
             task_occupancy,
             automation_fee_per_sec,
             active_config.next_epoch_registry_max_gas_cap)
     }
 
     fun validate_configuration_parameters_common(
-        epoch_interval_secs: u64,
+        cycle_duration_secs: u64,
         task_duration_cap_in_secs: u64,
         registry_max_gas_cap: u64,
         congestion_threshold_percentage: u8,
@@ -615,7 +682,7 @@ module supra_framework::automation_registry {
     ) {
         assert!(congestion_threshold_percentage <= MAX_PERCENTAGE, EMAX_CONGESTION_THRESHOLD);
         assert!(congestion_exponent > 0, ECONGESTION_EXP_NON_ZERO);
-        assert!(task_duration_cap_in_secs > epoch_interval_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
+        assert!(task_duration_cap_in_secs > cycle_duration_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
         assert!(registry_max_gas_cap > 0, EREGISTRY_MAX_GAS_CAP_NON_ZERO);
     }
 
@@ -628,7 +695,9 @@ module supra_framework::automation_registry {
         (registry_fee_resource_signer, registry_fee_address_signer_cap)
     }
 
+
     /// Initialization of Automation Registry with configuration parameters is expected metrics.
+    /// Deprecated in favor of initialize_v2
     public(friend) fun initialize(
         supra_framework: &signer,
         epoch_interval_secs: u64,
@@ -641,9 +710,36 @@ module supra_framework::automation_registry {
         congestion_exponent: u8,
         task_capacity: u16,
     ) {
+        assert!(false, EDEPRECATED_SINCE_V2);
+    }
+
+    public fun initialize_refund_bookkeeping_resource(supra_framework: &signer) {
+        system_addresses::assert_supra_framework(supra_framework);
+        move_to(supra_framework, AutomationRefundBookkeeping {
+            total_deposited_automation_fee: 0
+        });
+    }
+
+    /// Initialization of Automation Registry with configuration parameters for SUPRA_NATIVE_AUTOMATION_V2 version.
+    /// Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
+    /// automation feature is being introduced very first time.
+    /// In case if framework upgrade is happening on the chain where automation feature is already released and
+    /// is in ongoing state, then migrate_v2 function should be utilized instead.
+    public(friend) fun initialize_v2(
+        supra_framework: &signer,
+        cycle_duration_secs: u64,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+    ) {
         system_addresses::assert_supra_framework(supra_framework);
         validate_configuration_parameters_common(
-            epoch_interval_secs,
+            cycle_duration_secs,
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             congestion_threshold_percentage,
@@ -679,153 +775,117 @@ module supra_framework::automation_registry {
             registration_enabled: true,
         });
 
-        move_to(supra_framework, AutomationEpochInfo {
-            expected_epoch_duration: epoch_interval_secs,
-            epoch_interval: epoch_interval_secs,
+        move_to(supra_framework, AutomationCycleInfo {
             start_time: 0,
+            index: 0,
+            duration_secs: cycle_duration_secs,
+            state: CYCLE_STARTED
         });
 
         initialize_refund_bookkeeping_resource(supra_framework)
     }
 
-    public fun initialize_refund_bookkeeping_resource(supra_framework: &signer) {
-        system_addresses::assert_supra_framework(supra_framework);
-        move_to(supra_framework, AutomationRefundBookkeeping {
-            total_deposited_automation_fee: 0
-        });
-    }
+    /// API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
+    /// detached from epoch-change.
+    /// IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
+    /// end-up in inconsistent state.
+    ///
+    /// TODO: Think of having native fucntion as means to identify that binary is not updated and lets have it called from
+    /// monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
+    /// thus not causing any inconcistensy in the chain
+    public fun migrate_v2(supra_framework: &signer, cycle_duration_secs: u64
+        ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleInfo {
+        assert_supra_framework(supra_framework);
 
-    /// On new epoch this function will be triggered and update the automation registry state
-    public(friend) fun on_new_epoch(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        // Unless registry in initialized, registry will not be updated on new epoch.
-        // Here we need to be careful as well. If the feature is disabled for the current epoch then
-        //  - refund for the previous epoch should be done if any charges has been done.
-        //  - all tasks should be removed from registry state
-        // Note that with the current setup feature::on_new_epoch is called before automation_registry::on_new_epoch
-        if (!is_initialized()) {
-            return
-        };
+        // Prepare the state for migration
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_epoch_info = borrow_global_mut<AutomationEpochInfo>(@supra_framework);
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
+        let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
 
-        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(
+        let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(
             @supra_framework
         ).main_config;
 
         let current_time = timestamp::now_seconds();
-        let intermediate_state = update_state_for_new_epoch(
+        // Refund the epoch fees as epoch will be cut short and on_new_epoch will be dummy due to migration,
+        // so this is the only place to do the refunds
+        update_state_for_migration(
             automation_registry,
-            refund_bookkeeping,
             &automation_registry_config,
             automation_epoch_info,
             current_time
         );
 
+        // Start migration by enabling feature, initializing the cycle releated resouces
+        features::change_feature_flags_for_next_epoch(
+            supra_framework,
+            vector[features::get_supra_native_automation_v2_feature()],
+            vector[]);
+        let id = 0;
+        move_to(supra_framework, AutomationCycleInfo {
+            start_time: current_time,
+            index: id,
+            duration_secs: cycle_duration_secs,
+            state: CYCLE_FINISHED
+        });
+        // Emit cycle end which will lead the native layer to start preparation to the new cycle.
+        on_cycle_end_internal();
+    }
 
-        // Apply the latest configuration if any parameter has been updated
-        // only after refund has been done for previous epoch.
-        update_config_from_buffer();
-
-        // If feature is not enabled then we are not charging and tasks are cleared.
-        if (!features::supra_native_automation_enabled()) {
-            finalize_epoch_change_for_feature_disabled_state(
-                automation_registry,
-                automation_epoch_info,
-                refund_bookkeeping,
-                current_time,
-                intermediate_state);
+    /// On new epoch caused by reconfiguration this function will be triggered and update the automation registry state
+    public(friend) fun on_new_epoch() acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
+        let cycle_info = borrow_global_mut<AutomationCycleInfo>(@supra_framework);
+        if (features::supra_native_automation_enabled()) {
+            // If the lifecycle has been suspended and we are recovering from it, then we update config from buffer and
+            // then start a new cycle directly
+            if ( cycle_info.state == LIFECYCLE_SUSPENDED) {
+                move_to_started_state(cycle_info);
+                update_config_from_buffer();
+            };
             return
         };
-
-        try_withdraw_task_automation_fees(
-            automation_registry,
-            refund_bookkeeping,
-            &automation_registry_config,
-            automation_epoch_info.epoch_interval,
-            current_time,
-            &mut intermediate_state,
-        );
-
-        finalize_epoch_change(automation_registry, automation_epoch_info, current_time, intermediate_state);
+        // We do not update config here, as due to feature being disabled, cycle ends early so it is expected
+        // that native layer will detect this state and generate refund transactions for a cycle that has been kept short.
+        // So the confing should remain intact.
+        move_to_suspended_state(cycle_info);
     }
 
-    fun finalize_epoch_change(
-        automation_registry: &mut AutomationRegistry,
-        automation_epoch_info: &mut AutomationEpochInfo,
-        current_time: u64,
-        intermediate_state: IntermediateStateOfEpochChange
-    ) {
-        let IntermediateStateOfEpochChange {
-            gas_committed_for_new_epoch,
-            gas_committed_for_next_epoch,
-            epoch_locked_fees,
-            removed_tasks,
-        } = intermediate_state;
+    fun on_cycle_end_internal() acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
+        update_config_from_buffer();
+        move_to_finished_state()
+    }
 
-        let epoch_locked_fees_value = coin::value(&epoch_locked_fees);
-        coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
-
-        automation_registry.gas_committed_for_next_epoch = gas_committed_for_next_epoch;
-        automation_registry.epoch_locked_fees = epoch_locked_fees_value;
-        automation_registry.gas_committed_for_this_epoch = (gas_committed_for_new_epoch as u256);
-        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        automation_epoch_info.start_time = current_time;
-        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
-        event::emit(RemovedTasks {
-            task_indexes: removed_tasks
-        });
-        event::emit(ActiveTasks {
-            task_indexes: automation_registry.epoch_active_task_ids
+    fun move_to_finished_state() acquires AutomationCycleInfo {
+        let cycle_info = borrow_global_mut<AutomationCycleInfo>(@supra_framework);
+        cycle_info.state = CYCLE_FINISHED;
+        event::emit(AutomationCycleFinished {
+            cycle_id: cycle_info.index,
         });
     }
 
-    fun finalize_epoch_change_for_feature_disabled_state(
-        automation_registry: &mut AutomationRegistry,
-        automation_epoch_info: &mut AutomationEpochInfo,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        current_time: u64,
-        intermediate_state: IntermediateStateOfEpochChange
-    ) {
-        let IntermediateStateOfEpochChange {
-            gas_committed_for_new_epoch: _,
-            gas_committed_for_next_epoch: _,
-            epoch_locked_fees,
-            removed_tasks,
-        } = intermediate_state;
-
-        destroy_zero(epoch_locked_fees);
-
-        automation_registry.gas_committed_for_next_epoch = 0;
-        automation_registry.epoch_locked_fees = 0;
-        automation_registry.gas_committed_for_this_epoch = 0;
-        automation_registry.epoch_active_task_ids = vector[];
-
-        safe_deposit_refund_all(automation_registry, refund_bookkeeping);
-        vector::append(
-            &mut removed_tasks,
-            enumerable_map::get_map_list(&automation_registry.tasks));
-        event::emit(RemovedTasks { task_indexes: removed_tasks });
-        event::emit(ActiveTasks {
-            task_indexes: vector[]
+    fun move_to_suspended_state(cycle_info: &mut AutomationCycleInfo) {
+        cycle_info.state = LIFECYCLE_SUSPENDED;
+        event::emit(AutomationCycleFinished {
+            cycle_id: cycle_info.index,
         });
-        enumerable_map::clear(&mut automation_registry.tasks);
-
-        automation_epoch_info.start_time = current_time;
-        automation_epoch_info.expected_epoch_duration = automation_epoch_info.epoch_interval;
     }
 
-    /// Checks all tasks for refunds, cancellation and expirations.
-    /// Cleans the stale tasks and calculates gas-committed for the new epoch.
-    fun update_state_for_new_epoch(
+    fun move_to_started_state(cycle_info: &mut AutomationCycleInfo) {
+        cycle_info.state = CYCLE_STARTED;
+        cycle_info.index = cycle_info.index + 1;
+        cycle_info.start_time = timestamp::now_seconds();
+        event::emit(AutomationCycleStarted {
+            cycle_id: cycle_info.index,
+            timestamp: cycle_info.start_time
+        });
+    }
+
+    /// Checks all tasks for epoch fee refunds.
+    fun update_state_for_migration(
         automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
         arc: &AutomationRegistryConfig,
         aei: &AutomationEpochInfo,
         current_time: u64
-    ): IntermediateStateOfEpochChange {
+    ) {
         let previous_epoch_duration = current_time - aei.start_time;
         let refund_interval = 0;
         let refund_automation_fee_per_sec = 0;
@@ -837,34 +897,24 @@ module supra_framework::automation_registry {
             // Compute the automation fee multiplier for ended epoch
             refund_automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(arc, previous_tcmg, arc.registry_max_gas_cap);
         };
+        refund_fee(automation_registry, arc, refund_automation_fee_per_sec, refund_interval, current_time);
 
-        if (refund_automation_fee_per_sec != 0) {
-            refund_cleanup_tasks(
-                automation_registry,
-                refund_bookkeeping,
-                current_time,
-                arc,
-                refund_automation_fee_per_sec,
-                refund_interval)
-        } else {
-            cleanup_tasks(automation_registry, refund_bookkeeping, current_time)
-        }
+        automation_registry.gas_committed_for_next_epoch = 0;
+        automation_registry.epoch_locked_fees = 0;
+        automation_registry.gas_committed_for_this_epoch = 0;
     }
 
-    /// Refunds active tasks of the previous epoch, cleans up expired and cancelled tasks.
-    /// Also calculates and returns the total committed max gas for the new epoch along with the task indexes
-    /// that have been removed from the registry.
-    fun refund_cleanup_tasks(
-        automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        current_time: u64,
+    fun refund_fee(
+        automation_registry: &AutomationRegistry,
         arc: &AutomationRegistryConfig,
         refund_automation_fee_per_sec: u256,
         refund_interval: u64,
-    ): IntermediateStateOfEpochChange {
+        current_time: u64)
+    {
+        if (refund_automation_fee_per_sec == 0) {
+            return
+        };
         let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-        let tcmg = 0;
-        let removed_tasks = vector[];
 
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
@@ -872,7 +922,7 @@ module supra_framework::automation_registry {
         let epoch_locked_fees = automation_registry.epoch_locked_fees;
 
         vector::for_each(ids, |task_index| {
-            let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+            let task = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
             if (task.state != PENDING) {
                 let refund = calculate_task_fee(
                     arc,
@@ -889,72 +939,7 @@ module supra_framework::automation_registry {
                     refund);
                 epoch_locked_fees = remaining_epoch_locked_fees;
             };
-
-            // Drop or activate task for this current epoch.
-            if (task.expiry_time <= current_time || task.state == CANCELLED) {
-                safe_deposit_refund(
-                    refund_bookkeeping,
-                    &resource_signer,
-                    automation_registry.registry_fee_address,
-                    task.task_index,
-                    task.owner,
-                    task.locked_fee_for_next_epoch,
-                task.locked_fee_for_next_epoch);
-                enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-                vector::push_back(&mut removed_tasks, task_index);
-            } else {
-                tcmg = tcmg + task.max_gas_amount;
-            }
         });
-        IntermediateStateOfEpochChange {
-            removed_tasks,
-            gas_committed_for_new_epoch: tcmg,
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: coin::zero(),
-        }
-    }
-
-    /// Cleans up expired and cancelled.
-    /// Also calculates and returns the total committed max gas for the new epoch along with the task indexes
-    /// that have been removed from the registry.
-    fun cleanup_tasks(
-        automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        current_time: u64
-    ): IntermediateStateOfEpochChange {
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-        let tcmg = 0;
-        let removed_tasks = vector[];
-
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-        // Perform clean up and updation of state (we can't use enumerable_map::for_each, as actually we need value as mutable ref)
-        vector::for_each(ids, |task_index| {
-            let task = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
-            // Drop or activate task for this current epoch.
-            if (task.expiry_time <= current_time || task.state == CANCELLED) {
-                safe_deposit_refund(
-                    refund_bookkeeping,
-                    &resource_signer,
-                    automation_registry.registry_fee_address,
-                    task.task_index,
-                    task.owner,
-                    task.locked_fee_for_next_epoch,
-                    task.locked_fee_for_next_epoch);
-                enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-                vector::push_back(&mut removed_tasks, task_index);
-            } else {
-                tcmg = tcmg + task.max_gas_amount;
-            }
-        });
-
-        IntermediateStateOfEpochChange {
-            removed_tasks,
-            gas_committed_for_new_epoch: tcmg,
-            gas_committed_for_next_epoch: 0,
-            epoch_locked_fees: coin::zero(),
-        }
     }
 
     /// Traverses through all existing tasks and refunds deposited fee upon registration fully.
@@ -1361,7 +1346,7 @@ module supra_framework::automation_registry {
     }
 
     /// The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
-    fun update_config_from_buffer() acquires ActiveAutomationRegistryConfig {
+    fun update_config_from_buffer() acquires ActiveAutomationRegistryConfig, AutomationCycleInfo {
         if (config_buffer::does_exist<AutomationRegistryConfig>()) {
             let buffer = config_buffer::extract<AutomationRegistryConfig>();
             let automation_registry_config = &mut borrow_global_mut<ActiveAutomationRegistryConfig>(
@@ -1375,6 +1360,13 @@ module supra_framework::automation_registry {
             automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
             automation_registry_config.congestion_exponent = buffer.congestion_exponent;
             automation_registry_config.task_capacity = buffer.task_capacity;
+        };
+        if (config_buffer::does_exist<AutomationCycleDuration>()) {
+            let buffer = config_buffer::extract<AutomationCycleDuration>();
+            let cycle_info = borrow_global_mut<AutomationCycleInfo>(
+                @supra_framework
+            );
+            cycle_info.duration_secs = buffer.duration_secs;
         };
     }
 
@@ -1418,14 +1410,67 @@ module supra_framework::automation_registry {
         congestion_base_fee_in_quants_per_sec: u64,
         congestion_exponent: u8,
         task_capacity: u16,
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo {
+    ) {
+        assert!(false, EDEPRECATED_SINCE_V2);
+    }
+
+    /// Update Automation Registry Config along with cycle duration.
+    public fun update_config_v2(
+        supra_framework: &signer,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+        cycle_duration_secs: u64,
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
+        system_addresses::assert_supra_framework(supra_framework);
+
+
+        update_registration_config_internal(
+            supra_framework,
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+            cycle_duration_secs,
+        );
+
+        // Update cycle duration in buffer
+        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
+        let new_cycle_duration = AutomationCycleDuration {
+            duration_secs: cycle_duration_secs
+        };
+        config_buffer::upsert(copy new_cycle_duration);
+        event::emit(new_cycle_duration);
+    }
+
+    /// Update Automation Registry Config releated to registration.
+    fun update_registration_config_internal(
+        supra_framework: &signer,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+        cycle_duration_secs: u64,
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
 
         let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
-        let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
 
         validate_configuration_parameters_common(
-            automation_epoch_info.epoch_interval,
+            cycle_duration_secs,
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             congestion_threshold_percentage,
@@ -1481,7 +1526,7 @@ module supra_framework::automation_registry {
         automation_fee_cap_for_epoch: u64,
         tx_hash: vector<u8>,
         aux_data: vector<vector<u8>>
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         // Guarding registration if feature is not enabled.
         assert!(features::supra_native_automation_enabled(), EDISABLED_AUTOMATION_FEATURE);
         assert!(vector::is_empty(&aux_data), ENO_AUX_DATA_SUPPORTED);
@@ -1494,7 +1539,7 @@ module supra_framework::automation_registry {
 
         let owner = signer::address_of(owner_signer);
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
+        let automation_cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
 
         //Well-formedness check of payload_tx is done in native layer beforehand.
 
@@ -1503,7 +1548,7 @@ module supra_framework::automation_registry {
             expiry_time,
             registration_time,
             &automation_registry_config.main_config,
-            automation_epoch_info
+            automation_cycle_info
         );
 
         assert!(gas_price_cap > 0, EINVALID_GAS_PRICE);
@@ -1520,7 +1565,7 @@ module supra_framework::automation_registry {
         let estimated_automation_fee_for_epoch = estimate_automation_fee_with_committed_occupancy_internal(
             max_gas_amount,
             automation_registry.gas_committed_for_next_epoch,
-            automation_epoch_info,
+            automation_cycle_info.duration_secs,
             automation_registry_config);
         assert!(automation_fee_cap_for_epoch >= estimated_automation_fee_for_epoch,
             EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH
@@ -1568,7 +1613,7 @@ module supra_framework::automation_registry {
         expiry_time: u64,
         registration_time: u64,
         automation_registry_config: &AutomationRegistryConfig,
-        automation_epoch_info: &AutomationEpochInfo
+        automation_cycle_info: &AutomationCycleInfo
     ) {
         assert!(expiry_time > registration_time, EINVALID_EXPIRY_TIME);
         let task_duration = expiry_time - registration_time;
@@ -1576,8 +1621,8 @@ module supra_framework::automation_registry {
 
         // Check that task is valid at least in the next epoch
         assert!(
-            expiry_time > (automation_epoch_info.start_time + automation_epoch_info.epoch_interval),
-            EEXPIRY_BEFORE_NEXT_EPOCH
+            expiry_time > (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
+            EEXPIRY_BEFORE_NEXT_CYCLE
         );
     }
 
@@ -1591,7 +1636,7 @@ module supra_framework::automation_registry {
     public entry fun cancel_task(
         owner_signer: &signer,
         task_index: u64
-    ) acquires AutomationRegistry, AutomationEpochInfo , AutomationRefundBookkeeping{
+    ) acquires AutomationRegistry, AutomationCycleInfo , AutomationRefundBookkeeping{
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
         assert!(enumerable_map::contains(&automation_registry.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
@@ -1624,10 +1669,10 @@ module supra_framework::automation_registry {
             automation_task_metadata_mut.state = CANCELLED;
         };
 
-        let epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
-        // This check means the task was expected to be executed in the next epoch, but it has been cancelled.
+        let cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
+        // This check means the task was expected to be executed in the next cycle, but it has been cancelled.
         // We need to remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
-        if (automation_task_metadata.expiry_time > (epoch_info.start_time + epoch_info.expected_epoch_duration)) {
+        if (automation_task_metadata.expiry_time > (cycle_info.start_time + cycle_info.duration_secs)) {
             assert!(
                 automation_registry.gas_committed_for_next_epoch >= automation_task_metadata.max_gas_amount,
                 EGAS_COMMITTEED_VALUE_UNDERFLOW
@@ -1647,14 +1692,14 @@ module supra_framework::automation_registry {
     public entry fun stop_tasks(
         owner_signer: &signer,
         task_indexes: vector<u64>
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationCycleInfo, AutomationRefundBookkeeping {
         // Ensure that task indexes are provided
         assert!(!vector::is_empty(&task_indexes), EEMPTY_TASK_INDEXES);
 
         let owner = signer::address_of(owner_signer);
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let arc = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).main_config;
-        let epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
+        let cycle_info = borrow_global<AutomationCycleInfo>(@supra_framework);
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
 
         let tcmg = automation_registry.gas_committed_for_this_epoch;
@@ -1668,13 +1713,12 @@ module supra_framework::automation_registry {
 
         // Calculate refundable fee for this remaining time task in current epoch
         let current_time = timestamp::now_seconds();
-        let epoch_end_time = epoch_info.expected_epoch_duration + epoch_info.start_time;
-        let residual_interval = if (epoch_end_time <= current_time) {
+        let cycle_end_time = cycle_info.duration_secs + cycle_info.start_time;
+        let residual_interval = if (cycle_end_time <= current_time) {
             0
         } else {
-            epoch_end_time - current_time
+            cycle_end_time - current_time
         };
-
 
         // Loop through each task index to validate and stop the task
         vector::for_each(task_indexes, |task_index| {
@@ -1690,7 +1734,7 @@ module supra_framework::automation_registry {
                 // This check means the task was expected to be executed in the next epoch, but it has been stopped.
                 // We need to remove its gas commitment from `gas_committed_for_next_epoch` for this particular task.
                 // Also it checks that task should not be cancelled.
-                if (task.state != CANCELLED && task.expiry_time > epoch_end_time) {
+                if (task.state != CANCELLED && task.expiry_time > cycle_end_time) {
                     // Prevent underflow in gas committed
                     assert!(
                         automation_registry.gas_committed_for_next_epoch >= task.max_gas_amount,
@@ -1754,11 +1798,22 @@ module supra_framework::automation_registry {
     }
 
     /// Update epoch interval in registry while actually update happens in block module
-    public(friend) fun update_epoch_interval_in_registry(epoch_interval_microsecs: u64) acquires AutomationEpochInfo {
-        if (exists<AutomationEpochInfo>(@supra_framework)) {
-            let automation_epoch_info = borrow_global_mut<AutomationEpochInfo>(@supra_framework);
-            automation_epoch_info.epoch_interval = epoch_interval_microsecs / MICROSECS_CONVERSION_FACTOR;
-        };
+    /// Deprecated since SUPRA_NATIVE_AUTOMATION_V2 feature release in favor of monitor_cycle_end
+    public(friend) fun update_epoch_interval_in_registry(_epoch_interval_microsecs: u64) {
+        assert!(false, EDEPRECATED_SINCE_V2);
+    }
+
+    /// Checks the cycle end and emit an event on it.
+    /// Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
+    public(friend) fun monitor_cycle_end() {
+        // TODO: check is initialized, if not emit error but do not fail.
+        // check if SUPRA_NATIVE_AUTOMATION feature is disabled, do nothing
+        // call dummy native function which should be available if SUPRA_NATIVE_AUTOMATION_V2 is enabled.
+        //    - It does nothing , if binary is also updated, otherwise VM will panic causing block-prologue to
+        //      fail resulting in node failure as well.
+        // Otherwise if cycle_start + cycle_duration >= current time, mark the cycle as finished:
+        // on_cycle_end_internal
+        assert_cycle_based_automation_registry_management_support();
     }
 
     /// Insertion sort implementation for vector
@@ -1785,6 +1840,16 @@ module supra_framework::automation_registry {
     fun downscale_to_u64(value: u256): u64 { ((value / DECIMAL) as u64) }
 
     fun downscale_to_u256(value: u256): u256 { value / DECIMAL }
+
+    /// If SUPRA_NATIVE_AUTOMATION_V2 is enabled then call native function to assert full support of cycle based
+    /// automation registry management.
+    fun assert_cycle_based_automation_registry_management_support() {
+        if (features::supra_native_automation_v2_enabled()) {
+            native_cycle_based_automation_registry_management_support();
+        }
+    }
+
+    native fun native_cycle_based_automation_registry_management_support(): bool;
 
     #[test_only]
     const AUTOMATION_MAX_GAS_TEST: u64 = 100_000_000;
@@ -1829,7 +1894,7 @@ module supra_framework::automation_registry {
 
         let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
 
-        initialize(
+        initialize_v2(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             TTL_UPPER_BOUND_TEST,
@@ -1920,7 +1985,7 @@ module supra_framework::automation_registry {
         automation_fee_cap: u64,
         expiry_time: u64,
         state: u8,
-    ): u64 acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationEpochInfo, AutomationRefundBookkeeping {
+    ): u64 acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationCycleInfo, AutomationRefundBookkeeping {
         register(user,
             PAYLOAD,
             expiry_time,
@@ -2039,7 +2104,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_task_duration(
         supra_framework: &signer,
     ) {
-        initialize(
+        initialize_v2(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2058,7 +2123,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_registry_max_gas_cap(
         supra_framework: &signer,
     ) {
-        initialize(
+        initialize_v2(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2077,7 +2142,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_congestion_exponent(
         supra_framework: &signer,
     ) {
-        initialize(
+        initialize_v2(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2096,7 +2161,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_threshold_percentage(
         supra_framework: &signer,
     ) {
-        initialize(
+        initialize_v2(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2114,7 +2179,7 @@ module supra_framework::automation_registry {
     fun test_registry(
         supra_framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132";
@@ -2122,19 +2187,12 @@ module supra_framework::automation_registry {
         register(user, payload, 86400, 1000, 100000, 100_000_00, parent_hash, AUX_DATA);
     }
 
-    #[test]
-    fun test_on_new_epoch_without_initialization(
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        // Nothing will be attempted if the registry is not initialized.
-        on_new_epoch()
-    }
-
     #[test(supra_framework = @supra_framework, user = @0x1cafe)]
     #[expected_failure(abort_code = EDISABLED_AUTOMATION_FEATURE, location = Self)]
     fun test_registration_with_partial_initialization(
         supra_framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test_partially(supra_framework, user);
 
         let payload = x"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132";
@@ -2145,7 +2203,7 @@ module supra_framework::automation_registry {
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_update_config_success_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2159,7 +2217,7 @@ module supra_framework::automation_registry {
         config_buffer::initialize(framework);
         // Next epoch gas committed gas is less than the new limit value.
         // Configuration parameter will update after on new epoch
-        update_config(framework,
+        update_config_v2(framework,
             1_626_560,
             75,
             1005,
@@ -2167,7 +2225,9 @@ module supra_framework::automation_registry {
             70,
             2000,
             5,
-            200);
+            200,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
+        );
 
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         assert!(state.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 1);
@@ -2184,13 +2244,14 @@ module supra_framework::automation_registry {
         assert!(state.congestion_base_fee_in_quants_per_sec == 2000, 7);
         assert!(state.congestion_exponent == 5, 8);
         assert!(state.task_capacity == 200, 9);
+        // TODO check cycle duration update as well
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
     #[expected_failure(abort_code = EUNACCEPTABLE_AUTOMATION_GAS_LIMIT, location = Self)]
     fun check_automation_gas_limit_failed_update(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2203,7 +2264,7 @@ module supra_framework::automation_registry {
         );
 
         // Next epoch gas committed gas is greater than the new limit value.
-        update_config(
+        update_config_v2(
             framework,
             TTL_UPPER_BOUND_TEST,
             45,
@@ -2213,6 +2274,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
     }
 
@@ -2220,10 +2282,10 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EUNACCEPTABLE_TASK_DURATION_CAP, location = Self)]
     fun check_config_udpate_with_invalid_task_duration_cap(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry,  ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         // Specified task duration cap is less than epoch length
-        update_config(
+        update_config_v2(
             framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2,
             AUTOMATION_MAX_GAS_TEST,
@@ -2233,6 +2295,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
             TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
     }
 
@@ -2240,10 +2303,10 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EMAX_CONGESTION_THRESHOLD, location = Self)]
     fun check_config_udpate_with_max_congestion_threshold(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         // Specified task duration cap is less than epoch length
-        update_config(
+        update_config_v2(
             framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
             AUTOMATION_MAX_GAS_TEST,
@@ -2252,7 +2315,8 @@ module supra_framework::automation_registry {
             150,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
-            TASK_CAPACITY_TEST
+            TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
         );
     }
 
@@ -2260,10 +2324,10 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = ECONGESTION_EXP_NON_ZERO, location = Self)]
     fun check_config_udpate_with_invalid_congestion_exponent(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         // Specified task duration cap is less than epoch length
-        update_config(
+        update_config_v2(
             framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
             AUTOMATION_MAX_GAS_TEST,
@@ -2273,6 +2337,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST,
             0,
             TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS,
         );
     }
 
@@ -2280,10 +2345,10 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = EREGISTRY_MAX_GAS_CAP_NON_ZERO, location = Self)]
     fun check_config_udpate_with_invalid_registry_max_gas_cap(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         // Specified task duration cap is less than epoch length
-        update_config(
+        update_config_v2(
             framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
             0,
@@ -2292,7 +2357,8 @@ module supra_framework::automation_registry {
             CONGESTION_THRESHOLD_TEST,
             CONGESTION_BASE_FEE_TEST,
             CONGESTION_EXPONENT_TEST,
-            TASK_CAPACITY_TEST
+            TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
     }
 
@@ -2300,7 +2366,7 @@ module supra_framework::automation_registry {
     fun check_task_registration(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let max_gas_amount = 10;
         let estimated_fee = estimate_automation_fee(max_gas_amount);
@@ -2350,7 +2416,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_full_tasks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         update_config_for_tests(
             framework,
@@ -2398,7 +2464,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         timestamp::update_global_time_for_test_secs(50);
@@ -2414,11 +2480,11 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
-    #[expected_failure(abort_code = EEXPIRY_BEFORE_NEXT_EPOCH, location = Self)]
+    #[expected_failure(abort_code = EEXPIRY_BEFORE_NEXT_CYCLE, location = Self)]
     fun check_registration_invalid_expiry_time_before_next_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2437,7 +2503,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_expiry_time_surpassing_task_duration_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2455,7 +2521,7 @@ module supra_framework::automation_registry {
     fun check_registration_valid_expiry_time_matches_task_duration_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2474,7 +2540,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_gas_price_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2493,7 +2559,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_max_gas_amount(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2511,7 +2577,7 @@ module supra_framework::automation_registry {
     fun check_registration_invalid_parent_hash(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2529,7 +2595,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_aux_data(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let new_param1 = vector[0u8, 1, 2];
         let aux_data = vector[new_param1];
@@ -2549,7 +2615,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_overflow_gas_limit(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2578,7 +2644,7 @@ module supra_framework::automation_registry {
     fun check_registration_with_insufficient_automation_fee_cap(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2595,7 +2661,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2654,7 +2720,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_cancellation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2744,7 +2810,7 @@ module supra_framework::automation_registry {
     fun check_pending_task_cancellation_refunds(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -2778,7 +2844,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_non_existing_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         cancel_task(user, 1);
@@ -2790,7 +2856,7 @@ module supra_framework::automation_registry {
         framework: &signer,
         user: &signer,
         user2: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2810,7 +2876,7 @@ module supra_framework::automation_registry {
     fun check_cancellation_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -2833,7 +2899,7 @@ module supra_framework::automation_registry {
     fun check_normal_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 100_000;
 
@@ -2872,7 +2938,7 @@ module supra_framework::automation_registry {
     fun check_congestion_fee_charge_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 10_000_000;
 
@@ -2911,217 +2977,217 @@ module supra_framework::automation_registry {
             expected_registry_balance + expected_epoch_fee);
     }
 
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_update_state_for_new_epoch(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-        let exists = true;
+    // #[test(framework = @supra_framework, user = @0x1cafa)]
+    // fun check_update_state_for_new_epoch(
+    //     framework: &signer,
+    //     user: &signer
+    // ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    //     initialize_registry_test(framework, user);
+    //     let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+    //     let automation_fee_cap = 100_000_000;
+    //     let exists = true;
+    //
+    //     let task1 = register_with_state(
+    //         framework,
+    //         user,
+    //         44_000_000,
+    //         automation_fee_cap,
+    //         task_exipry_time,
+    //         ACTIVE);
+    //     let task2 = register_with_state(
+    //         framework,
+    //         user,
+    //         44_000_000,
+    //         automation_fee_cap,
+    //         task_exipry_time,
+    //         ACTIVE);
+    //     let task3 = register_with_state(
+    //         framework,
+    //         user,
+    //         11_000_000,
+    //         automation_fee_cap,
+    //         task_exipry_time,
+    //         PENDING);
+    //     let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+    //     let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+    //
+    //
+    //     // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+    //     let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+    //     // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+    //     let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+    //
+    //     let fwk_address = address_of(framework);
+    //     let user_address = address_of(user);
+    //
+    //     // No refund when there is no locked fee.
+    //     set_locked_fee(framework, 0);
+    //     {
+    //         let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+    //         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
+    //         let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
+    //         let aei = borrow_global<AutomationCycleInfo>(fwk_address);
+    //         let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+    //         consume_intermediate_state(result);
+    //         // If there is no locked fee, nothing to refund;
+    //         // tasks only will be charged for the next epoch.
+    //         check_account_balance(user_address, expected_user_current_balance);
+    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+    //         // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+    //         check_task_state(ar, task3, exists, PENDING);
+    //     };
+    //
+    //     // Set some locked fee which is enough to pay refund if necessary
+    //     set_locked_fee(framework, 100_000_000);
+    //
+    //     {
+    //         // if epoch length matches or greater the expected epoch interval then no refund is expected
+    //         // even if there is a locked fee.
+    //         let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+    //         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
+    //         let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
+    //         let aei = borrow_global<AutomationEpochInfo>(fwk_address);
+    //
+    //         let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+    //         consume_intermediate_state(result);
+    //
+    //         check_account_balance(user_address, expected_user_current_balance);
+    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+    //         check_task_state(ar, task1, exists, ACTIVE);
+    //         check_task_state(ar, task2, exists, ACTIVE);
+    //         // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+    //         check_task_state(ar, task3, exists, PENDING);
+    //
+    //         // Refund is expected only for ACTIVE AND CANCELLED TASK BUT NOT FOR PENDING
+    //         update_task_state(ar, task2, CANCELLED);
+    //         let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+    //         consume_intermediate_state(result);
+    //         // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
+    //         let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task
+    //             + automation_fee_cap; // refund of the depodit for cancelled task
+    //         expected_user_current_balance = expected_user_current_balance + expected_refund;
+    //         expected_registry_current_balance = expected_registry_current_balance - expected_refund;
+    //
+    //         check_account_balance(user_address, expected_user_current_balance);
+    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+    //         check_task_state(ar, task1, exists, ACTIVE);
+    //         check_task_state(ar, task2, !exists, CANCELLED);
+    //         // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+    //         check_task_state(ar, task3, exists, PENDING);
+    //
+    //         // Now we have only task1 as Active and task 3 as pending.
+    //         // If epoch duration surpasses tasks expiration time, then they are refunded on  locked deposit, and removed from registry.
+    //         // even pending task.
+    //         let result = update_state_for_new_epoch(
+    //             ar,
+    //             refund_bookkeeping,
+    //             arc,
+    //             aei,
+    //             task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS
+    //         );
+    //         consume_intermediate_state(result);
+    //         let expected_refund = 2 * automation_fee_cap; // refund of the depodit for both available tasks
+    //
+    //         expected_user_current_balance = expected_user_current_balance + expected_refund;
+    //         expected_registry_current_balance = expected_registry_current_balance - expected_refund;
+    //
+    //         check_account_balance(user_address, expected_user_current_balance);
+    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+    //     };
+    // }
 
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        let task2 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        let task3 = register_with_state(
-            framework,
-            user,
-            11_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            PENDING);
-        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-
-
-        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
-        let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
-
-        let fwk_address = address_of(framework);
-        let user_address = address_of(user);
-
-        // No refund when there is no locked fee.
-        set_locked_fee(framework, 0);
-        {
-            let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
-            let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
-            let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-            let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-            let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
-            consume_intermediate_state(result);
-            // If there is no locked fee, nothing to refund;
-            // tasks only will be charged for the next epoch.
-            check_account_balance(user_address, expected_user_current_balance);
-            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-            // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-            check_task_state(ar, task3, exists, PENDING);
-        };
-
-        // Set some locked fee which is enough to pay refund if necessary
-        set_locked_fee(framework, 100_000_000);
-
-        {
-            // if epoch length matches or greater the expected epoch interval then no refund is expected
-            // even if there is a locked fee.
-            let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
-            let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
-            let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-            let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-
-            let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-            consume_intermediate_state(result);
-
-            check_account_balance(user_address, expected_user_current_balance);
-            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-            check_task_state(ar, task1, exists, ACTIVE);
-            check_task_state(ar, task2, exists, ACTIVE);
-            // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-            check_task_state(ar, task3, exists, PENDING);
-
-            // Refund is expected only for ACTIVE AND CANCELLED TASK BUT NOT FOR PENDING
-            update_task_state(ar, task2, CANCELLED);
-            let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
-            consume_intermediate_state(result);
-            // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
-            let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task
-                + automation_fee_cap; // refund of the depodit for cancelled task
-            expected_user_current_balance = expected_user_current_balance + expected_refund;
-            expected_registry_current_balance = expected_registry_current_balance - expected_refund;
-
-            check_account_balance(user_address, expected_user_current_balance);
-            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-            check_task_state(ar, task1, exists, ACTIVE);
-            check_task_state(ar, task2, !exists, CANCELLED);
-            // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-            check_task_state(ar, task3, exists, PENDING);
-
-            // Now we have only task1 as Active and task 3 as pending.
-            // If epoch duration surpasses tasks expiration time, then they are refunded on  locked deposit, and removed from registry.
-            // even pending task.
-            let result = update_state_for_new_epoch(
-                ar,
-                refund_bookkeeping,
-                arc,
-                aei,
-                task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS
-            );
-            consume_intermediate_state(result);
-            let expected_refund = 2 * automation_fee_cap; // refund of the depodit for both available tasks
-
-            expected_user_current_balance = expected_user_current_balance + expected_refund;
-            expected_registry_current_balance = expected_registry_current_balance - expected_refund;
-
-            check_account_balance(user_address, expected_user_current_balance);
-            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-        };
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_update_state_for_new_epoch_with_remaining_time_refund(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-        let exists = true;
-
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        let task2 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            CANCELLED);
-        let task3 = register_with_state(
-            framework,
-            user,
-            11_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            PENDING);
-        let registration_charges = 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-        let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
-
-
-        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
-        let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
-
-        let fwk_address = address_of(framework);
-        let user_address = address_of(user);
-
-
-        // Set some locked fee which is enough to pay refund if necessary
-        set_locked_fee(framework, 100_000_000);
-
-        // Refund is expected only for the remaing time till the task expiry time for both cancelled and active tasks
-        // Task was expiring in the middle of the 3rd epoch, but epoch duration was cat short by 3/4
-        let current_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 4;
-        // update epoch-start-time to be 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS
-        {
-            let aei = borrow_global_mut<AutomationEpochInfo>(fwk_address);
-            aei.start_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
-        };
-
-        let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
-        let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-        let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-
-        check_account_balance(user_address, expected_user_current_balance);
-        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-
-        let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, current_time);
-        consume_intermediate_state(result);
-        // It is expected that the tasks will be chared only for 1/2 epoch fee, so if the epoch lenght is 1/4,
-        // then refund should be 1/4.
-        // as account has 2 tasks with same automation and congestion fees then refund is double
-        // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
-        let expected_refund = (expected_congestion_fee_per_task + expected_automation_fee_per_task) / 2
-                + automation_fee_cap; // refund of the depodit for cancelled task
-
-        expected_user_current_balance = expected_user_current_balance + expected_refund;
-        expected_registry_current_balance = expected_registry_current_balance - expected_refund;
-
-        check_task_state(ar, task1, exists, ACTIVE);
-        check_task_state(ar, task2, !exists, CANCELLED);
-        // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-        check_task_state(ar, task3, exists, PENDING);
-
-        check_account_balance(user_address, expected_user_current_balance);
-        // // Check registry balance
-        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    }
+    // #[test(framework = @supra_framework, user = @0x1cafa)]
+    // fun check_update_state_for_new_epoch_with_remaining_time_refund(
+    //     framework: &signer,
+    //     user: &signer
+    // ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    //     initialize_registry_test(framework, user);
+    //     let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+    //     let automation_fee_cap = 100_000_000;
+    //     let exists = true;
+    //
+    //     let task1 = register_with_state(
+    //         framework,
+    //         user,
+    //         44_000_000,
+    //         automation_fee_cap,
+    //         task_exipry_time,
+    //         ACTIVE);
+    //     let task2 = register_with_state(
+    //         framework,
+    //         user,
+    //         44_000_000,
+    //         automation_fee_cap,
+    //         task_exipry_time,
+    //         CANCELLED);
+    //     let task3 = register_with_state(
+    //         framework,
+    //         user,
+    //         11_000_000,
+    //         automation_fee_cap,
+    //         task_exipry_time,
+    //         PENDING);
+    //     let registration_charges = 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+    //     let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
+    //     let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
+    //
+    //
+    //     // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+    //     let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+    //     // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+    //     let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+    //
+    //     let fwk_address = address_of(framework);
+    //     let user_address = address_of(user);
+    //
+    //
+    //     // Set some locked fee which is enough to pay refund if necessary
+    //     set_locked_fee(framework, 100_000_000);
+    //
+    //     // Refund is expected only for the remaing time till the task expiry time for both cancelled and active tasks
+    //     // Task was expiring in the middle of the 3rd epoch, but epoch duration was cat short by 3/4
+    //     let current_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 4;
+    //     // update epoch-start-time to be 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS
+    //     {
+    //         let aei = borrow_global_mut<AutomationEpochInfo>(fwk_address);
+    //         aei.start_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
+    //     };
+    //
+    //     let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
+    //     let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
+    //     let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
+    //     let aei = borrow_global<AutomationEpochInfo>(fwk_address);
+    //
+    //     check_account_balance(user_address, expected_user_current_balance);
+    //     check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+    //
+    //     let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, current_time);
+    //     consume_intermediate_state(result);
+    //     // It is expected that the tasks will be chared only for 1/2 epoch fee, so if the epoch lenght is 1/4,
+    //     // then refund should be 1/4.
+    //     // as account has 2 tasks with same automation and congestion fees then refund is double
+    //     // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
+    //     let expected_refund = (expected_congestion_fee_per_task + expected_automation_fee_per_task) / 2
+    //             + automation_fee_cap; // refund of the depodit for cancelled task
+    //
+    //     expected_user_current_balance = expected_user_current_balance + expected_refund;
+    //     expected_registry_current_balance = expected_registry_current_balance - expected_refund;
+    //
+    //     check_task_state(ar, task1, exists, ACTIVE);
+    //     check_task_state(ar, task2, !exists, CANCELLED);
+    //     // Task state is still pending, tasks will be activated after their epoch-fee is calculated
+    //     check_task_state(ar, task3, exists, PENDING);
+    //
+    //     check_account_balance(user_address, expected_user_current_balance);
+    //     // // Check registry balance
+    //     check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+    // }
 
     #[test(framework = @supra_framework, user = @0x1cafb)]
     fun check_automation_task_fee_refund_is_done_with_old_config(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         config_buffer::initialize(framework);
         let t1_t2_max_gas = 44_000_000;
@@ -3148,7 +3214,7 @@ module supra_framework::automation_registry {
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, PENDING);
         // Set some locked fee which is enough to pay refund if necessary
         set_locked_fee(framework, 100_000_000);
-        update_config(framework,
+        update_config_v2(framework,
             TTL_UPPER_BOUND_TEST,
             AUTOMATION_MAX_GAS_TEST,
             AUTOMATION_BASE_FEE_TEST / 2,
@@ -3157,6 +3223,7 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST / 2,
             CONGESTION_EXPONENT_TEST - 1,
             TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
         // Disable feature in order to avoid charges and check only refunds.
         toggle_feature_flag(framework, false);
@@ -3210,7 +3277,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
 
@@ -3296,7 +3363,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation_for_short_tasks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let expiry_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
@@ -3376,7 +3443,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_calculation_with_zero_multipliers(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
 
@@ -3495,7 +3562,7 @@ module supra_framework::automation_registry {
     fun check_automation_task_fee_withdrawal_on_new_epoch(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 10_000_000;
@@ -3584,7 +3651,7 @@ module supra_framework::automation_registry {
     fun check_estimate_api(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig {
         initialize_registry_test(framework, user);
         let fwk_address = address_of(framework);
         let task_max_gas = 10_000_000;
@@ -3706,7 +3773,7 @@ module supra_framework::automation_registry {
     #[expected_failure(abort_code = ETASK_REGISTRATION_DISABLED, location = Self)]
     fun test_register_fails_when_registration_disabled(
         framework: &signer, user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         disable_registration(framework);
@@ -3727,7 +3794,7 @@ module supra_framework::automation_registry {
     fun check_task_successful_stopped(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -3857,7 +3924,7 @@ module supra_framework::automation_registry {
         framework: &signer,
         user: &signer,
         user2: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3876,7 +3943,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_stopped_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
 
         register(user,
@@ -3900,7 +3967,7 @@ module supra_framework::automation_registry {
     fun check_stopping_of_cancelled_task(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -3964,7 +4031,7 @@ module supra_framework::automation_registry {
     fun check_bookkeeping_refunds_and_unlocks(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
 
@@ -4131,7 +4198,7 @@ module supra_framework::automation_registry {
     fun task_registration_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         initialize_registry_test(framework, user);
         let count = 0;
         let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
@@ -4161,7 +4228,7 @@ module supra_framework::automation_registry {
     fun check_task_registration_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
         task_registration_performance(framework, user);
     }
 
@@ -4176,7 +4243,7 @@ module supra_framework::automation_registry {
     fun check_task_activation_on_new_epoch_performance(
         framework: &signer,
         user: &signer
-    ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleInfo {
         task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
@@ -4187,6 +4254,11 @@ module supra_framework::automation_registry {
         on_new_epoch();
         timestamp::update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         on_new_epoch();
+    }
+
+    #[test]
+    fun check_monitor_cycle_end() {
+        monitor_cycle_end()
     }
 
 }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -84,10 +84,12 @@ module supra_framework::automation_registry {
     const EDEPOSIT_REFUND: u64 = 27;
     /// Failed to unlock/refund epoch fee for a task. Internal error, for more details see emitted error events.
     const EEPOCH_FEE_REFUND: u64 = 28;
-    /// Deprecated function call since SUPRA_NATIVE_AUTOMATION_V2 release.
+    /// Deprecated function call since cycle based automation release.
     const EDEPRECATED_SINCE_V2: u64 = 29;
     /// Automation registry max gas capacity cannot be zero.
     const ECYCLE_DURATION_NON_ZERO: u64 = 30;
+    /// Attempt to do migration to cycle based automation which is already enabled.
+    const EINVALID_MIGRATION_ACTION: u64 = 31;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -181,7 +183,7 @@ module supra_framework::automation_registry {
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
-    /// Epoch state. Deprecated since SUPRA_NATIVE_AUTOMATION_V2 version.
+    /// Epoch state. Deprecated since SUPRA_CYCLE_BASED_AUTOMATION version.
     struct AutomationEpochInfo has key, copy {
         /// Epoch expected duration at the beginning of the new epoch, Based on this and actual
         /// epoch_duration which will be (current_time - last_reconfiguration_time) automation tasks
@@ -720,7 +722,7 @@ module supra_framework::automation_registry {
         });
     }
 
-    /// Initialization of Automation Registry with configuration parameters for SUPRA_NATIVE_AUTOMATION_V2 version.
+    /// Initialization of Automation Registry with configuration parameters for SUPRA_CYCLE_BASED_AUTOMATION version.
     /// Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
     /// automation feature is being introduced very first time.
     /// In case if framework upgrade is happening on the chain where automation feature is already released and
@@ -796,6 +798,7 @@ module supra_framework::automation_registry {
     public fun migrate_v2(supra_framework: &signer, cycle_duration_secs: u64
         ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleInfo {
         assert_supra_framework(supra_framework);
+        assert!(!features::supra_cycle_based_automation_enabled(), EINVALID_MIGRATION_ACTION);
 
         // Prepare the state for migration
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
@@ -818,7 +821,7 @@ module supra_framework::automation_registry {
         // Start migration by enabling feature, initializing the cycle releated resouces
         features::change_feature_flags_for_next_epoch(
             supra_framework,
-            vector[features::get_supra_native_automation_v2_feature()],
+            vector[features::get_supra_cycle_based_automation_feature()],
             vector[]);
         let id = 0;
         move_to(supra_framework, AutomationCycleInfo {
@@ -831,13 +834,25 @@ module supra_framework::automation_registry {
         on_cycle_end_internal();
     }
 
-    /// On new epoch caused by reconfiguration this function will be triggered and update the automation registry state
+    /// On new epoch caused by reconfiguration this function will be triggered and update the automation registry state.
+    /// If registry is not fully initialized nothing is done. Epoch change can be caused by governance action or by DKG
+    /// finalization. In case of the later case execution should not fail.
+    ///
+    /// If native automation feature is disabled then automation lifecycle is suspended. And detached managment will
+    /// initiate refund and cealnup actions.
+    ///
+    /// If native automation feature is enabled and automation lifecycle has been in suspended state,
+    /// then lifecycle is restarted.
     public(friend) fun on_new_epoch() acquires AutomationCycleInfo, ActiveAutomationRegistryConfig {
+        if (!is_initialized()) {
+            return
+        };
         let cycle_info = borrow_global_mut<AutomationCycleInfo>(@supra_framework);
         if (features::supra_native_automation_enabled()) {
             // If the lifecycle has been suspended and we are recovering from it, then we update config from buffer and
             // then start a new cycle directly
-            if ( cycle_info.state == LIFECYCLE_SUSPENDED) {
+            // TODO: check automation registry to be in empty state, otherwise emit an error event and remain in suspended state.
+            if (cycle_info.state == LIFECYCLE_SUSPENDED) {
                 move_to_started_state(cycle_info);
                 update_config_from_buffer();
             };
@@ -1798,7 +1813,7 @@ module supra_framework::automation_registry {
     }
 
     /// Update epoch interval in registry while actually update happens in block module
-    /// Deprecated since SUPRA_NATIVE_AUTOMATION_V2 feature release in favor of monitor_cycle_end
+    /// Deprecated since SUPRA_CYCLE_BASED_AUTOMATION feature release in favor of monitor_cycle_end
     public(friend) fun update_epoch_interval_in_registry(_epoch_interval_microsecs: u64) {
         assert!(false, EDEPRECATED_SINCE_V2);
     }
@@ -1808,7 +1823,7 @@ module supra_framework::automation_registry {
     public(friend) fun monitor_cycle_end() {
         // TODO: check is initialized, if not emit error but do not fail.
         // check if SUPRA_NATIVE_AUTOMATION feature is disabled or cycle state is suspended, do nothing
-        // call dummy native function which should be available if SUPRA_NATIVE_AUTOMATION_V2 is enabled.
+        // call dummy native function which should be available if SUPRA_CYCLE_BASED_AUTOMATION is enabled.
         //    - It does nothing , if binary is also updated, otherwise VM will panic causing block-prologue to
         //      fail resulting in node failure as well.
         // Otherwise if cycle_start + cycle_duration >= current time, mark the cycle as finished and update configs from buffer:
@@ -1841,10 +1856,10 @@ module supra_framework::automation_registry {
 
     fun downscale_to_u256(value: u256): u256 { value / DECIMAL }
 
-    /// If SUPRA_NATIVE_AUTOMATION_V2 is enabled then call native function to assert full support of cycle based
+    /// If SUPRA_CYCLE_BASED_AUTOMATION is enabled then call native function to assert full support of cycle based
     /// automation registry management.
     fun assert_cycle_based_automation_registry_management_support() {
-        if (features::supra_native_automation_v2_enabled()) {
+        if (features::supra_cycle_based_automation_enabled()) {
             native_cycle_based_automation_registry_management_support();
         }
     }

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -25,8 +25,6 @@ module supra_framework::automation_registry {
     #[test_only]
     use std::signer::address_of;
     #[test_only]
-    use aptos_std::debug::print;
-    #[test_only]
     use supra_framework::timestamp::update_global_time_for_test_secs;
 
     friend supra_framework::block;
@@ -91,7 +89,7 @@ module supra_framework::automation_registry {
     const EEPOCH_FEE_REFUND: u64 = 28;
     /// Deprecated function call since cycle based automation release.
     const EDEPRECATED_SINCE_V2: u64 = 29;
-    /// Automation registry max gas capacity cannot be zero.
+    /// Automation cycle duration cannot be zero.
     const ECYCLE_DURATION_NON_ZERO: u64 = 30;
     /// Attempt to do migration to cycle based automation which is already enabled.
     const EINVALID_MIGRATION_ACTION: u64 = 31;
@@ -99,12 +97,6 @@ module supra_framework::automation_registry {
     const ECYCLE_TRANSITION_IN_PROGRESS: u64 = 32;
     /// Attempt to run operation in invalid registry state.
     const EINVALID_REGISTRY_STATE: u64 = 33;
-    /// Attempt to run charge action with inconsistent input values compared to internal state, or with cancelled task.
-    const EINVALID_CHARGE_ACTION: u64 = 34;
-    /// Attempt to run refund action with duration more than cycle duration is.
-    const EINVALID_REFUND_DURATION: u64 = 35;
-    /// Attempt to drop task which is still valid
-    const EINVALID_DROP_ACTION: u64 = 36;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -127,13 +119,13 @@ module supra_framework::automation_registry {
     const CANCELLED: u8 = 2;
 
     /// Constants describing CYCLE state.
-    /// State transition flaw is:
+    /// State transition flow is:
     /// CYCLE_READY -> CYCLE_STARTED
     /// CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
-    /// CYCLE_FINISHED ->  { CYCLE_STARTED}
-    /// CYCLE_SUSPENDED ->  {CYCLE_READY, STARTED}
+    /// CYCLE_FINISHED ->  CYCLE_STARTED
+    /// CYCLE_SUSPENDED -> { CYCLE_READY, STARTED }
     const CYCLE_READY: u8 = 0;
-    /// Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by autoamtion cycle manager in native layer.
+    /// Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by registry when cycle transition is completed.
     const CYCLE_STARTED: u8 = 1;
     /// Triggered when cycle end is identified.
     const CYCLE_FINISHED: u8 = 2;
@@ -207,20 +199,21 @@ module supra_framework::automation_registry {
     }
 
     /// It tracks entries both pending and completed, organized by unique indices.
+    /// Holds intermediate state data of the automation cycle transition from END->STARTED, or SUSPENDED->READY
     struct TransitionState has copy, drop, store {
-        /// Remaining duration if cycle was kept short. Actual only in case of suspention.
+        /// Refund duration of automation fees when automation feature/cycle is suspended.
         refund_duration: u64,
-        /// Duration of the new cycle.
+        /// Duration of the new cycle to charge fees for.
         new_cycle_duration: u64,
-        /// Calculated automation fee per second for the new cycle.
+        /// Calculated automation fee per second for a new cycle or for refund period.
         automation_fee_per_sec: u64,
         /// Gas committed for the new cycle being transitioned.
         gas_committed_for_new_cycle: u64,
-        /// Gas committed for next cycle
+        /// Gas committed for the next cycle.
         gas_committed_for_next_cycle: u64,
-        /// Total fee charged to users during the cycle, which is not withdrawable
+        /// Total fee charged from users for the new cycle, which is not withdrawable.
         locked_fees: u64,
-        /// Number of the tasks to be processed during transition.
+        /// List of the tasks to be processed during transition.
         expected_tasks_to_be_processed: vector<u64>,
         /// So far processed tasks during transition
         /// In case if transition spans between multiple blocks then
@@ -233,10 +226,6 @@ module supra_framework::automation_registry {
     }
     fun is_transition_in_progress(state: &TransitionState): bool {
         vector::length(&state.actual_processed_tasks) != 0
-    }
-
-    fun update_processed_tasks(state: &mut TransitionState, task_indexes: vector<u64>) {
-        vector::append(&mut state.actual_processed_tasks, task_indexes);
     }
 
     fun append_processed_task(state: &mut TransitionState, task_index: u64) {
@@ -270,9 +259,9 @@ module supra_framework::automation_registry {
         duration_secs: u64,
     }
 
-    /// Cycle state.
+    /// Provides information of the current cycle state.
     struct AutomationCycleInfo has copy, drop, store {
-        /// Current cycle id. Incremented when a start of the new cycle is processed.
+        /// Current cycle id. Incremented when a start of a new cycle is given.
         index: u64,
         /// State of the current cycle.
         state: u8,
@@ -283,7 +272,7 @@ module supra_framework::automation_registry {
     }
 
     #[event]
-    /// Event emitted in the cycle-state.
+    /// Event emitted for cycle state transition.
     struct AutomationCycleEvent has copy, drop, store {
         /// Updated cycle state information.
         cycle_state_info: AutomationCycleInfo,
@@ -302,7 +291,7 @@ module supra_framework::automation_registry {
         state: u8,
         /// Current cycle start time which is updated with the current chain time when a cycle is increamented.
         start_time: u64,
-        /// Automation cycle duration in seconds.
+        /// Automation cycle duration in seconds for the current cycle.
         duration_secs: u64,
         /// Intermediate state of cycle transition to next one or suspended state.
         transition_state: std::option::Option<TransitionState>,
@@ -726,7 +715,7 @@ module supra_framework::automation_registry {
     /// Calculates automation fee per second for the current cycle
     /// referencing the current automation registry fee parameters, and committed gas for this cycle stored in
     /// the automation registry and current maximum allowed occupancy.
-    public fun calculate_automation_fee_unit_for_current_cycle(): u64 acquires ActiveAutomationRegistryConfig, AutomationRegistry {
+    public fun calculate_automation_fee_multiplier_for_current_cycle(): u64 acquires ActiveAutomationRegistryConfig, AutomationRegistry {
         // Compute the automation fee multiplier for this cycle
         let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
@@ -746,7 +735,7 @@ module supra_framework::automation_registry {
     }
 
     #[view]
-    /// Returns the current status of the registration in the automation registry.
+    /// Returns the current cycle info.
     public fun get_cycle_info(): AutomationCycleInfo acquires AutomationCycleDetails {
         let details = borrow_global<AutomationCycleDetails>(@supra_framework);
         into_automation_cycle_info(details)
@@ -812,7 +801,7 @@ module supra_framework::automation_registry {
         let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
 
         assert!(
-            automation_registry.gas_committed_for_next_epoch < registry_max_gas_cap,
+            automation_registry.gas_committed_for_next_epoch <= registry_max_gas_cap,
             EUNACCEPTABLE_AUTOMATION_GAS_LIMIT
         );
 
@@ -1039,7 +1028,7 @@ module supra_framework::automation_registry {
 
     /// API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
     /// detached from epoch-change and cycle based lifecycle of the automation registry is enabled.
-    /// IMPORTANT: Should alwasy be followed by `SUPRA_AUTOMATION_CYCLE` feature flag being enabled and
+    /// IMPORTANT: Should always be followed by `SUPRA_AUTOMATION_CYCLE` feature flag being enabled and
     /// supra_governance::reconfiguration otherwise registry/chain will end-up in inconsistent state.
     ///
     /// monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
@@ -1069,7 +1058,7 @@ module supra_framework::automation_registry {
             current_time
         );
 
-        // Start migration by enabling feature, initializing the cycle releated resouces
+        // Initializing the cycle releated resouces
         let id = 0;
         move_to(supra_framework, AutomationCycleDetails {
             start_time: current_time,
@@ -1078,7 +1067,7 @@ module supra_framework::automation_registry {
             state: CYCLE_READY,
             transition_state: std::option::none()
         });
-        // Remain in CYCLE_READY statey if feature is not enabled or registry is not fully initialized
+        // Remain in CYCLE_READY state if feature is not enabled or registry is not fully initialized
         if (!is_feature_enabled_and_initialized()) {
             return
         };
@@ -1089,29 +1078,12 @@ module supra_framework::automation_registry {
 
     // Public friend api
 
-    /// Initialization of Automation Registry with configuration parameters is expected metrics.
-    /// Deprecated in favor of initialize_v2
-    public(friend) fun initialize(
-        _supra_framework: &signer,
-        _epoch_interval_secs: u64,
-        _task_duration_cap_in_secs: u64,
-        _registry_max_gas_cap: u64,
-        _automation_base_fee_in_quants_per_sec: u64,
-        _flat_registration_fee_in_quants: u64,
-        _congestion_threshold_percentage: u8,
-        _congestion_base_fee_in_quants_per_sec: u64,
-        _congestion_exponent: u8,
-        _task_capacity: u16,
-    ) {
-        assert!(false, EDEPRECATED_SINCE_V2);
-    }
-
     /// Initialization of Automation Registry with configuration parameters for SUPRA_AUTOMATION_CYCLE version.
     /// Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
-    /// automation feature is being introduced very first time.
-    /// In case if framework upgrade is happening on the chain where automation feature is already released and
-    /// is in ongoing state, then migrate_v2 function should be utilized instead.
-    public(friend) fun initialize_v2(
+    /// automation feature is being introduced very first time utilizing `genesis::initialize_supra_native_automation_v2`.
+    /// In case if framework upgrade is happening on the chain where automation feature with epoch based lifecycle is
+    /// already released and is in ongoing state, then `migrate_v2` function should be utilized instead.
+    public(friend) fun initialize(
         supra_framework: &signer,
         cycle_duration_secs: u64,
         task_duration_cap_in_secs: u64,
@@ -1181,7 +1153,7 @@ module supra_framework::automation_registry {
     }
 
     /// Checks the cycle end and emit an event on it.
-    /// Does nothig if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
+    /// Does nothing if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
     public(friend) fun monitor_cycle_end() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
         if (!is_feature_enabled_and_initialized() || !features::supra_automation_cycle_enabled()) {
             return
@@ -1195,14 +1167,20 @@ module supra_framework::automation_registry {
         on_cycle_end_internal(cycle_info)
     }
 
-    /// On new epoch caused by reconfiguration this function will be triggered and update the automation registry state.
-    /// If registry is not fully initialized nothing is done. Epoch change can be caused by governance action or by DKG
-    /// finalization. In case of the later case execution should not fail.
+    /// On new epoch will be triggered for automation registry caused by `supra_governance::reconfiguration` or DKG finalization
+    /// to update the automation registry state depending on SUPRA_NATIVE_AUTOMATION feature flag state.
     ///
-    /// If native automation feature is disabled then automation lifecycle is suspended. And detached managment will
-    /// initiate refund and cealnup actions.
+    /// If registry is not fully initialized nothing is done.
     ///
-    /// If native automation feature is enabled and automation lifecycle has been in suspended state,
+    /// If native automation feature is disabled and automation cycle in CYCLE_STARTED state,
+    /// then automation lifecycle is suspended immediately. And detached managment will
+    /// initiate reprocessing of the available tasks which will end up in refund and cealnup actions.
+    ///
+    /// Otherwise suspention is postponed untill the end of the transition state.
+    ///
+    /// Nothing will be done if automation cycle was already suspneded, i.e. in CYCLE_READY state.
+    ///
+    /// If native automation feature is enabled and automation lifecycle has been in CYCLE_READY state,
     /// then lifecycle is restarted.
     public(friend) fun on_new_epoch() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
         if (!is_initialized()) {
@@ -1228,7 +1206,8 @@ module supra_framework::automation_registry {
         };
 
         // We do not update config here, as due to feature being disabled, cycle ends early so it is expected
-        // that native layer will detect this state and generate refund transactions for a cycle that has been kept short.
+        // that the current fee-parameters will be used to calculate automation-fee for refund for a cycle
+        // that has been kept short.
         // So the confing should remain intact.
         if (cycle_info.state == CYCLE_STARTED) {
             try_move_to_suspended_state(registry_data, cycle_info);
@@ -1353,20 +1332,29 @@ module supra_framework::automation_registry {
         system_addresses::assert_vm(&vm);
         let cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
         if (cycle_info.state == CYCLE_FINISHED) {
-            on_cycle_transition(vm, task_indexes);
+            on_cycle_transition(task_indexes);
             return
         };
         assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
-        on_cycle_suspend(vm, task_indexes);
+        on_cycle_suspend(task_indexes);
     }
 
     // Private helper functions
 
-    fun on_cycle_transition(vm: signer, task_indexes: vector<u64>)
+    /// Traverses the list of the tasks and based on the task state and expiry information either charges or drops
+    /// the task after refunding eligable fees
+    ///
+    /// Tasks are cheked not to be processed more than once.
+    /// This function should be called only if registry is in CYCLE_FINISHED state, meaning a normal cycle transition is
+    /// happening.
+    ///
+    /// After processing all input tasks, intermediate transition state is updated and transition end is check
+    /// (whether all expected tasks has been processed already).
+    ///
+    /// In case if transition end is detected a start of the new cycle is given
+    /// (if during trasition period suspention is not requested) and corresponding event is emitted.
+    fun on_cycle_transition(task_indexes: vector<u64>)
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
-        // Operational constraint: can only be invoked by the VM
-        system_addresses::assert_vm(&vm);
-
         if (vector::is_empty(&task_indexes)) {
             return
         };
@@ -1416,10 +1404,15 @@ module supra_framework::automation_registry {
         }
     }
 
-    fun on_cycle_suspend(vm: signer, task_indexes: vector<u64> )
+    /// Traverses the list of the tasks and refunds automation(if not PENDING) and depoist fees for all tasks
+    /// and removes from registry.
+    ///
+    /// This function is called only if automation feature is disabled, i.e. CYCLE_SUSPENDED state.
+    ///
+    /// After processing input set of tasks the end of suspention process is checked(i.e. all expected tasks has been processed).
+    /// In case if end is identified the registry state is update to CYCLE_READY and corresponding event is emitted.
+    fun on_cycle_suspend(task_indexes: vector<u64> )
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
-        // Operational constraint: can only be invoked by the VM
-        system_addresses::assert_vm(&vm);
 
         if (vector::is_empty(&task_indexes)) {
             return
@@ -1518,6 +1511,7 @@ module supra_framework::automation_registry {
     }
 
     /// Drops or charges the input task.
+    /// If the task is already processed or missing from the registry then nothing is done.
     fun drop_or_charge_task(
         task_index: u64,
         automation_registry: &mut AutomationRegistry,
@@ -1601,12 +1595,17 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
-    /// moves to the next state.
-    /// As transition happens from suspended state and while transition was in progress the feature was enabled back,
-    /// then the transition will happend direclty to starated state, otherwise the transition will be done to the ready state.
-    /// In both cases config will be updated. In this case we will make sure to keep the consistency of state when transition to ready state happens
-    /// through path Started -> Suspended -> Ready or Started-> {Finished, Suspended} -> Ready or Started -> Finished -> {Started, Suspended}
+    /// Updates the cycle state if the transition is identified to be finalized.
+    ///
+    /// As transition happens from suspended state and while transition was in progress
+    ///    - if the feature was enabled back, then the transition will happend direclty to starated state,
+    ///    - otherwise the transition will be done to the ready state.
+    ///
+    /// In both cases config will be updated. In this case we will make sure to keep the consistency of state
+    /// when transition to ready state happens through paths
+    ///  - Started -> Suspended -> Ready
+    ///  - or Started-> {Finished, Suspended} -> Ready
+    ///  - or Started -> Finished -> {Started, Suspended}
     fun update_cycle_transition_state_from_suspended(
         automation_registry: &mut AutomationRegistry,
         cycle_info: &mut AutomationCycleDetails,
@@ -1630,11 +1629,14 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Updates the transition state with newly processed tasks and if transition is identified to be finalized, then
-    /// moves to the next state.
-    /// First it moves to the next cycle. But if happened so that there was a suspension during cycle transition which was ignored,
+    /// Updates the cycle state if the transition is identified to be finalized.
+    ///
+    /// From CYCLE_FINALIZED state we always move to the next cycle and in CYCLE_STARTED state.
+    ///
+    /// But if it happened so that there was a suspension during cycle transition which was ignored,
     /// then immediately cycle state is updated to suspended.
-    /// Expectation will be that native layer catches this double transition and will issue refunds for the new cycle
+    ///
+    /// Expectation will be that native layer catches this double transition and issues refunds for the new cycle fees
     /// which will not proceeded farther in any case.
     fun update_cycle_transition_state_from_finished(
         automation_registry: &mut AutomationRegistry,
@@ -1645,22 +1647,24 @@ module supra_framework::automation_registry {
         let transition_state = std::option::borrow(&cycle_info.transition_state);
         let transition_finalized = is_transition_finalized(transition_state);
 
-        if (transition_finalized) {
-            automation_registry.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
-            automation_registry.gas_committed_for_this_epoch = (transition_state.gas_committed_for_new_cycle as u256);
-            automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
-            automation_registry.epoch_locked_fees = transition_state.locked_fees;
-
-            // Set current timestamp as cycle start_time
-            // Increase cycle and update the state to Started
-            move_to_started_state(cycle_info);
-            if (!vector::is_empty(&automation_registry.epoch_active_task_ids)) {
-                event::emit(ActiveTasks {
-                    task_indexes: automation_registry.epoch_active_task_ids
-                });
-            }
+        if (!transition_finalized) {
+            return
         };
-        if (transition_finalized  && !features::supra_native_automation_enabled()) {
+
+        automation_registry.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
+        automation_registry.gas_committed_for_this_epoch = (transition_state.gas_committed_for_new_cycle as u256);
+        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
+        automation_registry.epoch_locked_fees = transition_state.locked_fees;
+
+        // Set current timestamp as cycle start_time
+        // Increase cycle and update the state to Started
+        move_to_started_state(cycle_info);
+        if (!vector::is_empty(&automation_registry.epoch_active_task_ids)) {
+            event::emit(ActiveTasks {
+                task_indexes: automation_registry.epoch_active_task_ids
+            });
+        };
+        if (!features::supra_native_automation_enabled()) {
             try_move_to_suspended_state(automation_registry, cycle_info)
         }
     }
@@ -1737,10 +1741,12 @@ module supra_framework::automation_registry {
         };
         cycle_info.transition_state = std::option::some(transition_state);
         // During cycle transition we update config only after transition state is created in order to have new cycle
-        // duration as transition parameter.
+        // duration as transition state parameter.
         update_config_from_buffer(cycle_info);
         // Calculate automation fee per second for the new epoch only after configuration is updated.
         let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+        // As we already know the committed gas for the new cycle it is being calculated using updated fee-parameters
+        // and will be used to charge tasks during transition process.
         transition_state.automation_fee_per_sec =
             calculate_automation_fee_multiplier_for_committed_occupancy(transition_state.gas_committed_for_new_cycle);
         update_cycle_state_to(cycle_info, CYCLE_FINISHED);
@@ -1774,7 +1780,7 @@ module supra_framework::automation_registry {
 
     /// Transition to suspended state is expected to be called
     ///   a) when cycle is active and in progress
-    ///     - here we do simply move to suspended state so native layer can start requesting tasks processing
+    ///     - here we simply move to suspended state so native layer can start requesting tasks processing
     ///       which will end up in  refunds and cleanup. Note that refund will be done based on total gas-committed
     ///       for the current cycle defined at the begining for the cycle, and using current automation fee parameters
     ///   b) when cycle has just finished and there was another transaction causing feature suspension
@@ -1794,11 +1800,23 @@ module supra_framework::automation_registry {
             return
         };
         if (std::option::is_none(&cycle_info.transition_state)) {
-            assert!(timestamp::now_seconds() >= cycle_info.start_time, EINVALID_REGISTRY_STATE);
+            // Indicates that cycle was in STARTED state when suspention has been identified.
+            // It is safe to assert that cycle_end_time will always be greater than current chain time as
+            // the cycle end is check in the block metadata txn execution which proceeds any other transaction in the block.
+            // Including the transaction which caused transition to suspended state.
+            // So in case if cycle_end_time < current_time then cycle end would have been identified
+            // and we would have enterend else branch instead.
+            // This holds true even if we identified suspention when moving from FINALIZED->STARTED state.
+            // As in this case we will first transition to the STARTED state and only then to SUSPENDED.
+            // And when transition to STARTED state we update the cycle start-time to be the current-chain-time.
+            let current_time = timestamp::now_seconds();
+            let cycle_end_time = cycle_info.start_time + cycle_info.duration_secs;
+            assert!(current_time >= cycle_info.start_time, EINVALID_REGISTRY_STATE);
+            assert!(current_time < cycle_end_time, EINVALID_REGISTRY_STATE);
             assert!(cycle_info.state == CYCLE_STARTED, EINVALID_REGISTRY_STATE);
             let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
             let transition_state = TransitionState {
-                refund_duration: cycle_info.duration_secs + cycle_info.start_time - timestamp::now_seconds(),
+                refund_duration: cycle_end_time - current_time,
                 new_cycle_duration: cycle_info.duration_secs,
                 automation_fee_per_sec: calculate_automation_fee_multiplier_for_current_cycle_internal(active_config, automation_registry),
                 gas_committed_for_new_cycle: 0,
@@ -2159,7 +2177,7 @@ module supra_framework::automation_registry {
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         resource_signer: &signer,
         task: AutomationTaskFeeMeta,
-        current_epoch_end_time: u64,
+        current_cycle_end_time: u64,
         intermediate_state: &mut IntermediateStateOfEpochChange) {
         // Remove the automation task if the epoch fee cap is exceeded
         // It might happen that task has been expired by the time charging is being done.
@@ -2210,7 +2228,7 @@ module supra_framework::automation_registry {
         });
 
         // Calculate gas commitment for the next epoch only for valid active tasks
-        if (task.expiry_time > current_epoch_end_time) {
+        if (task.expiry_time > current_cycle_end_time) {
             intermediate_state.gas_committed_for_next_epoch = intermediate_state.gas_committed_for_next_epoch + task.max_gas_amount;
         };
     }
@@ -2270,7 +2288,7 @@ module supra_framework::automation_registry {
         let task_duration = expiry_time - registration_time;
         assert!(task_duration <= automation_registry_config.task_duration_cap_in_secs, EEXPIRY_TIME_UPPER);
 
-        // Check that task is valid at least in the next epoch
+        // Check that task is valid at least in the next cycle
         assert!(
             expiry_time > (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
             EEXPIRY_BEFORE_NEXT_CYCLE
@@ -2354,7 +2372,7 @@ module supra_framework::automation_registry {
 
         let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
 
-        initialize_v2(
+        initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             TTL_UPPER_BOUND_TEST,
@@ -2559,7 +2577,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_task_duration(
         supra_framework: &signer,
     ) {
-        initialize_v2(
+        initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2578,7 +2596,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_registry_max_gas_cap(
         supra_framework: &signer,
     ) {
-        initialize_v2(
+        initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2597,7 +2615,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_congestion_exponent(
         supra_framework: &signer,
     ) {
-        initialize_v2(
+        initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2616,7 +2634,7 @@ module supra_framework::automation_registry {
     fun test_initialization_with_invalid_threshold_percentage(
         supra_framework: &signer,
     ) {
-        initialize_v2(
+        initialize(
             supra_framework,
             EPOCH_INTERVAL_FOR_TEST_IN_SECS,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
@@ -2715,6 +2733,35 @@ module supra_framework::automation_registry {
         assert!(transition_state.new_cycle_duration  == 1000, 7);
     }
 
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun check_automation_gas_limit_update_corner_case(
+        framework: &signer, user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        register(user,
+            PAYLOAD,
+            86400,
+            50,
+            20,
+            1000,
+            PARENT_HASH,
+            AUX_DATA
+        );
+
+        // Next epoch gas committed gas is greater than the new limit value.
+        update_config_v2(
+            framework,
+            TTL_UPPER_BOUND_TEST,
+            50,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
+        );
+    }
     #[test(framework = @supra_framework, user = @0x1cafe)]
     #[expected_failure(abort_code = EUNACCEPTABLE_AUTOMATION_GAS_LIMIT, location = Self)]
     fun check_automation_gas_limit_failed_update(
@@ -3992,7 +4039,7 @@ module supra_framework::automation_registry {
         on_new_epoch();
 
         let expected_remaining_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS - timestamp::now_seconds();
-        let expected_automation_fee_multiplier = calculate_automation_fee_unit_for_current_cycle();
+        let expected_automation_fee_multiplier = calculate_automation_fee_multiplier_for_current_cycle();
 
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -4105,7 +4152,7 @@ module supra_framework::automation_registry {
         on_new_epoch();
 
         let expected_remaining_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS - timestamp::now_seconds();
-        let expected_automation_fee_multiplier = calculate_automation_fee_unit_for_current_cycle();
+        let expected_automation_fee_multiplier = calculate_automation_fee_multiplier_for_current_cycle();
 
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -5494,10 +5541,11 @@ module supra_framework::automation_registry {
         initialize_registry_test(framework, user);
         let count = 0;
         let exp_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        while (count < 500) {
+        let max_task_count = (TASK_CAPACITY_TEST as u64);
+        while (count < max_task_count) {
             register(user,
                 PAYLOAD,
-                exp_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS * (count / 2),
+                exp_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS * (count % 2),
                 10000,
                 20,
                 1000000,
@@ -5508,7 +5556,7 @@ module supra_framework::automation_registry {
         };
 
         // No active task and committed gas for the next epoch is total of the all registered tasks
-        assert!(10000 * 500 == get_gas_committed_for_next_epoch(), 1);
+        assert!(10000 * max_task_count == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
         assert!(active_task_ids == vector[], 1);
     }
@@ -5532,6 +5580,28 @@ module supra_framework::automation_registry {
     //  - 1/3 of epoch passed to simulate refund, but tasks are still active
     //  - last epoch identifies all tasks are expired
     // #[test(framework = @supra_framework, user = @0x1cafe)]
+    fun process_tasks_in_batch_performance(
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        let task_indexes = get_task_ids();
+        let count = vector::length(&task_indexes);
+        let i = 0;
+        let batch = 25;
+        while (i < count) {
+            let vm_signer = create_signer(@vm_reserved);
+            let task_partition = vector::range(i, i + batch);
+            process_tasks(vm_signer, task_partition);
+            i = i + batch;
+        };
+    }
+
+    // #[test_only]
+    // Kept only for performance analysis intentions
+    // Register 500 tasks with 1.5 EPOCH_INTERVAL duration/expiration time
+    // And run 3 epochs to check gas-used when
+    //  - full epoch passed
+    //  - 1/3 of epoch passed to simulate refund, but tasks are still active
+    //  - last epoch identifies all tasks are expired
+    #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_task_activation_on_new_epoch_performance(
         framework: &signer,
         user: &signer
@@ -5539,13 +5609,18 @@ module supra_framework::automation_registry {
         task_registration_performance(framework, user);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
+        monitor_cycle_end();
+        process_tasks_in_batch_performance();
+
         timestamp::update_global_time_for_test_secs(
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
-        on_new_epoch();
-        timestamp::update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
+        monitor_cycle_end();
+        process_tasks_in_batch_performance();
+
+        timestamp::update_global_time_for_test_secs(3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        process_tasks_in_batch_performance();
     }
 
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -8,7 +8,6 @@ module supra_framework::automation_registry {
     use std::signer;
     use std::vector;
     use aptos_std::math64;
-    use supra_framework::automation_registry;
     use supra_framework::system_addresses::assert_supra_framework;
     use supra_framework::coin::Coin;
 
@@ -25,6 +24,8 @@ module supra_framework::automation_registry {
 
     #[test_only]
     use std::signer::address_of;
+    #[test_only]
+    use aptos_std::debug::print;
     #[test_only]
     use supra_framework::timestamp::update_global_time_for_test_secs;
 
@@ -208,7 +209,7 @@ module supra_framework::automation_registry {
     /// It tracks entries both pending and completed, organized by unique indices.
     struct TransitionState has copy, drop, store {
         /// Remaining duration if cycle was kept short. Actual only in case of suspention.
-        remaining_cycle_duration: u64,
+        refund_duration: u64,
         /// Duration of the new cycle.
         new_cycle_duration: u64,
         /// Calculated automation fee per second for the new cycle.
@@ -1048,6 +1049,7 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleDetails {
         assert_supra_framework(supra_framework);
         assert!(!features::supra_automation_cycle_enabled(), EINVALID_MIGRATION_ACTION);
+        assert!(exists<AutomationEpochInfo>(@supra_framework), EINVALID_MIGRATION_ACTION);
 
         // Prepare the state for migration
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
@@ -1083,7 +1085,6 @@ module supra_framework::automation_registry {
         // Emit cycle end which will lead the native layer to start preparation to the new cycle.
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         on_cycle_end_internal(cycle_info);
-
     }
 
     // Public friend api
@@ -1160,11 +1161,12 @@ module supra_framework::automation_registry {
             registration_enabled: true,
         });
 
-        let (cycle_state, cycle_id) = if (features::supra_automation_cycle_enabled()) {
-            (CYCLE_STARTED, 1)
-        } else {
-            (CYCLE_READY, 0)
-        };
+        let (cycle_state, cycle_id) =
+            if (features::supra_automation_cycle_enabled() && features::supra_native_automation_enabled()) {
+                (CYCLE_STARTED, 1)
+            } else {
+                (CYCLE_READY, 0)
+            };
 
         move_to(supra_framework, AutomationCycleDetails {
             start_time: timestamp::now_seconds(),
@@ -1229,12 +1231,12 @@ module supra_framework::automation_registry {
         // that native layer will detect this state and generate refund transactions for a cycle that has been kept short.
         // So the confing should remain intact.
         if (cycle_info.state == CYCLE_STARTED) {
-            move_to_suspended_state(registry_data, cycle_info);
+            try_move_to_suspended_state(registry_data, cycle_info);
         } else if (cycle_info.state == CYCLE_FINISHED && std::option::is_some(&cycle_info.transition_state)) {
             let trasition_state = std::option::borrow(&cycle_info.transition_state);
             if (!is_transition_in_progress(trasition_state)) {
                 // Just entered cycle-end phase, and meanwhile also feature has been disabled so it is safe to move to suspended state.
-                move_to_suspended_state(registry_data, cycle_info);
+                try_move_to_suspended_state(registry_data, cycle_info);
             }
             // Otherwise wait of the cycle transition to end and then feature flag value will be taken into account.
         }
@@ -1343,55 +1345,24 @@ module supra_framework::automation_registry {
         event::emit(automation_task_metadata);
     }
 
-    /// Called by MoveVm on `AutomationBookkeepingAction::Drop` action emitted by native layer ahead of cycle transition
-    fun on_drop(vm: signer, task_indexes: vector<u64>
+
+    /// Called by MoveVm on `AutomationBookkeepingAction::Process` action emitted by native layer ahead of cycle transition
+    fun process_tasks(vm: signer, task_indexes: vector<u64>
     ) acquires AutomationCycleDetails, AutomationRegistry, AutomationRefundBookkeeping, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
-        if (vector::is_empty(&task_indexes)) {
+        let cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
+        if (cycle_info.state == CYCLE_FINISHED) {
+            on_cycle_transition(vm, task_indexes);
             return
         };
-
-        let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
-        assert!(cycle_info.state == CYCLE_FINISHED, EINVALID_REGISTRY_STATE);
-        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
-
-        let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-
-        let current_time = timestamp::now_seconds();
-        let transaction_state = std::option::borrow_mut(&mut cycle_info.transition_state);
-        let removed_tasks = vector[];
-        vector::for_each(task_indexes, |task_index| {
-            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
-                assert!(task.state == CANCELLED || task.expiry_time <= current_time , EINVALID_DROP_ACTION);
-
-                safe_deposit_refund(
-                    refund_bookkeeping,
-                    &resource_signer,
-                    automation_registry.registry_fee_address,
-                    task_index,
-                    task.owner,
-                    task.locked_fee_for_next_epoch,
-                    task.locked_fee_for_next_epoch);
-                vector::push_back(&mut removed_tasks, task_index);
-                append_processed_task(transaction_state, task_index);
-            };
-        });
-
-        update_cycle_transition_state_from_finished(automation_registry, cycle_info);
-        event::emit(RemovedTasks {
-            task_indexes: removed_tasks
-        });
-
+        assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
+        on_cycle_suspend(vm, task_indexes);
     }
 
-    /// Called by MoveVm on `AutomationBookkeepingAction::Charge` action emitted by native layer ahead of cycle transition
-    fun on_charge(vm: signer, task_indexes: vector<u64>)
+    // Private helper functions
+
+    fun on_cycle_transition(vm: signer, task_indexes: vector<u64>)
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
@@ -1416,18 +1387,13 @@ module supra_framework::automation_registry {
             epoch_locked_fees: coin::zero()
         };
 
-        let charge_duration = transition_state.new_cycle_duration;
-        let automation_fee_per_sec = (transition_state.automation_fee_per_sec as u256);
-
-        try_charge_tasks_automation_fees(
+        drop_or_charge_tasks(
+            task_indexes,
             automation_registry,
             refund_bookkeeping,
             transition_state,
             &automation_registry_config.main_config,
-            automation_fee_per_sec,
-        charge_duration,
-        timestamp::now_seconds(),
-            task_indexes,
+            timestamp::now_seconds(),
             &mut intermedate_result
         );
         let IntermediateStateOfEpochChange {
@@ -1450,9 +1416,7 @@ module supra_framework::automation_registry {
         }
     }
 
-    /// Called by MoveVm on `AutomationBookkeepingAction::RefundAndCleanup` action.
-    /// Action from native layer will be tiggered by move layer when automation registy cycle is updated to SUSPENDED.
-    fun on_refund_and_cleanup(vm: signer, task_indexes: vector<u64> )
+    fun on_cycle_suspend(vm: signer, task_indexes: vector<u64> )
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
@@ -1482,11 +1446,11 @@ module supra_framework::automation_registry {
                 let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
 
                 // Do not attempt fee refund if remaining duration is 0
-                if (task.state != PENDING && transition_state.remaining_cycle_duration != 0) {
+                if (task.state != PENDING && transition_state.refund_duration != 0) {
                     let refund = calculate_task_fee(
                         &arc.main_config,
                         &task,
-                        transition_state.remaining_cycle_duration,
+                        transition_state.refund_duration,
                         current_time,
                         (transition_state.automation_fee_per_sec as u256));
                     let (_, remaining_epoch_locked_fees) = safe_fee_refund(
@@ -1518,7 +1482,115 @@ module supra_framework::automation_registry {
         });
     }
 
-    // Private helper functions
+    /// Traverses all input task indexes and either drops or tries to charge automation fee if possible.
+    fun drop_or_charge_tasks(
+        task_ids: vector<u64>,
+        automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        transition_state: &mut TransitionState,
+        arc: &AutomationRegistryConfig,
+        current_time: u64,
+        intermediate_state: &mut IntermediateStateOfEpochChange,
+    ) {
+
+        let resource_signer = account::create_signer_with_capability(
+            &automation_registry.registry_fee_address_signer_cap
+        );
+        let current_cycle_end_time = current_time + transition_state.new_cycle_duration;
+
+        // Sort task indexes to charge automation fees in the tasks chronological order
+        sort_vector(&mut task_ids);
+
+        // Process each active task and calculate fee for the epoch for the tasks
+        vector::for_each(task_ids, |task_index| {
+            drop_or_charge_task(
+                task_index,
+                automation_registry,
+                refund_bookkeeping,
+                arc,
+                transition_state,
+                &resource_signer,
+                current_time,
+                current_cycle_end_time,
+                intermediate_state
+            )
+        });
+    }
+
+    /// Drops or charges the input task.
+    fun drop_or_charge_task(
+        task_index: u64,
+        automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        arc: &AutomationRegistryConfig,
+        transition_state: &mut TransitionState,
+        resource_signer: &signer,
+        current_time: u64,
+        current_cycle_end_time: u64,
+        intermediate_state: &mut IntermediateStateOfEpochChange,
+    )
+    {
+        if (already_processed(transition_state,task_index) || !enumerable_map::contains(&automation_registry.tasks, task_index)) {
+            return
+        };
+        append_processed_task(transition_state, task_index);
+        let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+        if (task_meta.state == CANCELLED || task_meta.expiry_time <= current_time) {
+            refund_deposit_and_drop(task_index, automation_registry, refund_bookkeeping, resource_signer, &mut intermediate_state.removed_tasks);
+            return
+        };
+
+        let fee= calculate_task_fee(
+            arc,
+            task_meta,
+            transition_state.new_cycle_duration,
+            current_time,
+            (transition_state.automation_fee_per_sec as u256));
+        // If the task reached this phase that means it is valid active task for the new epoch.
+        // During cleanup all expired tasks has been removed from the registry but the state of the tasks is not updated.
+        // As here we need to distinguish new tasks from already existing active tasks,
+        // as the fee calculation for them will be different based on their active duration in the epoch.
+        // For more details see calculate_task_fee function.
+        task_meta.state = ACTIVE;
+        let task = AutomationTaskFeeMeta {
+            task_index,
+            owner: task_meta.owner,
+            fee,
+            expiry_time: task_meta.expiry_time,
+            automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
+            max_gas_amount: task_meta.max_gas_amount,
+            locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
+        };
+        try_withdraw_task_automation_fee(
+            automation_registry,
+            refund_bookkeeping,
+            resource_signer,
+            task,
+            current_cycle_end_time,
+            intermediate_state
+        );
+    }
+
+    /// Refunds the deposit fee of the task and removes from registry.
+    fun refund_deposit_and_drop(
+        task_index: u64,
+        automation_registry: &mut AutomationRegistry,
+        refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        resource_signer: &signer,
+        removed_tasks: &mut vector<u64>
+
+    )  {
+        let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+        safe_deposit_refund(
+            refund_bookkeeping,
+            resource_signer,
+            automation_registry.registry_fee_address,
+            task_index,
+            task.owner,
+            task.locked_fee_for_next_epoch,
+            task.locked_fee_for_next_epoch);
+        vector::push_back(removed_tasks, task_index);
+    }
 
     fun into_automation_cycle_info(details: &AutomationCycleDetails): AutomationCycleInfo {
         AutomationCycleInfo {
@@ -1589,7 +1661,7 @@ module supra_framework::automation_registry {
             }
         };
         if (transition_finalized  && !features::supra_native_automation_enabled()) {
-            move_to_suspended_state(automation_registry, cycle_info)
+            try_move_to_suspended_state(automation_registry, cycle_info)
         }
     }
 
@@ -1654,7 +1726,7 @@ module supra_framework::automation_registry {
             return
         };
         let transition_state = TransitionState {
-            remaining_cycle_duration: 0,
+            refund_duration: 0,
             new_cycle_duration: cycle_info.duration_secs,
             automation_fee_per_sec: 0,
             gas_committed_for_new_cycle: automation_registry.gas_committed_for_next_epoch,
@@ -1700,16 +1772,21 @@ module supra_framework::automation_registry {
         update_cycle_state_to(cycle_info, CYCLE_STARTED)
     }
 
-    /// Transition to suspended state is expected
+    /// Transition to suspended state is expected to be called
     ///   a) when cycle is active and in progress
-    ///     - here we do simply move to suspended state so native layer can start requesting refunds and cleanup actions
+    ///     - here we do simply move to suspended state so native layer can start requesting tasks processing
+    ///       which will end up in  refunds and cleanup. Note that refund will be done based on total gas-committed
+    ///       for the current cycle defined at the begining for the cycle, and using current automation fee parameters
     ///   b) when cycle has just finished and there was another transaction causing feature suspension
     ///     - as this both events happen in scope of the same block, then we will simply update the state to suspended
-    ///       and the native layer should identify this and request refund and cleanup with 0 fee and 0 duration,
-    ///       which will lead to simply deposit refund and cleanup.
+    ///       and the native layer should identify the transition and request processing of the all available tasks.
+    ///       Note that in this case automation fee refund will not be expected and suspention and cycle end matched and
+    ///       no fee was yet charged to be refunded.
+    ///       So the duration for refund and automation-fee-per-second for refund will be 0
     ///   c) when cycle transition was in progress and there was a feature suspension, but it could not be applied,
-    ///      and postponed till the cycle transition concluded
-    fun move_to_suspended_state(automation_registry: &AutomationRegistry, cycle_info: &mut AutomationCycleDetails
+    ///      and postponed till the cycle transition concludes
+    /// In all cases if there are no tasks in registry the state will be updated directly to CYCLE_READY state.
+    fun try_move_to_suspended_state(automation_registry: &AutomationRegistry, cycle_info: &mut AutomationCycleDetails
     ) acquires  ActiveAutomationRegistryConfig {
         if (enumerable_map::length(&automation_registry.tasks) == 0) {
             // Registry is empty move to ready state directly
@@ -1721,7 +1798,7 @@ module supra_framework::automation_registry {
             assert!(cycle_info.state == CYCLE_STARTED, EINVALID_REGISTRY_STATE);
             let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
             let transition_state = TransitionState {
-                remaining_cycle_duration: cycle_info.duration_secs + cycle_info.start_time - timestamp::now_seconds(),
+                refund_duration: cycle_info.duration_secs + cycle_info.start_time - timestamp::now_seconds(),
                 new_cycle_duration: cycle_info.duration_secs,
                 automation_fee_per_sec: calculate_automation_fee_multiplier_for_current_cycle_internal(active_config, automation_registry),
                 gas_committed_for_new_cycle: 0,
@@ -1734,16 +1811,18 @@ module supra_framework::automation_registry {
         } else {
             assert!(cycle_info.state == CYCLE_FINISHED, EINVALID_REGISTRY_STATE);
             let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+            assert!(!is_transition_in_progress(transition_state), EINVALID_REGISTRY_STATE);
             // Did not manage to charge cycle fee, so automation_fee_per_sec be 0 along with remaining duration
             // So the tasks sent for refund, will get only deposit refunded.
-            transition_state.remaining_cycle_duration = 0;
+            transition_state.refund_duration = 0;
             transition_state.automation_fee_per_sec = 0;
             transition_state.gas_committed_for_new_cycle = 0;
         };
         update_cycle_state_to(cycle_info, CYCLE_SUSPENDED)
     }
 
-    /// Checks all tasks for epoch fee refunds.
+    /// Refunds automation fee for epoch for all eligible tasks and clears automation registry state in terms of
+    /// fee primitives.
     fun update_state_for_migration(
         automation_registry: &mut AutomationRegistry,
         arc: &AutomationRegistryConfig,
@@ -1761,14 +1840,14 @@ module supra_framework::automation_registry {
             // Compute the automation fee multiplier for ended epoch
             refund_automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(arc, previous_tcmg, arc.registry_max_gas_cap);
         };
-        refund_fee(automation_registry, arc, refund_automation_fee_per_sec, refund_interval, current_time);
+        refund_tasks_fees(automation_registry, arc, refund_automation_fee_per_sec, refund_interval, current_time);
 
-        automation_registry.gas_committed_for_next_epoch = 0;
         automation_registry.epoch_locked_fees = 0;
         automation_registry.gas_committed_for_this_epoch = 0;
     }
 
-    fun refund_fee(
+    /// Refunds automation fee for epoch for all eligible tasks.
+    fun refund_tasks_fees(
         automation_registry: &AutomationRegistry,
         arc: &AutomationRegistryConfig,
         refund_automation_fee_per_sec: u256,
@@ -1803,29 +1882,6 @@ module supra_framework::automation_registry {
                     refund);
                 epoch_locked_fees = remaining_epoch_locked_fees;
             };
-        });
-    }
-
-    /// Traverses through all existing tasks and refunds deposited fee upon registration fully.
-    fun safe_deposit_refund_all(
-        automation_registry: &AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping) {
-        let ids = enumerable_map::get_map_list(&automation_registry.tasks);
-
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-        vector::for_each(ids, |task_index| {
-            let task = enumerable_map::get_value_ref(&automation_registry.tasks, task_index);
-
-            safe_deposit_refund(
-                refund_bookkeeping,
-                &resource_signer,
-                automation_registry.registry_fee_address,
-                task.task_index,
-                task.owner,
-                task.locked_fee_for_next_epoch,
-                task.locked_fee_for_next_epoch);
         });
     }
 
@@ -2098,100 +2154,30 @@ module supra_framework::automation_registry {
         result - one_scaled
     }
 
-    /// Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-    /// - If the user has sufficient balance, deducts the fee and emits a success event.
-    /// - If the balance is insufficient, removes the task and emits a cancellation event.
-    /// - If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-    /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-    fun try_charge_tasks_automation_fees(
-        automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        transition_state: &mut TransitionState,
-        arc: &AutomationRegistryConfig,
-        automation_fee_per_sec: u256,
-        cycle_duration: u64,
-        current_time: u64,
-        task_ids: vector<u64>,
-        intermediate_state: &mut IntermediateStateOfEpochChange,
-    ) {
-
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-        let current_cycle_end_time = current_time + cycle_duration;
-
-        // Sort task indexes to charge automation fees in the tasks chronological order
-        sort_vector(&mut task_ids);
-
-        // Process each active task and calculate fee for the epoch for the tasks
-        vector::for_each(task_ids, |task_index| {
-            if (!already_processed(transition_state, task_index) && enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                append_processed_task(transition_state, task_index);
-                let task = {
-                    let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
-                    assert!(task_meta.state != CANCELLED, EINVALID_CHARGE_ACTION);
-                    let fee= calculate_task_fee(arc, task_meta, cycle_duration, current_time, automation_fee_per_sec);
-                    // If the task reached this phase that means it is valid active task for the new epoch.
-                    // During cleanup all expired tasks has been removed from the registry but the state of the tasks is not updated.
-                    // As here we need to distinguish new tasks from already existing active tasks,
-                    // as the fee calculation for them will be different based on their active duration in the epoch.
-                    // For more details see calculate_task_fee function.
-                    task_meta.state = ACTIVE;
-                    AutomationTaskFeeMeta {
-                        task_index,
-                        owner: task_meta.owner,
-                        fee,
-                        expiry_time: task_meta.expiry_time,
-                        automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                        max_gas_amount: task_meta.max_gas_amount,
-                        locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
-                    }
-                };
-                try_withdraw_task_automation_fee(
-                    automation_registry,
-                    refund_bookkeeping,
-                    &resource_signer,
-                    task,
-                    current_time,
-                    current_cycle_end_time,
-                    intermediate_state
-                );
-            };
-        });
-    }
-
     fun try_withdraw_task_automation_fee(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         resource_signer: &signer,
         task: AutomationTaskFeeMeta,
-        current_time: u64,
         current_epoch_end_time: u64,
         intermediate_state: &mut IntermediateStateOfEpochChange) {
         // Remove the automation task if the epoch fee cap is exceeded
         // It might happen that task has been expired by the time charging is being done.
         // This may be caused by the fact that bookkeeping transactions has been withheld due to epoch transition.
-        let is_task_expired = task.expiry_time <= current_time;
-        if (task.fee > task.automation_fee_cap || is_task_expired) {
-            safe_deposit_refund(
+        if (task.fee > task.automation_fee_cap) {
+            refund_deposit_and_drop(
+                task.task_index,
+                automation_registry,
                 refund_bookkeeping,
                 resource_signer,
-                automation_registry.registry_fee_address,
-                task.task_index,
-                task.owner,
-                task.locked_deposit_fee,
-                task.locked_deposit_fee
+                &mut intermediate_state.removed_tasks
             );
-            enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
-            vector::push_back(&mut intermediate_state.removed_tasks, task.task_index);
-            if (!is_task_expired) {
-                event::emit(TaskCancelledCapacitySurpassed {
-                    task_index: task.task_index,
-                    owner: task.owner,
-                    fee: task.fee,
-                    automation_fee_cap: task.automation_fee_cap,
-                });
-            };
+            event::emit(TaskCancelledCapacitySurpassed {
+                task_index: task.task_index,
+                owner: task.owner,
+                fee: task.fee,
+                automation_fee_cap: task.automation_fee_cap,
+            });
             return
         };
         let user_balance = coin::balance<SupraCoin>(task.owner);
@@ -2356,7 +2342,7 @@ module supra_framework::automation_registry {
 
 
     #[test_only]
-    /// Initializes registry without enabling SUPRA_NATIVE_AUTOMATION feature flag
+    /// Initializes registry without enabling SUPRA_NATIVE_AUTOMATION and SUPRA_AUTOMATION_CYCLE feature flags
     fun initialize_registry_test_partially(supra_framework: &signer, user: &signer) {
         use supra_framework::coin;
         use supra_framework::supra_coin::{Self, SupraCoin};
@@ -2386,7 +2372,8 @@ module supra_framework::automation_registry {
         supra_coin::mint(supra_framework, get_registry_fee_address(), REGISTRY_DEFAULT_BALANCE);
         coin::destroy_burn_cap(burn_cap);
         coin::destroy_mint_cap(mint_cap);
-        toggle_custom_feature_flags(supra_framework, vector[features::get_supra_automation_cycle_feature()], true);
+
+        config_buffer::initialize(supra_framework);
     }
 
     #[test_only]
@@ -2443,8 +2430,8 @@ module supra_framework::automation_registry {
     #[test_only]
     /// Initializes registry. enables SUPRA_NATIVE_AUTOMATION feature flag and initialize config-buffer
     fun initialize_registry_test(supra_framework: &signer, user: &signer) {
-        config_buffer::initialize(supra_framework);
         toggle_feature_flag(supra_framework, true);
+        toggle_custom_feature_flags(supra_framework, vector[features::get_supra_automation_cycle_feature()], true);
         initialize_registry_test_partially(supra_framework, user);
     }
 
@@ -3482,7 +3469,7 @@ module supra_framework::automation_registry {
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        on_charge(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), vector[0]);
 
         // 10 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
@@ -3523,7 +3510,7 @@ module supra_framework::automation_registry {
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        on_charge(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), vector[0]);
 
         has_task_with_id(0);
 
@@ -3540,7 +3527,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_drop_execution(
+    fun check_successful_drop_execution(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3574,11 +3561,6 @@ module supra_framework::automation_registry {
         let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
 
 
-        // // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
-        // let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
-        // let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
-
         let fwk_address = address_of(framework);
         let user_address = address_of(user);
 
@@ -3592,7 +3574,7 @@ module supra_framework::automation_registry {
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        on_drop(create_signer(@vm_reserved), vector[task2, task3]);
+        process_tasks(create_signer(@vm_reserved), vector[task2, task3]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -3616,7 +3598,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_drop_even_if_refund_fails(
+    fun check_successful_drop_even_if_refund_fails(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3647,7 +3629,7 @@ module supra_framework::automation_registry {
         // Make sure we are in FINISHED state
         monitor_cycle_end();
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        on_drop(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), vector[task1]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -3665,7 +3647,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_drop_even_input_is_empty_or_non_existent(
+    fun check_successful_process_tasks_even_input_is_empty_or_non_existent(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3690,8 +3672,8 @@ module supra_framework::automation_registry {
         // Make sure we are in FINISHED state
         monitor_cycle_end();
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        on_drop(create_signer(@vm_reserved), vector[]);
-        on_drop(create_signer(@vm_reserved), vector[5]);
+        process_tasks(create_signer(@vm_reserved), vector[]);
+        process_tasks(create_signer(@vm_reserved), vector[5]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -3710,33 +3692,8 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_DROP_ACTION, location = Self)]
-    fun check_on_drop_fails_if_task_is_not_cancelled_or_expired(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-
-        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        // Make sure we are in FINISHED state
-        monitor_cycle_end();
-        // Attempt to drop a task that is still active and not expired
-        on_drop(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
     #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_drop_fails_on_started_state(
+    fun check_process_tasks_fails_on_started_state(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3752,35 +3709,12 @@ module supra_framework::automation_registry {
             task_exipry_time,
             ACTIVE);
         // Attempt to drop in STARTED state
-        on_drop(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), vector[task1]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
     #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_drop_fails_on_suspended_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        // feature is disabled in started state moves registry in suspended state
-        toggle_feature_flag(framework, false);
-        on_new_epoch();
-        // Attempt to drop in suspended
-        on_drop(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_drop_fails_on_ready_state(
+    fun check_process_tasks_fails_on_ready_state(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3788,12 +3722,12 @@ module supra_framework::automation_registry {
         // feature is disabled in started state, when registry is empty, moves registry in ready state
         toggle_feature_flag(framework, false);
         on_new_epoch();
-        on_drop(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), vector[0]);
     }
 
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_charge_execution(
+    fun check_successful_charge_execution(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3852,9 +3786,9 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
-        on_charge(create_signer(@vm_reserved), vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved), vector[task1, task2]);
         // Also check that processed tasks are ignored and charging is done only once
-        on_charge(create_signer(@vm_reserved), vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved), vector[task1, task2]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -3878,7 +3812,7 @@ module supra_framework::automation_registry {
             check_task_state(ar, task1, exists, ACTIVE);
         };
 
-        on_charge(create_signer(@vm_reserved), vector[task3]);
+        process_tasks(create_signer(@vm_reserved), vector[task3]);
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
             let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(fwk_address);
@@ -3906,7 +3840,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_charge_for_tasks_to_be_dropped(
+    fun check_successful_charge_for_tasks_to_be_dropped_due_to_limitations(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -3979,7 +3913,7 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
-        on_charge(create_signer(@vm_reserved), vector[task1, task2, task3]);
+        process_tasks(create_signer(@vm_reserved), vector[task1, task2, task3]);
 
         {
             // Check there are no tasks
@@ -4012,136 +3946,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_charge_even_input_is_empty_or_non_existent(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            CANCELLED);
-        let expected_user_current_balance = ACCOUNT_BALANCE - (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-
-        let fwk_address = address_of(framework);
-        let user_address = address_of(user);
-
-        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        // Make sure we are in FINISHED state
-        monitor_cycle_end();
-        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        on_charge(create_signer(@vm_reserved), vector[]);
-        on_charge(create_signer(@vm_reserved), vector[5]);
-
-        let ar = borrow_global<AutomationRegistry>(fwk_address);
-        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
-
-        // As long as there was a single task in the registry registry will move to started state
-        assert!(cycle_details.state == CYCLE_FINISHED, 0);
-        let transition_state = std::option::borrow(&cycle_details.transition_state);
-        assert!(vector::is_empty(&transition_state.actual_processed_tasks), 1);
-
-        // Check that no refund has happened
-        check_account_balance(user_address, expected_user_current_balance);
-        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-
-        // Check that task has been removed from registry
-        assert!(has_task_with_id(task1), 2);
-    }
-
-
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_CHARGE_ACTION, location = Self)]
-    fun check_on_charge_fails_if_task_is_cancelled(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            CANCELLED);
-
-        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        // Make sure we are in FINISHED state
-        monitor_cycle_end();
-        // Attempt to charge a task that is cancelled
-        on_charge(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_charge_fails_on_started_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        // Attempt to charge in STARTED state
-        on_charge(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_charge_fails_on_suspended_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        // feature is disabled in started state moves registry in suspended state
-        toggle_feature_flag(framework, false);
-        on_new_epoch();
-        // Attempt to charge in suspended
-        on_charge(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_charge_fails_on_ready_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        // feature is disabled in started state, when registry is empty, moves registry in ready state
-        toggle_feature_flag(framework, false);
-        on_new_epoch();
-        on_charge(create_signer(@vm_reserved), vector[0]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_refund_and_cleanup_execution(
+    fun check_successful_refund_and_cleanup_execution(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -4194,14 +3999,14 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(transition_state.remaining_cycle_duration == expected_remaining_time, 1);
+            assert!(transition_state.refund_duration == expected_remaining_time, 1);
             assert!(transition_state.automation_fee_per_sec == expected_automation_fee_multiplier, 1);
 
         };
 
         // set enough cycle fee to be able to refund
         set_locked_fee(framework, 10_000_000_000);
-        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved),  vector[task1, task2]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -4228,12 +4033,12 @@ module supra_framework::automation_registry {
         };
 
         // Empty input does not cause issues
-        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[]);
+        process_tasks(create_signer(@vm_reserved),  vector[]);
 
         // Non existing item does not cause issues
-        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[10, 12]);
+        process_tasks(create_signer(@vm_reserved),  vector[10, 12]);
 
-        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2, task3]);
+        process_tasks(create_signer(@vm_reserved),  vector[task1, task2, task3]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -4261,7 +4066,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_refund_and_cleanup_even_if_refund_fails(
+    fun check_successful_refund_and_cleanup_even_if_refund_fails(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -4307,12 +4112,12 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(transition_state.remaining_cycle_duration == expected_remaining_time, 1);
+            assert!(transition_state.refund_duration == expected_remaining_time, 1);
             assert!(transition_state.automation_fee_per_sec == expected_automation_fee_multiplier, 2);
 
         };
 
-        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved),  vector[task1, task2]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -4336,7 +4141,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_successful_on_refund_and_cleanup_transitioned_from_finished_state(
+    fun check_successful_refund_and_cleanup_transitioned_from_finished_state(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
@@ -4375,12 +4180,12 @@ module supra_framework::automation_registry {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
             assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(transition_state.remaining_cycle_duration == 0, 1);
+            assert!(transition_state.refund_duration == 0, 1);
             assert!(transition_state.automation_fee_per_sec == 0, 1);
 
         };
 
-        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved),  vector[task1, task2]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -4402,63 +4207,6 @@ module supra_framework::automation_registry {
         assert!(!has_task_with_id(task1), 5);
         assert!(!has_task_with_id(task2), 6);
 
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_refund_and_cleanup_fails_on_started_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        // Attempt to refund in STARTED state
-        on_refund_and_cleanup(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_refund_and_cleanup_fails_on_finished_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-        let automation_fee_cap = 100_000_000;
-        let task1 = register_with_state(
-            framework,
-            user,
-            44_000_000,
-            automation_fee_cap,
-            task_exipry_time,
-            ACTIVE);
-        // feature is disabled in started state moves registry in suspended state
-        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        monitor_cycle_end();
-        // Attempt to refund in finished state
-        on_refund_and_cleanup(create_signer(@vm_reserved), vector[task1]);
-    }
-
-    #[test(framework = @supra_framework, user = @0x1cafa)]
-    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
-    fun check_on_refund_and_cleanup_fails_on_ready_state(
-        framework: &signer,
-        user: &signer
-    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-        initialize_registry_test(framework, user);
-        // feature is disabled in started state, when registry is empty, moves registry in ready state
-        toggle_feature_flag(framework, false);
-        on_new_epoch();
-        on_refund_and_cleanup(create_signer(@vm_reserved), vector[0]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafb)]
@@ -4518,7 +4266,7 @@ module supra_framework::automation_registry {
             assert!(cycle_details.duration_secs == expected_cycle_duration, 3);
 
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(transition_state.remaining_cycle_duration  == EPOCH_INTERVAL_FOR_TEST_IN_SECS, 4);
+            assert!(transition_state.refund_duration == EPOCH_INTERVAL_FOR_TEST_IN_SECS, 4);
             let expected_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
                 &config.main_config,
                 (2 * t1_t2_max_gas as u256),
@@ -4666,7 +4414,7 @@ module supra_framework::automation_registry {
         let total_committed_gas_for_new_cycle = t1_t2_max_gas + t3_max_gas;
         let automation_fee_per_sec_for_new_cycle = calculate_automation_fee_multiplier_for_committed_occupancy(total_committed_gas_for_new_cycle);
         // Drop one task to mark transition initiated
-        on_drop(create_signer(@vm_reserved), vector[t2]);
+        process_tasks(create_signer(@vm_reserved), vector[t2]);
         // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
         let expected_cycle_duration =
         {
@@ -4758,7 +4506,7 @@ module supra_framework::automation_registry {
             assert!(std::option::is_some(&cycle_details.transition_state), 2);
         };
 
-        on_refund_and_cleanup(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), vector[0]);
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
             assert!(cycle_details.state == CYCLE_READY, 3);
@@ -5129,7 +4877,7 @@ module supra_framework::automation_registry {
         let committed_gas_for_new_cycle = 2 * t1_t2_max_gas + t3_max_gas;
 
         // Not only charges will be applied but also state will be updated to STARTED as all expected tasks will be processed.
-        on_charge(create_signer(@vm_reserved), vector[t1, t2, t3]);
+        process_tasks(create_signer(@vm_reserved), vector[t1, t2, t3]);
 
         let tcmg = (committed_gas_for_new_cycle as u256);
         let user_address = address_of(user);
@@ -5357,7 +5105,7 @@ module supra_framework::automation_registry {
         let committed_gas_for_new_cycle = 4 * max_gas_amount;
 
         // Not only charges will be applied but also state will be updated to STARTED as all expected tasks will be processed.
-        on_charge(create_signer(@vm_reserved), vector[t1, t2, t3, t4]);
+        process_tasks(create_signer(@vm_reserved), vector[t1, t2, t3, t4]);
 
         assert!(committed_gas_for_new_cycle == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
@@ -5509,7 +5257,7 @@ module supra_framework::automation_registry {
         // Start new cycle
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        on_charge(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), vector[0]);
 
         // 0.002 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000;
@@ -5837,7 +5585,7 @@ module supra_framework::automation_registry {
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        on_drop(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), vector[task1]);
 
         toggle_feature_flag(framework, false);
         on_new_epoch();
@@ -5848,7 +5596,7 @@ module supra_framework::automation_registry {
         };
 
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        on_drop(create_signer(@vm_reserved), vector[task2]);
+        process_tasks(create_signer(@vm_reserved), vector[task2]);
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
             assert!(ar.gas_committed_for_next_epoch == 0, 1);
@@ -5865,10 +5613,280 @@ module supra_framework::automation_registry {
         };
     }
 
+    #[test_only]
+    fun check_cycle_state(state: u8, index: u64, start_time: u64, cycle_duration: u64) acquires  AutomationCycleDetails {
+        let cycle_details = borrow_global<AutomationCycleDetails>(@supra_framework);
+        // Check that we are still in finished state and processed-task are only task2 and task3
+        assert!(cycle_details.state == state, (cycle_details.state as u64));
+        assert!(cycle_details.index == index, cycle_details.index);
+        assert!(cycle_details.start_time == start_time, cycle_details.start_time);
+        assert!(cycle_details.duration_secs == cycle_duration, cycle_details.duration_secs);
+        if (state == CYCLE_FINISHED || state == CYCLE_SUSPENDED) {
+            assert!(std::option::is_some(&cycle_details.transition_state), (state as  u64));
+        }
+    }
 
-    #[test]
-    fun check_monitor_cycle_end() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
-        monitor_cycle_end()
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_monitor_cycle_end_when_feature_flags_are_disabled(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], false);
+        initialize_registry_test_partially(framework, user);
+        check_cycle_state(CYCLE_READY, 0, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Updating the time which should cause cycle end if in proper state
+        update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Both SUPRA_NATIVE_AUTOMATION and SUPRA_AUTOMATION_CYCLE are disabled
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_READY, 0, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        //Enable feature
+        toggle_feature_flag(framework, true);
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_READY, 0, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        //Disable feature enable automation cycle
+        toggle_feature_flag(framework, false);
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], true);
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_READY, 0, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        //Both enabled feature and automation cycle,
+        // but as long as registry is not in STARTED state no transistion will happen even if cycle duration passed
+        toggle_feature_flag(framework, true);
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_READY, 0, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_monitor_cycle_end_from_started_state(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        check_cycle_state(CYCLE_STARTED, 1, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Updating the time which should cause cycle end if in proper state
+        update_global_time_for_test_secs(2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // SUPRA_AUTOMATION_CYCLE is disabled
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], false);
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_STARTED, 1, 0, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Both feature flags are enabled, but as long as registry is empty we will only progress
+        // in cycle and remain in started state.
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], true);
+        monitor_cycle_end();
+        let recent_chain_time = timestamp::now_seconds();
+        check_cycle_state(CYCLE_STARTED, 2, recent_chain_time, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Register a task to move to FINISHED state if cycle end is identified
+        register(user,
+            PAYLOAD,
+            86400,
+            2000,
+            200,
+            100_000_000,
+            PARENT_HASH,
+            AUX_DATA
+        );
+
+        // Chain time remains the same, so no transition will happen
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_STARTED, 2, recent_chain_time, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Chain time updated but epoch end was not reached
+        update_global_time_for_test_secs(recent_chain_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_STARTED, 2, recent_chain_time, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Chain time remains the same, so no transition will happen
+        update_global_time_for_test_secs(recent_chain_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        check_cycle_state(CYCLE_FINISHED, 2, recent_chain_time, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+
+        // Process the single task which will lead to the state to be updated to STARTED again
+        recent_chain_time = timestamp::now_seconds();
+        process_tasks(create_signer(@vm_reserved), vector[0]);
+        check_cycle_state(CYCLE_STARTED, 3, recent_chain_time, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+    }
+
+    #[test_only]
+    fun swap_cycle_details_with_epoch(framework: &signer) acquires AutomationCycleDetails {
+        let cycle_details = move_from<AutomationCycleDetails>(@supra_framework);
+        let epoch_info = AutomationEpochInfo {
+            expected_epoch_duration: cycle_details.duration_secs,
+            epoch_interval: cycle_details.duration_secs,
+            start_time: cycle_details.start_time,
+        };
+        move_to(framework, epoch_info)
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_migration(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry, AutomationRefundBookkeeping, AutomationEpochInfo {
+        initialize_registry_test(framework, user);
+
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let task_exists = true;
+        let t1_t2_max_gas_amount = 44_000_000;
+        let t3_max_gas_amount = 11_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        let task2 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task3 = register_with_state(
+            framework,
+            user,
+            11_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+
+        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        let expected_automation_fee_per_task_1_2 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task_1_2 = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        // 11/100 * 1000 = 110 - automation_epoch_fee_per_second, 7200 epoch duration (PENDING tasks are charge for the first cycle fully)
+        let expected_automation_fee_per_task_3 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 110;
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        swap_cycle_details_with_epoch(framework);
+        assert!(exists<AutomationEpochInfo>(@supra_framework), 0);
+        assert!(!exists<AutomationCycleDetails>(@supra_framework), 1);
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], false);
+        // Simulate that half of the epoch passed, when migration was requested
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        // set enough cycle fee to be able to refund
+        set_locked_fee(framework, 10_000_000_000);
+
+        migrate_v2(framework, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        assert!(!exists<AutomationEpochInfo>(@supra_framework), 0);
+        assert!(exists<AutomationCycleDetails>(@supra_framework), 1);
+        assert!(is_feature_enabled_and_initialized(), 2);
+        check_cycle_state(CYCLE_FINISHED, 0, timestamp::now_seconds(), EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        {
+            // Check refunds have been done for both task1 and task2 only
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let total_expected_fee_refunds_task_1_2 = expected_automation_fee_per_task_1_2 + expected_congestion_fee_per_task_1_2;
+            expected_user_current_balance = expected_user_current_balance + total_expected_fee_refunds_task_1_2;
+            expected_registry_current_balance = expected_registry_current_balance - total_expected_fee_refunds_task_1_2;
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+            check_task_state(ar, task1, task_exists, ACTIVE);
+            check_task_state(ar, task2, task_exists, CANCELLED);
+            check_task_state(ar, task3, task_exists, PENDING);
+
+        };
+
+        // after epoch change we are still in the same state and waiting for actions from native layer to have tasks processed for the new cycle
+        on_new_epoch();
+        check_cycle_state(CYCLE_FINISHED, 0, timestamp::now_seconds(), EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        {
+            // Check refunds have been done for both task1 and task2 only
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+            check_task_state(ar, task1, task_exists, ACTIVE);
+            check_task_state(ar, task2, task_exists, CANCELLED);
+            check_task_state(ar, task3, task_exists, PENDING);
+
+        };
+
+        // Process tasks and check the registry state after it
+        let total_committed_gas_for_new_cycle = t1_t2_max_gas_amount + t3_max_gas_amount; // task 2 was cancelled.
+        process_tasks(create_signer(@vm_reserved), vector[task1, task2, task3]);
+        check_cycle_state(CYCLE_STARTED, 1, timestamp::now_seconds(), EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        {
+            // Check charges are done only for task 1 and task3 and task 3 was refunded with deposit fee.
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+
+            // As cycle duration is half of the previous epoch duration, and these values are calculated for epoch duraton.
+            let total_expected_fee_charges_task_1_3 = (expected_automation_fee_per_task_1_2 + expected_automation_fee_per_task_3) / 2;
+
+            check_account_balance(user_address, expected_user_current_balance - total_expected_fee_charges_task_1_3 + automation_fee_cap);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance + total_expected_fee_charges_task_1_3 - automation_fee_cap);
+
+            assert!(ar.gas_committed_for_this_epoch == (total_committed_gas_for_new_cycle as u256), 3);
+            assert!(ar.gas_committed_for_next_epoch == total_committed_gas_for_new_cycle, 4);
+            assert!(ar.epoch_locked_fees == total_expected_fee_charges_task_1_3, 5);
+            assert!(vector::contains(&ar.epoch_active_task_ids, &task1), 6);
+            assert!(vector::contains(&ar.epoch_active_task_ids, &task3), 7);
+            assert!(!vector::contains(&ar.epoch_active_task_ids, &task2), 7);
+
+            check_task_state(ar, task1, task_exists, ACTIVE);
+            check_task_state(ar, task3, task_exists, ACTIVE);
+            assert!(!has_task_with_id(task2), 9);
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_MIGRATION_ACTION, location = Self)]
+    fun check_migration_fails_on_second_round_even_if_automation_cycle_is_not_enabled(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry, AutomationEpochInfo {
+        initialize_registry_test(framework, user);
+
+        swap_cycle_details_with_epoch(framework);
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], false);
+        // Simulate that half of the epoch passed, when migration was requested
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        migrate_v2(framework, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        assert!(!exists<AutomationEpochInfo>(@supra_framework), 0);
+        assert!(exists<AutomationCycleDetails>(@supra_framework), 1);
+        assert!(is_feature_enabled_and_initialized(), 2);
+        check_cycle_state(CYCLE_STARTED, 1, timestamp::now_seconds(), EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        migrate_v2(framework, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_MIGRATION_ACTION, location = Self)]
+    fun check_migration_fails_on_second_round(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry, AutomationEpochInfo {
+        initialize_registry_test(framework, user);
+
+        swap_cycle_details_with_epoch(framework);
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], false);
+        // Simulate that half of the epoch passed, when migration was requested
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        migrate_v2(framework, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        toggle_custom_feature_flags(framework, vector[features::get_supra_automation_cycle_feature()], true);
+        on_new_epoch();
+
+        assert!(!exists<AutomationEpochInfo>(@supra_framework), 0);
+        assert!(exists<AutomationCycleDetails>(@supra_framework), 1);
+        assert!(is_feature_enabled_and_initialized(), 2);
+
+        check_cycle_state(CYCLE_STARTED, 1, timestamp::now_seconds(), EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+
+        migrate_v2(framework, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
     }
 
     #[test]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -229,7 +229,7 @@ module supra_framework::automation_registry {
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
-    /// Epoch state. Deprecated since SUPRA_CYCLE_BASED_AUTOMATION version.
+    /// Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
     struct AutomationEpochInfo has key, copy {
         /// Epoch expected duration at the beginning of the new epoch, Based on this and actual
         /// epoch_duration which will be (current_time - last_reconfiguration_time) automation tasks
@@ -982,7 +982,7 @@ module supra_framework::automation_registry {
     public fun migrate_v2(supra_framework: &signer, cycle_duration_secs: u64
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleDetails {
         assert_supra_framework(supra_framework);
-        assert!(!features::supra_cycle_based_automation_enabled(), EINVALID_MIGRATION_ACTION);
+        assert!(!features::supra_automation_cycle_enabled(), EINVALID_MIGRATION_ACTION);
 
         // Prepare the state for migration
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
@@ -1005,7 +1005,7 @@ module supra_framework::automation_registry {
         // Start migration by enabling feature, initializing the cycle releated resouces
         features::change_feature_flags_for_next_epoch(
             supra_framework,
-            vector[features::get_supra_cycle_based_automation_feature()],
+            vector[features::get_supra_automation_cycle_feature()],
             vector[]);
         let id = 0;
         move_to(supra_framework, AutomationCycleDetails {
@@ -1020,7 +1020,7 @@ module supra_framework::automation_registry {
             return
         };
         // Emit cycle end which will lead the native layer to start preparation to the new cycle.
-        assert_cycle_based_automation_registry_management_support();
+        assert_automation_cycle_management_support();
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         on_cycle_end_internal(cycle_info)
     }
@@ -1044,7 +1044,7 @@ module supra_framework::automation_registry {
         assert!(false, EDEPRECATED_SINCE_V2);
     }
 
-    /// Initialization of Automation Registry with configuration parameters for SUPRA_CYCLE_BASED_AUTOMATION version.
+    /// Initialization of Automation Registry with configuration parameters for SUPRA_AUTOMATION_CYCLE version.
     /// Expected to have this function call either at genesis startup or as part of the SUPRA_FRAMEWORK upgrade where
     /// automation feature is being introduced very first time.
     /// In case if framework upgrade is happening on the chain where automation feature is already released and
@@ -1099,7 +1099,7 @@ module supra_framework::automation_registry {
             registration_enabled: true,
         });
 
-        let (cycle_state, cycle_id) = if (features::supra_cycle_based_automation_enabled()) {
+        let (cycle_state, cycle_id) = if (features::supra_automation_cycle_enabled()) {
             (CYCLE_STARTED, 1)
         } else {
             (READY_TO_START_NEW_CYCLE, 0)
@@ -1123,7 +1123,7 @@ module supra_framework::automation_registry {
         if (!is_feature_enabled_and_initialized()) {
             return
         };
-        assert_cycle_based_automation_registry_management_support();
+        assert_automation_cycle_management_support();
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         if (cycle_info.state != CYCLE_STARTED
             || cycle_info.start_time + cycle_info.duration_secs < timestamp::now_seconds()) {
@@ -1180,7 +1180,7 @@ module supra_framework::automation_registry {
     }
 
     /// Update epoch interval in registry while actually update happens in block module
-    /// Deprecated since SUPRA_CYCLE_BASED_AUTOMATION feature release in favor of monitor_cycle_end
+    /// Deprecated since SUPRA_AUTOMATION_CYCLE feature release in favor of monitor_cycle_end
     public(friend) fun update_epoch_interval_in_registry(_epoch_interval_microsecs: u64) {
         assert!(false, EDEPRECATED_SINCE_V2);
     }
@@ -1286,7 +1286,7 @@ module supra_framework::automation_registry {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
         if (vector::is_empty(&task_indexes)) {
-            return;
+            return
         };
 
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
@@ -2322,15 +2322,15 @@ module supra_framework::automation_registry {
 
     fun downscale_to_u256(value: u256): u256 { value / DECIMAL }
 
-    /// If SUPRA_CYCLE_BASED_AUTOMATION is enabled then call native function to assert full support of cycle based
+    /// If SUPRA_AUTOMATION_CYCLE is enabled then call native function to assert full support of cycle based
     /// automation registry management.
-    fun assert_cycle_based_automation_registry_management_support() {
-        if (features::supra_cycle_based_automation_enabled()) {
-            native_cycle_based_automation_registry_management_support();
+    fun assert_automation_cycle_management_support() {
+        if (features::supra_automation_cycle_enabled()) {
+            native_automation_cycle_management_support();
         }
     }
 
-    native fun native_cycle_based_automation_registry_management_support(): bool;
+    native fun native_automation_cycle_management_support(): bool;
 
     #[test_only]
     const AUTOMATION_MAX_GAS_TEST: u64 = 100_000_000;

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1,4 +1,5 @@
-/// Supra Automation tegistry
+/// Copywrite (c) -- 2025 Supra
+/// Supra Automation Registry
 ///
 /// This contract is part of the Supra Framework and is designed to manage automated task entries
 module supra_framework::automation_registry {
@@ -96,6 +97,8 @@ module supra_framework::automation_registry {
     const EINVALID_REGISTRY_STATE: u64 = 33;
     /// Attempt to run charge action with inconsistent input values compared to internal state.
     const EINVALID_CHARGE_ACTION: u64 = 34;
+    /// Attempt to run refund action with duration more than cycle duration is.
+    const EINVALID_REFUND_DURATION: u64 = 35;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -119,11 +122,11 @@ module supra_framework::automation_registry {
 
     /// Constants describing CYCLE state.
     /// State transition flaw is:
-    /// READY_TO_START -> CYCLE_STARTED
+    /// CYCLE_READY -> CYCLE_STARTED
     /// CYCLE_STARTED -> { CYCLE_FINISHED, CYCLE_SUSPENDED }
     /// CYCLE_FINISHED ->  { CYCLE_STARTED}
-    /// CYCLE_SUSPENDED ->  {READY_TO_START, STARTED}
-    const READY_TO_START_NEW_CYCLE: u8 = 0;
+    /// CYCLE_SUSPENDED ->  {CYCLE_READY, STARTED}
+    const CYCLE_READY: u8 = 0;
     /// Triggered eigther when SUPRA_NATIVE_AUTOMATION feature is enabled or by autoamtion cycle manager in native layer.
     const CYCLE_STARTED: u8 = 1;
     /// Triggered when cycle end is identified.
@@ -198,7 +201,7 @@ module supra_framework::automation_registry {
     }
 
     /// It tracks entries both pending and completed, organized by unique indices.
-    struct TransitionState has key, copy, drop, store {
+    struct TransitionState has copy, drop, store {
         /// Duration of the new cycle.
         new_cycle_duration: u64,
         /// Calculated automation fee per second for the new cycle.
@@ -230,7 +233,7 @@ module supra_framework::automation_registry {
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
-    struct AutomationEpochInfo has key, copy {
+    struct AutomationEpochInfo has key, copy, drop {
         /// Epoch expected duration at the beginning of the new epoch, Based on this and actual
         /// epoch_duration which will be (current_time - last_reconfiguration_time) automation tasks
         /// refunds will be calculated.
@@ -251,7 +254,7 @@ module supra_framework::automation_registry {
     }
 
     /// Cycle state.
-    struct AutomationCycleInfo has key, copy, drop, store {
+    struct AutomationCycleInfo has copy, drop, store {
         /// Current cycle id. Incremented when a start of the new cycle is processed.
         index: u64,
         /// State of the current cycle.
@@ -264,7 +267,7 @@ module supra_framework::automation_registry {
 
     #[event]
     /// Event emitted in the cycle-state.
-    struct AutomationCycleEvent has key, copy, drop, store {
+    struct AutomationCycleEvent has copy, drop, store {
         /// Updated cycle state information.
         cycle_state_info: AutomationCycleInfo,
         /// The state transitioned from
@@ -275,7 +278,7 @@ module supra_framework::automation_registry {
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Cycle state.
-    struct AutomationCycleDetails has key, copy, drop, store {
+    struct AutomationCycleDetails has key, copy, drop {
         /// Cycle index corresponding to the current state. Incremented when a transition to the new cycle is finalized.
         index: u64,
         /// State of the current cycle.
@@ -748,6 +751,13 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
 
+        // Update cycle duration in buffer
+        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
+        let new_cycle_duration = AutomationCycleDuration {
+            duration_secs: cycle_duration_secs
+        };
+        config_buffer::upsert(copy new_cycle_duration);
+        event::emit(new_cycle_duration);
 
         update_registration_config_internal(
             supra_framework,
@@ -762,13 +772,6 @@ module supra_framework::automation_registry {
             cycle_duration_secs,
         );
 
-        // Update cycle duration in buffer
-        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
-        let new_cycle_duration = AutomationCycleDuration {
-            duration_secs: cycle_duration_secs
-        };
-        config_buffer::upsert(copy new_cycle_duration);
-        event::emit(new_cycle_duration);
     }
 
     /// Enables the registration process in the automation registry.
@@ -973,12 +976,13 @@ module supra_framework::automation_registry {
     }
 
     /// API to gracfully migrate from automation feature v1 inplementation to v2 where bookkeeping of the tasks is
-    /// detached from epoch-change.
-    /// IMPORTANT: Should alwasy be followed by supra_governance::reconfiguration otherwise registry/chain will
-    /// end-up in inconsistent state.
+    /// detached from epoch-change and cycle based lifecycle of the automation registry is enabled.
+    /// IMPORTANT: Should alwasy be followed by `SUPRA_AUTOMATION_CYCLE` feature flag being enabled and
+    /// supra_governance::reconfiguration otherwise registry/chain will end-up in inconsistent state.
     ///
     /// monitor_cycle_end (block_prologue->automation_registry::monitor_cycle_end) which will lead to panic and node will stop
     /// thus not causing any inconcistensy in the chain
+    ///
     public fun migrate_v2(supra_framework: &signer, cycle_duration_secs: u64
     ) acquires AutomationRegistry, AutomationEpochInfo, ActiveAutomationRegistryConfig, AutomationCycleDetails {
         assert_supra_framework(supra_framework);
@@ -986,7 +990,7 @@ module supra_framework::automation_registry {
 
         // Prepare the state for migration
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
-        let automation_epoch_info = borrow_global<AutomationEpochInfo>(@supra_framework);
+        let automation_epoch_info = move_from<AutomationEpochInfo>(@supra_framework);
 
         let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(
             @supra_framework
@@ -998,31 +1002,27 @@ module supra_framework::automation_registry {
         update_state_for_migration(
             automation_registry,
             &automation_registry_config,
-            automation_epoch_info,
+            &automation_epoch_info,
             current_time
         );
 
         // Start migration by enabling feature, initializing the cycle releated resouces
-        features::change_feature_flags_for_next_epoch(
-            supra_framework,
-            vector[features::get_supra_automation_cycle_feature()],
-            vector[]);
         let id = 0;
         move_to(supra_framework, AutomationCycleDetails {
             start_time: current_time,
             index: id,
             duration_secs: cycle_duration_secs,
-            state: READY_TO_START_NEW_CYCLE,
+            state: CYCLE_READY,
             transition_state: std::option::none()
         });
-        // Remain in READY_TO_START statey if feature is not enabled or registry is not fully initialized
+        // Remain in CYCLE_READY statey if feature is not enabled or registry is not fully initialized
         if (!is_feature_enabled_and_initialized()) {
             return
         };
         // Emit cycle end which will lead the native layer to start preparation to the new cycle.
-        assert_automation_cycle_management_support();
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
-        on_cycle_end_internal(cycle_info)
+        on_cycle_end_internal(cycle_info);
+
     }
 
     // Public friend api
@@ -1102,7 +1102,7 @@ module supra_framework::automation_registry {
         let (cycle_state, cycle_id) = if (features::supra_automation_cycle_enabled()) {
             (CYCLE_STARTED, 1)
         } else {
-            (READY_TO_START_NEW_CYCLE, 0)
+            (CYCLE_READY, 0)
         };
 
         move_to(supra_framework, AutomationCycleDetails {
@@ -1118,9 +1118,9 @@ module supra_framework::automation_registry {
     }
 
     /// Checks the cycle end and emit an event on it.
-    /// Does nothig if SUPRA_NATIVE_AUTOMATION is disabled
+    /// Does nothig if SUPRA_NATIVE_AUTOMATION or SUPRA_AUTOMATION_CYCLE is disabled.
     public(friend) fun monitor_cycle_end() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
-        if (!is_feature_enabled_and_initialized()) {
+        if (!is_feature_enabled_and_initialized() || !features::supra_automation_cycle_enabled()) {
             return
         };
         assert_automation_cycle_management_support();
@@ -1150,10 +1150,10 @@ module supra_framework::automation_registry {
         if (features::supra_native_automation_enabled()) {
             // If the lifecycle has been suspended and we are recovering from it, then we update config from buffer and
             // then start a new cycle directly.
-            // Unless we are in READY_TO_START state feature flag being enabled will not have any effect.
+            // Unless we are in CYCLE_READY state, the feature flag being enabled will not have any effect.
             // All the other states mean that we are in the middle of previous transition, which should end
             // before reenabling the feature.
-            if (cycle_info.state == READY_TO_START_NEW_CYCLE) {
+            if (cycle_info.state == CYCLE_READY) {
                 if (enumerable_map::length(&registry_data.tasks) != 0) {
                     event::emit(ErrorInconsistentSuspendedState {});
                     return
@@ -1163,6 +1163,7 @@ module supra_framework::automation_registry {
             };
             return
         };
+
         // We do not update config here, as due to feature being disabled, cycle ends early so it is expected
         // that native layer will detect this state and generate refund transactions for a cycle that has been kept short.
         // So the confing should remain intact.
@@ -1400,6 +1401,7 @@ module supra_framework::automation_registry {
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+        assert!(cycle_info.duration_secs >= duration, EINVALID_REFUND_DURATION);
 
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
@@ -1622,7 +1624,7 @@ module supra_framework::automation_registry {
 
     fun move_to_ready_state(cycle_info: &mut AutomationCycleDetails) {
         cycle_info.transition_state = std::option::none<TransitionState>();
-        update_cycle_state_to(cycle_info, READY_TO_START_NEW_CYCLE)
+        update_cycle_state_to(cycle_info, CYCLE_READY)
     }
 
     fun move_to_started_state(cycle_info: &mut AutomationCycleDetails) {
@@ -2325,9 +2327,7 @@ module supra_framework::automation_registry {
     /// If SUPRA_AUTOMATION_CYCLE is enabled then call native function to assert full support of cycle based
     /// automation registry management.
     fun assert_automation_cycle_management_support() {
-        if (features::supra_automation_cycle_enabled()) {
-            native_automation_cycle_management_support();
-        }
+        native_automation_cycle_management_support();
     }
 
     native fun native_automation_cycle_management_support(): bool;

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -8,8 +8,9 @@ module supra_framework::automation_registry {
     use std::signer;
     use std::vector;
     use aptos_std::math64;
+    use supra_framework::automation_registry;
     use supra_framework::system_addresses::assert_supra_framework;
-    use supra_framework::coin::{Coin, destroy_zero};
+    use supra_framework::coin::Coin;
 
     use supra_std::enumerable_map::{Self, EnumerableMap};
 
@@ -24,6 +25,8 @@ module supra_framework::automation_registry {
 
     #[test_only]
     use std::signer::address_of;
+    #[test_only]
+    use supra_framework::timestamp::update_global_time_for_test_secs;
 
     friend supra_framework::block;
     friend supra_framework::genesis;
@@ -95,10 +98,12 @@ module supra_framework::automation_registry {
     const ECYCLE_TRANSITION_IN_PROGRESS: u64 = 32;
     /// Attempt to run operation in invalid registry state.
     const EINVALID_REGISTRY_STATE: u64 = 33;
-    /// Attempt to run charge action with inconsistent input values compared to internal state.
+    /// Attempt to run charge action with inconsistent input values compared to internal state, or with cancelled task.
     const EINVALID_CHARGE_ACTION: u64 = 34;
     /// Attempt to run refund action with duration more than cycle duration is.
     const EINVALID_REFUND_DURATION: u64 = 35;
+    /// Attempt to drop task which is still valid
+    const EINVALID_DROP_ACTION: u64 = 36;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -202,12 +207,14 @@ module supra_framework::automation_registry {
 
     /// It tracks entries both pending and completed, organized by unique indices.
     struct TransitionState has copy, drop, store {
+        /// Remaining duration if cycle was kept short. Actual only in case of suspention.
+        remaining_cycle_duration: u64,
         /// Duration of the new cycle.
         new_cycle_duration: u64,
         /// Calculated automation fee per second for the new cycle.
         automation_fee_per_sec: u64,
         /// Gas committed for the new cycle being transitioned.
-        gas_committed_for_this_cycle: u64,
+        gas_committed_for_new_cycle: u64,
         /// Gas committed for next cycle
         gas_committed_for_next_cycle: u64,
         /// Total fee charged to users during the cycle, which is not withdrawable
@@ -231,6 +238,15 @@ module supra_framework::automation_registry {
         vector::append(&mut state.actual_processed_tasks, task_indexes);
     }
 
+    fun append_processed_task(state: &mut TransitionState, task_index: u64) {
+        vector::push_back(&mut state.actual_processed_tasks, task_index);
+    }
+
+    fun already_processed(state: &TransitionState, task_index: u64): bool {
+        // TODO: maybe use native function if too expensive
+        vector::contains(&state.actual_processed_tasks, &task_index)
+    }
+
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
     struct AutomationEpochInfo has key, copy, drop {
@@ -246,8 +262,8 @@ module supra_framework::automation_registry {
         start_time: u64,
     }
 
-    /// Cycle Duration wrapper to store in the config-buffer.
     #[event]
+    /// Cycle Duration wrapper to store in the config-buffer.
     struct AutomationCycleDuration has drop, store, copy {
         /// Automation cycle duration in seconds.
         duration_secs: u64,
@@ -690,6 +706,33 @@ module supra_framework::automation_registry {
     }
 
     #[view]
+    /// Calculates automation fee per second for the specified task occupancy
+    /// referencing the current automation registry fee parameters, specified total/committed occupancy and current registry
+    /// maximum allowed occupancy.
+    public fun calculate_automation_fee_multiplier_for_committed_occupancy(
+        total_committed_max_gas: u64
+    ): u64 acquires ActiveAutomationRegistryConfig {
+        // Compute the automation fee multiplier for cycle
+        let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
+        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
+            &active_config.main_config,
+            (total_committed_max_gas as u256),
+            active_config.main_config.registry_max_gas_cap);
+        (automation_fee_per_sec as u64)
+    }
+
+    #[view]
+    /// Calculates automation fee per second for the current cycle
+    /// referencing the current automation registry fee parameters, and committed gas for this cycle stored in
+    /// the automation registry and current maximum allowed occupancy.
+    public fun calculate_automation_fee_unit_for_current_cycle(): u64 acquires ActiveAutomationRegistryConfig, AutomationRegistry {
+        // Compute the automation fee multiplier for this cycle
+        let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
+        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
+        calculate_automation_fee_multiplier_for_current_cycle_internal(active_config, automation_registry)
+    }
+
+    #[view]
     /// Returns the current status of the registration in the automation registry.
     public fun is_registration_enabled(): bool acquires ActiveAutomationRegistryConfig {
         borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).registration_enabled
@@ -723,15 +766,15 @@ module supra_framework::automation_registry {
 
     /// Update Automation Registry Config
     public fun update_config(
-        supra_framework: &signer,
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
+        _supra_framework: &signer,
+        _task_duration_cap_in_secs: u64,
+        _registry_max_gas_cap: u64,
+        _automation_base_fee_in_quants_per_sec: u64,
+        _flat_registration_fee_in_quants: u64,
+        _congestion_threshold_percentage: u8,
+        _congestion_base_fee_in_quants_per_sec: u64,
+        _congestion_exponent: u8,
+        _task_capacity: u16,
     ) {
         assert!(false, EDEPRECATED_SINCE_V2);
     }
@@ -751,16 +794,28 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
         system_addresses::assert_supra_framework(supra_framework);
 
+        validate_configuration_parameters_common(
+            cycle_duration_secs,
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            congestion_threshold_percentage,
+            congestion_exponent);
+
         // Update cycle duration in buffer
-        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
         let new_cycle_duration = AutomationCycleDuration {
             duration_secs: cycle_duration_secs
         };
         config_buffer::upsert(copy new_cycle_duration);
         event::emit(new_cycle_duration);
 
-        update_registration_config_internal(
-            supra_framework,
+        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
+
+        assert!(
+            automation_registry.gas_committed_for_next_epoch < registry_max_gas_cap,
+            EUNACCEPTABLE_AUTOMATION_GAS_LIMIT
+        );
+
+        let new_automation_registry_config = AutomationRegistryConfig {
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             automation_base_fee_in_quants_per_sec,
@@ -768,9 +823,15 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
-            task_capacity,
-            cycle_duration_secs,
-        );
+            task_capacity
+        };
+        config_buffer::upsert(copy new_automation_registry_config);
+
+        // next_epoch_registry_max_gas_cap will be update instantly
+        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
+        automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
+
+        event::emit(new_automation_registry_config);
 
     }
 
@@ -1030,16 +1091,16 @@ module supra_framework::automation_registry {
     /// Initialization of Automation Registry with configuration parameters is expected metrics.
     /// Deprecated in favor of initialize_v2
     public(friend) fun initialize(
-        supra_framework: &signer,
-        epoch_interval_secs: u64,
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
+        _supra_framework: &signer,
+        _epoch_interval_secs: u64,
+        _task_duration_cap_in_secs: u64,
+        _registry_max_gas_cap: u64,
+        _automation_base_fee_in_quants_per_sec: u64,
+        _flat_registration_fee_in_quants: u64,
+        _congestion_threshold_percentage: u8,
+        _congestion_base_fee_in_quants_per_sec: u64,
+        _congestion_exponent: u8,
+        _task_capacity: u16,
     ) {
         assert!(false, EDEPRECATED_SINCE_V2);
     }
@@ -1126,7 +1187,7 @@ module supra_framework::automation_registry {
         assert_automation_cycle_management_support();
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         if (cycle_info.state != CYCLE_STARTED
-            || cycle_info.start_time + cycle_info.duration_secs < timestamp::now_seconds()) {
+            || cycle_info.start_time + cycle_info.duration_secs > timestamp::now_seconds()) {
             return
         };
         on_cycle_end_internal(cycle_info)
@@ -1283,7 +1344,8 @@ module supra_framework::automation_registry {
     }
 
     /// Called by MoveVm on `AutomationBookkeepingAction::Drop` action emitted by native layer ahead of cycle transition
-    fun on_drop(vm: signer, task_indexes: vector<u64> ) acquires AutomationCycleDetails, AutomationRegistry, AutomationRefundBookkeeping {
+    fun on_drop(vm: signer, task_indexes: vector<u64>
+    ) acquires AutomationCycleDetails, AutomationRegistry, AutomationRefundBookkeeping, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
         if (vector::is_empty(&task_indexes)) {
@@ -1300,10 +1362,13 @@ module supra_framework::automation_registry {
             &automation_registry.registry_fee_address_signer_cap
         );
 
+        let current_time = timestamp::now_seconds();
+        let transaction_state = std::option::borrow_mut(&mut cycle_info.transition_state);
         let removed_tasks = vector[];
         vector::for_each(task_indexes, |task_index| {
             if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
                 let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
+                assert!(task.state == CANCELLED || task.expiry_time <= current_time , EINVALID_DROP_ACTION);
 
                 safe_deposit_refund(
                     refund_bookkeeping,
@@ -1314,10 +1379,11 @@ module supra_framework::automation_registry {
                     task.locked_fee_for_next_epoch,
                     task.locked_fee_for_next_epoch);
                 vector::push_back(&mut removed_tasks, task_index);
+                append_processed_task(transaction_state, task_index);
             };
         });
 
-        update_cycle_transition_state_from_finished(automation_registry, cycle_info, removed_tasks);
+        update_cycle_transition_state_from_finished(automation_registry, cycle_info);
         event::emit(RemovedTasks {
             task_indexes: removed_tasks
         });
@@ -1325,7 +1391,7 @@ module supra_framework::automation_registry {
     }
 
     /// Called by MoveVm on `AutomationBookkeepingAction::Charge` action emitted by native layer ahead of cycle transition
-    fun on_charge(vm: signer, automation_fee_per_sec: u64, task_indexes: vector<u64>, gas_committed_for_new_cycle: u64)
+    fun on_charge(vm: signer, task_indexes: vector<u64>)
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
@@ -1339,37 +1405,34 @@ module supra_framework::automation_registry {
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
 
         let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
-        if (transition_state.gas_committed_for_this_cycle == 0) {
-            transition_state.gas_committed_for_this_cycle = gas_committed_for_new_cycle;
-            transition_state.automation_fee_per_sec = automation_fee_per_sec;
-        } else {
-            assert!(transition_state.gas_committed_for_this_cycle == gas_committed_for_new_cycle, EINVALID_CHARGE_ACTION);
-            assert!(transition_state.automation_fee_per_sec == automation_fee_per_sec, EINVALID_CHARGE_ACTION);
-        };
 
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
         let automation_registry_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         let intermedate_result = IntermediateStateOfEpochChange {
             removed_tasks: vector[],
-            gas_committed_for_new_epoch: gas_committed_for_new_cycle,
+            gas_committed_for_new_epoch: transition_state.gas_committed_for_new_cycle,
             gas_committed_for_next_epoch: 0,
             epoch_locked_fees: coin::zero()
         };
 
-        let processed_tasks = try_charge_tasks_automation_fees(
+        let charge_duration = transition_state.new_cycle_duration;
+        let automation_fee_per_sec = (transition_state.automation_fee_per_sec as u256);
+
+        try_charge_tasks_automation_fees(
             automation_registry,
             refund_bookkeeping,
+            transition_state,
             &automation_registry_config.main_config,
-            (automation_fee_per_sec as u256),
-        transition_state.new_cycle_duration,
+            automation_fee_per_sec,
+        charge_duration,
         timestamp::now_seconds(),
             task_indexes,
             &mut intermedate_result
         );
         let IntermediateStateOfEpochChange {
             removed_tasks,
-            gas_committed_for_new_epoch,
+            gas_committed_for_new_epoch: _,
             gas_committed_for_next_epoch,
             epoch_locked_fees
         } = intermedate_result;
@@ -1378,7 +1441,7 @@ module supra_framework::automation_registry {
         transition_state.gas_committed_for_next_cycle = transition_state.gas_committed_for_next_cycle + gas_committed_for_next_epoch;
         coin::deposit(automation_registry.registry_fee_address, epoch_locked_fees);
 
-        update_cycle_transition_state_from_finished(automation_registry, cycle_info, processed_tasks);
+        update_cycle_transition_state_from_finished(automation_registry, cycle_info);
 
         if (!vector::is_empty(&removed_tasks)) {
             event::emit(RemovedTasks{
@@ -1389,7 +1452,7 @@ module supra_framework::automation_registry {
 
     /// Called by MoveVm on `AutomationBookkeepingAction::RefundAndCleanup` action.
     /// Action from native layer will be tiggered by move layer when automation registy cycle is updated to SUSPENDED.
-    fun on_refund_and_cleanup(vm: signer, duration: u64, automation_fee_per_sec: u64, task_indexes: vector<u64> )
+    fun on_refund_and_cleanup(vm: signer, task_indexes: vector<u64> )
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
@@ -1401,7 +1464,8 @@ module supra_framework::automation_registry {
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
-        assert!(cycle_info.duration_secs >= duration, EINVALID_REFUND_DURATION);
+        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+
 
         let automation_registry = borrow_global_mut<AutomationRegistry>(@supra_framework);
         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(@supra_framework);
@@ -1417,13 +1481,14 @@ module supra_framework::automation_registry {
             if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
                 let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
 
-                if (task.state != PENDING) {
+                // Do not attempt fee refund if remaining duration is 0
+                if (task.state != PENDING && transition_state.remaining_cycle_duration != 0) {
                     let refund = calculate_task_fee(
                         &arc.main_config,
                         &task,
-                        duration,
+                        transition_state.remaining_cycle_duration,
                         current_time,
-                        (automation_fee_per_sec as u256));
+                        (transition_state.automation_fee_per_sec as u256));
                     let (_, remaining_epoch_locked_fees) = safe_fee_refund(
                         epoch_locked_fees,
                         &resource_signer,
@@ -1443,10 +1508,11 @@ module supra_framework::automation_registry {
                     task.locked_fee_for_next_epoch,
                     task.locked_fee_for_next_epoch);
                 vector::push_back(&mut removed_tasks, task_index);
+                append_processed_task(transition_state, task_index);
             };
         });
 
-        update_cycle_transition_state_from_suspended(automation_registry, cycle_info, removed_tasks);
+        update_cycle_transition_state_from_suspended(automation_registry, cycle_info);
         event::emit(RemovedTasks {
             task_indexes: removed_tasks
         });
@@ -1472,10 +1538,9 @@ module supra_framework::automation_registry {
     fun update_cycle_transition_state_from_suspended(
         automation_registry: &mut AutomationRegistry,
         cycle_info: &mut AutomationCycleDetails,
-        processed_tasks: vector<u64>) acquires  ActiveAutomationRegistryConfig  {
+    ) acquires  ActiveAutomationRegistryConfig  {
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
         let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
-        update_processed_tasks(transition_state, processed_tasks);
 
         if (!is_transition_finalized(transition_state)) {
             return
@@ -1502,17 +1567,26 @@ module supra_framework::automation_registry {
     fun update_cycle_transition_state_from_finished(
         automation_registry: &mut AutomationRegistry,
         cycle_info: &mut AutomationCycleDetails,
-        processed_tasks: vector<u64>
-    ) {
+    ) acquires ActiveAutomationRegistryConfig {
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
 
-        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
-        // TODO maybe do this via native function where duplicates will be avoided
-        update_processed_tasks(transition_state, processed_tasks);
+        let transition_state = std::option::borrow(&cycle_info.transition_state);
         let transition_finalized = is_transition_finalized(transition_state);
 
         if (transition_finalized) {
-            on_cycle_start_internal(automation_registry, cycle_info);
+            automation_registry.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
+            automation_registry.gas_committed_for_this_epoch = (transition_state.gas_committed_for_new_cycle as u256);
+            automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
+            automation_registry.epoch_locked_fees = transition_state.locked_fees;
+
+            // Set current timestamp as cycle start_time
+            // Increase cycle and update the state to Started
+            move_to_started_state(cycle_info);
+            if (!vector::is_empty(&automation_registry.epoch_active_task_ids)) {
+                event::emit(ActiveTasks {
+                    task_indexes: automation_registry.epoch_active_task_ids
+                });
+            }
         };
         if (transition_finalized  && !features::supra_native_automation_enabled()) {
             move_to_suspended_state(automation_registry, cycle_info)
@@ -1555,6 +1629,7 @@ module supra_framework::automation_registry {
         congestion_threshold_percentage: u8,
         congestion_exponent: u8,
     ) {
+        assert!(cycle_duration_secs > 0, ECYCLE_DURATION_NON_ZERO);
         assert!(congestion_threshold_percentage <= MAX_PERCENTAGE, EMAX_CONGESTION_THRESHOLD);
         assert!(congestion_exponent > 0, ECONGESTION_EXP_NON_ZERO);
         assert!(task_duration_cap_in_secs > cycle_duration_secs, EUNACCEPTABLE_TASK_DURATION_CAP);
@@ -1570,45 +1645,33 @@ module supra_framework::automation_registry {
         (registry_fee_resource_signer, registry_fee_address_signer_cap)
     }
 
-    fun on_cycle_start_internal(
-        automation_registry: &mut AutomationRegistry,
-        cycle_info: &mut AutomationCycleDetails
-    ) {
-        // Indicates that moving to cycle start from transition state.
-        assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
-        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
-
-        automation_registry.gas_committed_for_next_epoch = transition_state.gas_committed_for_next_cycle;
-        automation_registry.gas_committed_for_this_epoch = (transition_state.gas_committed_for_this_cycle as u256);
-        automation_registry.epoch_active_task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
-        automation_registry.epoch_locked_fees = transition_state.locked_fees;
-
-        // Set current timestamp as cycle start_time
-        // Increase cycle and update the state to Started
-        move_to_started_state(cycle_info);
-        if (!vector::is_empty(&automation_registry.epoch_active_task_ids)) {
-            event::emit(ActiveTasks {
-                task_indexes: automation_registry.epoch_active_task_ids
-            });
-        }
-    }
-
     fun on_cycle_end_internal(cycle_info: &mut AutomationCycleDetails) acquires ActiveAutomationRegistryConfig, AutomationRegistry {
         let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
+        if (enumerable_map::length(&automation_registry.tasks) == 0) {
+            // Registry is empty update config-buffer and move to started state directly
+            update_config_from_buffer(cycle_info);
+            move_to_started_state(cycle_info);
+            return
+        };
         let transition_state = TransitionState {
+            remaining_cycle_duration: 0,
             new_cycle_duration: cycle_info.duration_secs,
             automation_fee_per_sec: 0,
-            gas_committed_for_this_cycle: 0,
+            gas_committed_for_new_cycle: automation_registry.gas_committed_for_next_epoch,
             gas_committed_for_next_cycle: 0,
             locked_fees: 0,
             expected_tasks_to_be_processed: enumerable_map::get_map_list(&automation_registry.tasks),
             actual_processed_tasks: vector[]
         };
         cycle_info.transition_state = std::option::some(transition_state);
-        update_cycle_state_to(cycle_info, CYCLE_FINISHED);
         // During cycle transition we update config only after transition state is created in order to have new cycle
         // duration as transition parameter.
         update_config_from_buffer(cycle_info);
+        // Calculate automation fee per second for the new epoch only after configuration is updated.
+        let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+        transition_state.automation_fee_per_sec =
+            calculate_automation_fee_multiplier_for_committed_occupancy(transition_state.gas_committed_for_new_cycle);
+        update_cycle_state_to(cycle_info, CYCLE_FINISHED);
     }
 
     fun update_cycle_state_to(cycle_info: &mut AutomationCycleDetails, state: u8) {
@@ -1646,18 +1709,36 @@ module supra_framework::automation_registry {
     ///       which will lead to simply deposit refund and cleanup.
     ///   c) when cycle transition was in progress and there was a feature suspension, but it could not be applied,
     ///      and postponed till the cycle transition concluded
-    fun move_to_suspended_state(automation_registry: &AutomationRegistry, cycle_info: &mut AutomationCycleDetails) {
+    fun move_to_suspended_state(automation_registry: &AutomationRegistry, cycle_info: &mut AutomationCycleDetails
+    ) acquires  ActiveAutomationRegistryConfig {
+        if (enumerable_map::length(&automation_registry.tasks) == 0) {
+            // Registry is empty move to ready state directly
+            update_cycle_state_to(cycle_info, CYCLE_READY);
+            return
+        };
         if (std::option::is_none(&cycle_info.transition_state)) {
+            assert!(timestamp::now_seconds() >= cycle_info.start_time, EINVALID_REGISTRY_STATE);
+            assert!(cycle_info.state == CYCLE_STARTED, EINVALID_REGISTRY_STATE);
+            let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
             let transition_state = TransitionState {
+                remaining_cycle_duration: cycle_info.duration_secs + cycle_info.start_time - timestamp::now_seconds(),
                 new_cycle_duration: cycle_info.duration_secs,
-                automation_fee_per_sec: 0,
-                gas_committed_for_this_cycle: 0,
+                automation_fee_per_sec: calculate_automation_fee_multiplier_for_current_cycle_internal(active_config, automation_registry),
+                gas_committed_for_new_cycle: 0,
                 gas_committed_for_next_cycle: 0,
                 locked_fees: 0,
                 expected_tasks_to_be_processed: enumerable_map::get_map_list(&automation_registry.tasks),
                 actual_processed_tasks: vector[]
             };
             cycle_info.transition_state = std::option::some(transition_state);
+        } else {
+            assert!(cycle_info.state == CYCLE_FINISHED, EINVALID_REGISTRY_STATE);
+            let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+            // Did not manage to charge cycle fee, so automation_fee_per_sec be 0 along with remaining duration
+            // So the tasks sent for refund, will get only deposit refunded.
+            transition_state.remaining_cycle_duration = 0;
+            transition_state.automation_fee_per_sec = 0;
+            transition_state.gas_committed_for_new_cycle = 0;
         };
         update_cycle_state_to(cycle_info, CYCLE_SUSPENDED)
     }
@@ -1927,6 +2008,18 @@ module supra_framework::automation_registry {
         downscale_to_u64(automation_fee_for_interval)
     }
 
+    fun calculate_automation_fee_multiplier_for_current_cycle_internal(
+        active_config: &ActiveAutomationRegistryConfig,
+        automation_registry: &AutomationRegistry
+    ): u64 {
+        // Compute the automation fee multiplier for this cycle
+        let multiplier = calculate_automation_fee_multiplier_for_epoch(
+            &active_config.main_config,
+            automation_registry.gas_committed_for_this_epoch,
+            active_config.main_config.registry_max_gas_cap);
+        (multiplier as u64)
+    }
+
     /// Calculate automation fee multiplier for epoch. It is measured in quants/sec.
     fun calculate_automation_fee_multiplier_for_epoch(
         arc: &AutomationRegistryConfig,
@@ -2013,14 +2106,14 @@ module supra_framework::automation_registry {
     fun try_charge_tasks_automation_fees(
         automation_registry: &mut AutomationRegistry,
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
+        transition_state: &mut TransitionState,
         arc: &AutomationRegistryConfig,
         automation_fee_per_sec: u256,
         cycle_duration: u64,
         current_time: u64,
         task_ids: vector<u64>,
         intermediate_state: &mut IntermediateStateOfEpochChange,
-    ): vector<u64> {
-        let processed_tasks = vector[];
+    ) {
 
         let resource_signer = account::create_signer_with_capability(
             &automation_registry.registry_fee_address_signer_cap
@@ -2032,10 +2125,11 @@ module supra_framework::automation_registry {
 
         // Process each active task and calculate fee for the epoch for the tasks
         vector::for_each(task_ids, |task_index| {
-            if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
-                vector::push_back(&mut processed_tasks, task_index);
+            if (!already_processed(transition_state, task_index) && enumerable_map::contains(&automation_registry.tasks, task_index)) {
+                append_processed_task(transition_state, task_index);
                 let task = {
                     let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
+                    assert!(task_meta.state != CANCELLED, EINVALID_CHARGE_ACTION);
                     let fee= calculate_task_fee(arc, task_meta, cycle_duration, current_time, automation_fee_per_sec);
                     // If the task reached this phase that means it is valid active task for the new epoch.
                     // During cleanup all expired tasks has been removed from the registry but the state of the tasks is not updated.
@@ -2058,71 +2152,11 @@ module supra_framework::automation_registry {
                     refund_bookkeeping,
                     &resource_signer,
                     task,
+                    current_time,
                     current_cycle_end_time,
                     intermediate_state
                 );
             };
-        });
-        processed_tasks
-    }
-
-    /// Processes automation task fees by checking user balances and task's commitment on automation-fee, i.e. automation-fee-cap
-    /// - If the user has sufficient balance, deducts the fee and emits a success event.
-    /// - If the balance is insufficient, removes the task and emits a cancellation event.
-    /// - If calculated fee for the epoch surpasses task's automation-fee-cap task is removed and cancellation event is emitted.
-    /// Return estimated committed gas for the next epoch, locked automation fee amount for this epoch, and list of active task indexes
-    fun try_withdraw_task_automation_fees(
-        automation_registry: &mut AutomationRegistry,
-        refund_bookkeeping: &mut AutomationRefundBookkeeping,
-        arc: &AutomationRegistryConfig,
-        epoch_interval: u64,
-        current_time: u64,
-        intermediate_state: &mut IntermediateStateOfEpochChange,
-    ) {
-        // Compute the automation fee multiplier for epoch
-        let automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
-            arc,
-            (intermediate_state.gas_committed_for_new_epoch as u256),
-            arc.registry_max_gas_cap);
-
-        let task_ids = enumerable_map::get_map_list(&automation_registry.tasks);
-        let resource_signer = account::create_signer_with_capability(
-            &automation_registry.registry_fee_address_signer_cap
-        );
-        let current_epoch_end_time = current_time + epoch_interval;
-
-        // Sort task indexes to charge automation fees in the tasks chronological order
-        sort_vector(&mut task_ids);
-
-        // Process each active task and calculate fee for the epoch for the tasks
-        vector::for_each(task_ids, |task_index| {
-            let task = {
-                let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
-                let fee= calculate_task_fee(arc, task_meta, epoch_interval, current_time, automation_fee_per_sec);
-                // If the task reached this phase that means it is valid active task for the new epoch.
-                // During cleanup all expired tasks has been removed from the registry but the state of the tasks is not updated.
-                // As here we need to distinguish new tasks from already existing active tasks,
-                // as the fee calculation for them will be different based on their active duration in the epoch.
-                // For more details see calculate_task_fee function.
-                task_meta.state = ACTIVE;
-                AutomationTaskFeeMeta {
-                    task_index,
-                    owner: task_meta.owner,
-                    fee,
-                    expiry_time: task_meta.expiry_time,
-                    automation_fee_cap: task_meta.automation_fee_cap_for_epoch,
-                    max_gas_amount: task_meta.max_gas_amount,
-                    locked_deposit_fee: task_meta.locked_fee_for_next_epoch,
-                }
-            };
-            try_withdraw_task_automation_fee(
-                automation_registry,
-                refund_bookkeeping,
-                &resource_signer,
-                task,
-                current_epoch_end_time,
-                intermediate_state
-            );
         });
     }
 
@@ -2131,10 +2165,14 @@ module supra_framework::automation_registry {
         refund_bookkeeping: &mut AutomationRefundBookkeeping,
         resource_signer: &signer,
         task: AutomationTaskFeeMeta,
+        current_time: u64,
         current_epoch_end_time: u64,
         intermediate_state: &mut IntermediateStateOfEpochChange) {
         // Remove the automation task if the epoch fee cap is exceeded
-        if (task.fee > task.automation_fee_cap) {
+        // It might happen that task has been expired by the time charging is being done.
+        // This may be caused by the fact that bookkeeping transactions has been withheld due to epoch transition.
+        let is_task_expired = task.expiry_time <= current_time;
+        if (task.fee > task.automation_fee_cap || is_task_expired) {
             safe_deposit_refund(
                 refund_bookkeeping,
                 resource_signer,
@@ -2146,12 +2184,14 @@ module supra_framework::automation_registry {
             );
             enumerable_map::remove_value(&mut automation_registry.tasks, task.task_index);
             vector::push_back(&mut intermediate_state.removed_tasks, task.task_index);
-            event::emit(TaskCancelledCapacitySurpassed {
-                task_index: task.task_index,
-                owner: task.owner,
-                fee: task.fee,
-                automation_fee_cap: task.automation_fee_cap,
-            });
+            if (!is_task_expired) {
+                event::emit(TaskCancelledCapacitySurpassed {
+                    task_index: task.task_index,
+                    owner: task.owner,
+                    fee: task.fee,
+                    automation_fee_cap: task.automation_fee_cap,
+                });
+            };
             return
         };
         let user_balance = coin::balance<SupraCoin>(task.owner);
@@ -2232,54 +2272,6 @@ module supra_framework::automation_registry {
             &automation_registry.registry_fee_address_signer_cap
         );
         coin::transfer<SupraCoin>(&resource_signer, to, amount);
-    }
-
-    /// Update Automation Registry Config releated to registration.
-    fun update_registration_config_internal(
-        supra_framework: &signer,
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
-        cycle_duration_secs: u64,
-    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
-        system_addresses::assert_supra_framework(supra_framework);
-
-        let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
-
-        validate_configuration_parameters_common(
-            cycle_duration_secs,
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            congestion_threshold_percentage,
-            congestion_exponent);
-
-        assert!(
-            automation_registry.gas_committed_for_next_epoch < registry_max_gas_cap,
-            EUNACCEPTABLE_AUTOMATION_GAS_LIMIT
-        );
-
-        let new_automation_registry_config = AutomationRegistryConfig {
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            automation_base_fee_in_quants_per_sec,
-            flat_registration_fee_in_quants,
-            congestion_threshold_percentage,
-            congestion_base_fee_in_quants_per_sec,
-            congestion_exponent,
-            task_capacity
-        };
-        config_buffer::upsert(copy new_automation_registry_config);
-
-        // next_epoch_registry_max_gas_cap will be update instantly
-        let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
-        automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
-
-        event::emit(new_automation_registry_config);
     }
 
     fun check_registration_task_duration(
@@ -2372,6 +2364,7 @@ module supra_framework::automation_registry {
         let user_addr = signer::address_of(user);
         account::create_account_for_test(user_addr);
         account::create_account_for_test(@supra_framework);
+        timestamp::set_time_has_started_for_testing(supra_framework);
 
         let (burn_cap, mint_cap) = supra_coin::initialize_for_test(supra_framework);
 
@@ -2393,21 +2386,25 @@ module supra_framework::automation_registry {
         supra_coin::mint(supra_framework, get_registry_fee_address(), REGISTRY_DEFAULT_BALANCE);
         coin::destroy_burn_cap(burn_cap);
         coin::destroy_mint_cap(mint_cap);
-
-        timestamp::set_time_has_started_for_testing(supra_framework);
+        toggle_custom_feature_flags(supra_framework, vector[features::get_supra_automation_cycle_feature()], true);
     }
 
     #[test_only]
     fun toggle_feature_flag(supra_framework: &signer, enable: bool) {
         let flag = vector[features::get_supra_native_automation_feature()];
+        toggle_custom_feature_flags(supra_framework, flag, enable);
+    }
+
+    #[test_only]
+    fun toggle_custom_feature_flags(supra_framework: &signer, flags: vector<u64>, enable: bool) {
         if (enable) {
             features::change_feature_flags_for_testing(supra_framework,
-                flag,
+                flags,
                 vector::empty<u64>());
         } else {
             features::change_feature_flags_for_testing(supra_framework,
                 vector::empty<u64>(),
-                flag)
+                flags)
         }
     }
 
@@ -2444,10 +2441,11 @@ module supra_framework::automation_registry {
     }
 
     #[test_only]
-    /// Initializes registry and enables SUPRA_NATIVE_AUTOMATION feature flag
+    /// Initializes registry. enables SUPRA_NATIVE_AUTOMATION feature flag and initialize config-buffer
     fun initialize_registry_test(supra_framework: &signer, user: &signer) {
-        initialize_registry_test_partially(supra_framework, user);
+        config_buffer::initialize(supra_framework);
         toggle_feature_flag(supra_framework, true);
+        initialize_registry_test_partially(supra_framework, user);
     }
 
 
@@ -2481,6 +2479,9 @@ module supra_framework::automation_registry {
         let task_details = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
         if (state != PENDING) {
             automation_registry.gas_committed_for_this_epoch = automation_registry.gas_committed_for_this_epoch + (max_gas_amount as u256);
+        };
+        if (state == CANCELLED) {
+            automation_registry.gas_committed_for_next_epoch = automation_registry.gas_committed_for_next_epoch - max_gas_amount;
         };
         task_details.state = state;
         task_index
@@ -2528,20 +2529,6 @@ module supra_framework::automation_registry {
     ) {
         let current_balance = coin::balance<SupraCoin>(account);
         assert!(current_balance == expected_balance, current_balance);
-    }
-
-    #[test_only]
-    fun consume_intermediate_state(
-        intermediate_state: IntermediateStateOfEpochChange,
-    ) {
-        let IntermediateStateOfEpochChange {
-            gas_committed_for_new_epoch: _,
-            gas_committed_for_next_epoch: _,
-            epoch_locked_fees,
-            removed_tasks: _,
-        } = intermediate_state;
-
-        destroy_zero(epoch_locked_fees);
     }
 
     /// Represents the fee charged for an automation task execution and some additional information.
@@ -2685,6 +2672,8 @@ module supra_framework::automation_registry {
     fun check_update_config_success_update(
         framework: &signer, user: &signer
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        let fwk_address = address_of(framework);
+
         initialize_registry_test(framework, user);
         register(user,
             PAYLOAD,
@@ -2695,7 +2684,6 @@ module supra_framework::automation_registry {
             PARENT_HASH,
             AUX_DATA
         );
-        config_buffer::initialize(framework);
         // Next epoch gas committed gas is less than the new limit value.
         // Configuration parameter will update after on new epoch
         update_config_v2(framework,
@@ -2707,15 +2695,20 @@ module supra_framework::automation_registry {
             2000,
             5,
             200,
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS
+            1000,
         );
 
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
         assert!(state.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 1);
         assert!(state.next_epoch_registry_max_gas_cap == 75, 1);
 
-        // Automation gas limit
-        on_new_epoch();
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        let expected_cycle_duration = {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_STARTED, 1);
+            cycle_details.duration_secs
+        };
+        monitor_cycle_end();
         let state = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework).main_config;
         assert!(state.registry_max_gas_cap == 75, 2);
         assert!(state.task_duration_cap_in_secs == 1_626_560, 3);
@@ -2725,7 +2718,14 @@ module supra_framework::automation_registry {
         assert!(state.congestion_base_fee_in_quants_per_sec == 2000, 7);
         assert!(state.congestion_exponent == 5, 8);
         assert!(state.task_capacity == 200, 9);
-        // TODO check cycle duration update as well
+
+        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+        assert!(cycle_details.state == CYCLE_FINISHED, 1);
+        assert!(std::option::is_some(&cycle_details.transition_state), 2);
+        assert!(cycle_details.duration_secs == expected_cycle_duration, 3);
+
+        let transition_state = std::option::borrow(&cycle_details.transition_state);
+        assert!(transition_state.new_cycle_duration  == 1000, 7);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
@@ -2842,6 +2842,28 @@ module supra_framework::automation_registry {
             EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
     }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = ECYCLE_DURATION_NON_ZERO, location = Self)]
+    fun check_config_udpate_with_invalid_cycle_duration(
+        framework: &signer, user: &signer
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig {
+        initialize_registry_test(framework, user);
+        // Specified task duration cap is less than epoch length
+        update_config_v2(
+            framework,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS + 1,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            0
+        );
+    }
+
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_task_registration(
@@ -3139,6 +3161,43 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = ECYCLE_TRANSITION_IN_PROGRESS, location = Self)]
+    fun check_registration_in_cycle_transition_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        register(user,
+            PAYLOAD,
+            86400,
+            10_000,
+            70,
+            100_000,
+            PARENT_HASH,
+            AUX_DATA
+        );
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        let fwk_address = address_of(framework);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+
+        // Expected cycle to be in suspended state so the following registration should fail
+        register(user,
+            PAYLOAD,
+            86400,
+            10_000,
+            70,
+            1,
+            PARENT_HASH,
+            AUX_DATA
+        );
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
     fun check_task_activation_on_new_epoch(
         framework: &signer,
         user: &signer
@@ -3204,45 +3263,39 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
 
-        register(user,
-            PAYLOAD,
-            86400,
+        let _ = register_with_state(
+            framework,
+            user,
             10,
-            20,
             1000,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE
         );
-        register(user,
-            PAYLOAD,
-            86400,
+        let _ = register_with_state(
+            framework,
+            user,
             10,
-            20,
             1000,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE
         );
-        register(user,
-            PAYLOAD,
-            86400,
+        let _ = register_with_state(
+            framework,
+            user,
             10,
-            20,
             1000,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE
         );
-        register(user,
-            PAYLOAD,
-            86400,
+        let _ = register_with_state(
+            framework,
+            user,
             10,
-            20,
             1000,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE
         );
 
-        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
         assert!(40 == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
         let expected_ids = vector<u64>[0, 1, 2, 3];
@@ -3360,19 +3413,42 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
 
-        register(user,
-            PAYLOAD,
-            86400,
+        let _ = register_with_state( framework,
+            user,
             10,
-            20,
             1000,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE
         );
-        timestamp::update_global_time_for_test_secs(50);
-        on_new_epoch();
         // Cancel the same task 2 times
         cancel_task(user, 0);
+        cancel_task(user, 0);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = ECYCLE_TRANSITION_IN_PROGRESS, location = Self)]
+    fun check_cancellation_in_transition_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        initialize_registry_test(framework, user);
+
+        let _ = register_with_state( framework,
+            user,
+            10,
+            1000,
+            86400,
+            ACTIVE
+        );
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        let fwk_address = address_of(framework);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+        // Cancel the in the FINISHED state
         cancel_task(user, 0);
     }
 
@@ -3383,11 +3459,12 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 100_000;
+        let max_gas_amount = 1_000_000;
 
         register(user,
             PAYLOAD,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
-            1_000_000, // normal gas amount
+            max_gas_amount, // normal gas amount
             20,
             100_000,
             PARENT_HASH,
@@ -3403,8 +3480,9 @@ module supra_framework::automation_registry {
         check_account_balance(user_address, expected_current_balance);
         check_account_balance(registry_fee_address, expected_registry_balance);
 
-        timestamp::update_global_time_for_test_secs(50);
-        on_new_epoch();
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        on_charge(create_signer(@vm_reserved), vector[0]);
 
         // 10 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
@@ -3416,17 +3494,18 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
-    fun check_congestion_fee_charge_on_new_epoch(
+    fun check_congestion_fee_charge_on_charge(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 10_000_000;
+        let max_gas_amount = 85_000_000;
 
         register(user,
             PAYLOAD,
             3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
-            85_000_000, // congestion threshold reached
+            max_gas_amount, // congestion threshold reached
             20,
             automation_fee_cap,
             PARENT_HASH,
@@ -3442,8 +3521,10 @@ module supra_framework::automation_registry {
         check_account_balance(user_address, expected_current_balance);
         check_account_balance(registry_fee_address, expected_registry_balance);
 
-        timestamp::update_global_time_for_test_secs(50);
-        on_new_epoch();
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        on_charge(create_signer(@vm_reserved), vector[0]);
+
         has_task_with_id(0);
 
         // 85/100 * 1000 = 850 - automation_epoch_fee_per_second, 7200 epoch duration
@@ -3458,236 +3539,1030 @@ module supra_framework::automation_registry {
             expected_registry_balance + expected_epoch_fee);
     }
 
-    // #[test(framework = @supra_framework, user = @0x1cafa)]
-    // fun check_update_state_for_new_epoch(
-    //     framework: &signer,
-    //     user: &signer
-    // ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-    //     initialize_registry_test(framework, user);
-    //     let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-    //     let automation_fee_cap = 100_000_000;
-    //     let exists = true;
-    //
-    //     let task1 = register_with_state(
-    //         framework,
-    //         user,
-    //         44_000_000,
-    //         automation_fee_cap,
-    //         task_exipry_time,
-    //         ACTIVE);
-    //     let task2 = register_with_state(
-    //         framework,
-    //         user,
-    //         44_000_000,
-    //         automation_fee_cap,
-    //         task_exipry_time,
-    //         ACTIVE);
-    //     let task3 = register_with_state(
-    //         framework,
-    //         user,
-    //         11_000_000,
-    //         automation_fee_cap,
-    //         task_exipry_time,
-    //         PENDING);
-    //     let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-    //     let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-    //
-    //
-    //     // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
-    //     let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-    //     // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
-    //     let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
-    //
-    //     let fwk_address = address_of(framework);
-    //     let user_address = address_of(user);
-    //
-    //     // No refund when there is no locked fee.
-    //     set_locked_fee(framework, 0);
-    //     {
-    //         let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
-    //         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
-    //         let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-    //         let aei = borrow_global<AutomationCycleInfo>(fwk_address);
-    //         let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
-    //         consume_intermediate_state(result);
-    //         // If there is no locked fee, nothing to refund;
-    //         // tasks only will be charged for the next epoch.
-    //         check_account_balance(user_address, expected_user_current_balance);
-    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    //         // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-    //         check_task_state(ar, task3, exists, PENDING);
-    //     };
-    //
-    //     // Set some locked fee which is enough to pay refund if necessary
-    //     set_locked_fee(framework, 100_000_000);
-    //
-    //     {
-    //         // if epoch length matches or greater the expected epoch interval then no refund is expected
-    //         // even if there is a locked fee.
-    //         let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
-    //         let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
-    //         let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-    //         let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-    //
-    //         let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-    //         consume_intermediate_state(result);
-    //
-    //         check_account_balance(user_address, expected_user_current_balance);
-    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    //         check_task_state(ar, task1, exists, ACTIVE);
-    //         check_task_state(ar, task2, exists, ACTIVE);
-    //         // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-    //         check_task_state(ar, task3, exists, PENDING);
-    //
-    //         // Refund is expected only for ACTIVE AND CANCELLED TASK BUT NOT FOR PENDING
-    //         update_task_state(ar, task2, CANCELLED);
-    //         let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
-    //         consume_intermediate_state(result);
-    //         // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
-    //         let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task
-    //             + automation_fee_cap; // refund of the depodit for cancelled task
-    //         expected_user_current_balance = expected_user_current_balance + expected_refund;
-    //         expected_registry_current_balance = expected_registry_current_balance - expected_refund;
-    //
-    //         check_account_balance(user_address, expected_user_current_balance);
-    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    //         check_task_state(ar, task1, exists, ACTIVE);
-    //         check_task_state(ar, task2, !exists, CANCELLED);
-    //         // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-    //         check_task_state(ar, task3, exists, PENDING);
-    //
-    //         // Now we have only task1 as Active and task 3 as pending.
-    //         // If epoch duration surpasses tasks expiration time, then they are refunded on  locked deposit, and removed from registry.
-    //         // even pending task.
-    //         let result = update_state_for_new_epoch(
-    //             ar,
-    //             refund_bookkeeping,
-    //             arc,
-    //             aei,
-    //             task_exipry_time + EPOCH_INTERVAL_FOR_TEST_IN_SECS
-    //         );
-    //         consume_intermediate_state(result);
-    //         let expected_refund = 2 * automation_fee_cap; // refund of the depodit for both available tasks
-    //
-    //         expected_user_current_balance = expected_user_current_balance + expected_refund;
-    //         expected_registry_current_balance = expected_registry_current_balance - expected_refund;
-    //
-    //         check_account_balance(user_address, expected_user_current_balance);
-    //         check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    //     };
-    // }
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_drop_execution(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let exists = true;
 
-    // #[test(framework = @supra_framework, user = @0x1cafa)]
-    // fun check_update_state_for_new_epoch_with_remaining_time_refund(
-    //     framework: &signer,
-    //     user: &signer
-    // ) acquires AutomationRegistry, AutomationCycleInfo, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
-    //     initialize_registry_test(framework, user);
-    //     let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
-    //     let automation_fee_cap = 100_000_000;
-    //     let exists = true;
-    //
-    //     let task1 = register_with_state(
-    //         framework,
-    //         user,
-    //         44_000_000,
-    //         automation_fee_cap,
-    //         task_exipry_time,
-    //         ACTIVE);
-    //     let task2 = register_with_state(
-    //         framework,
-    //         user,
-    //         44_000_000,
-    //         automation_fee_cap,
-    //         task_exipry_time,
-    //         CANCELLED);
-    //     let task3 = register_with_state(
-    //         framework,
-    //         user,
-    //         11_000_000,
-    //         automation_fee_cap,
-    //         task_exipry_time,
-    //         PENDING);
-    //     let registration_charges = 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-    //     let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
-    //     let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
-    //
-    //
-    //     // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
-    //     let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-    //     // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
-    //     let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
-    //
-    //     let fwk_address = address_of(framework);
-    //     let user_address = address_of(user);
-    //
-    //
-    //     // Set some locked fee which is enough to pay refund if necessary
-    //     set_locked_fee(framework, 100_000_000);
-    //
-    //     // Refund is expected only for the remaing time till the task expiry time for both cancelled and active tasks
-    //     // Task was expiring in the middle of the 3rd epoch, but epoch duration was cat short by 3/4
-    //     let current_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 4;
-    //     // update epoch-start-time to be 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS
-    //     {
-    //         let aei = borrow_global_mut<AutomationEpochInfo>(fwk_address);
-    //         aei.start_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
-    //     };
-    //
-    //     let ar = borrow_global_mut<AutomationRegistry>(fwk_address);
-    //     let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
-    //     let arc = &borrow_global<ActiveAutomationRegistryConfig>(fwk_address).main_config;
-    //     let aei = borrow_global<AutomationEpochInfo>(fwk_address);
-    //
-    //     check_account_balance(user_address, expected_user_current_balance);
-    //     check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    //
-    //     let result = update_state_for_new_epoch(ar, refund_bookkeeping, arc, aei, current_time);
-    //     consume_intermediate_state(result);
-    //     // It is expected that the tasks will be chared only for 1/2 epoch fee, so if the epoch lenght is 1/4,
-    //     // then refund should be 1/4.
-    //     // as account has 2 tasks with same automation and congestion fees then refund is double
-    //     // Half of each task epoch-fee is refunded due to short epoch + locked deposit fee for the cancelled task
-    //     let expected_refund = (expected_congestion_fee_per_task + expected_automation_fee_per_task) / 2
-    //             + automation_fee_cap; // refund of the depodit for cancelled task
-    //
-    //     expected_user_current_balance = expected_user_current_balance + expected_refund;
-    //     expected_registry_current_balance = expected_registry_current_balance - expected_refund;
-    //
-    //     check_task_state(ar, task1, exists, ACTIVE);
-    //     check_task_state(ar, task2, !exists, CANCELLED);
-    //     // Task state is still pending, tasks will be activated after their epoch-fee is calculated
-    //     check_task_state(ar, task3, exists, PENDING);
-    //
-    //     check_account_balance(user_address, expected_user_current_balance);
-    //     // // Check registry balance
-    //     check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
-    // }
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task3 = register_with_state(
+            framework,
+            user,
+            11_000_000,
+            automation_fee_cap,
+            task_exipry_time / 2,
+            ACTIVE);
+        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+
+        // // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        // let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        // let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        // Update time so task3 is expired.
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
+        on_drop(create_signer(@vm_reserved), vector[task2, task3]);
+
+        {
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(vector::contains(&transition_state.actual_processed_tasks, &task2), 1);
+            assert!(vector::contains(&transition_state.actual_processed_tasks, &task3), 2);
+
+            // Check that both tasks have been refunded with depoit fee only
+            let expected_total_deposit_refund = 2 * automation_fee_cap;
+            check_account_balance(user_address, expected_user_current_balance + expected_total_deposit_refund);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance - expected_total_deposit_refund);
+            // Check that only task1 still exists in pending state
+            check_task_state(ar, task1, exists, PENDING);
+            assert!(!has_task_with_id(task2), 3);
+            assert!(!has_task_with_id(task3), 4);
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_drop_even_if_refund_fails(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let expected_user_current_balance = ACCOUNT_BALANCE - (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        // Modify refund-bookkeeping locked deposit amount to cause refund failure
+        {
+            let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
+            refund_bookkeeping.total_deposited_automation_fee = 0;
+        };
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
+        on_drop(create_signer(@vm_reserved), vector[task1]);
+
+        let ar = borrow_global<AutomationRegistry>(fwk_address);
+        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+        // As long as there was a single task in the registry registry will move to started state
+        assert!(cycle_details.state == CYCLE_STARTED, 0);
+        assert!(std::option::is_none(&cycle_details.transition_state), 1);
+
+        // Check that no refund has happened
+        check_account_balance(user_address, expected_user_current_balance);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+        // Check that task has been removed from registry
+        assert!(!has_task_with_id(task1), 2);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_drop_even_input_is_empty_or_non_existent(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let expected_user_current_balance = ACCOUNT_BALANCE - (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
+        on_drop(create_signer(@vm_reserved), vector[]);
+        on_drop(create_signer(@vm_reserved), vector[5]);
+
+        let ar = borrow_global<AutomationRegistry>(fwk_address);
+        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+        // As long as there was a single task in the registry registry will move to started state
+        assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        let transition_state = std::option::borrow(&cycle_details.transition_state);
+        assert!(vector::is_empty(&transition_state.actual_processed_tasks), 1);
+
+        // Check that no refund has happened
+        check_account_balance(user_address, expected_user_current_balance);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+        // Check that task has been removed from registry
+        assert!(has_task_with_id(task1), 2);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_DROP_ACTION, location = Self)]
+    fun check_on_drop_fails_if_task_is_not_cancelled_or_expired(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        // Attempt to drop a task that is still active and not expired
+        on_drop(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_drop_fails_on_started_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        // Attempt to drop in STARTED state
+        on_drop(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_drop_fails_on_suspended_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        // feature is disabled in started state moves registry in suspended state
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        // Attempt to drop in suspended
+        on_drop(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_drop_fails_on_ready_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        // feature is disabled in started state, when registry is empty, moves registry in ready state
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        on_drop(create_signer(@vm_reserved), vector[0]);
+    }
+
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_charge_execution(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let exists = true;
+        let t1_t2_max_gas_amount = 44_000_000;
+        let t3_max_gas_amount = 11_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let task2 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        let task3 = register_with_state(
+            framework,
+            user,
+            11_000_000,
+            automation_fee_cap,
+            task_exipry_time / 2,
+            PENDING);
+        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let total_committed_gas = 2 * t1_t2_max_gas_amount + t3_max_gas_amount;
+
+
+        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        let expected_automation_fee_per_task_1_2 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // 19% surpasses the threshold, ((1+(19/100))^exponent-1) * 100 = 183 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task_1_2 = 183 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        // 11/100 * 1000 = 110 - automation_epoch_fee_per_second, 7200 epoch duration (PENDING tasks are charge for the first cycle fully)
+        let expected_automation_fee_per_task_3 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 110;
+        // 19% surpasses the threshold, ((1+(19/100))^exponent-1) * 100 = 183 congestion base fee, occupancy 11/100, 7200 epoch duration
+        let expected_congestion_fee_per_task_3 = 183 * 11 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        // Update time so task3 is expired.
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+        on_charge(create_signer(@vm_reserved), vector[task1, task2]);
+        // Also check that processed tasks are ignored and charging is done only once
+        on_charge(create_signer(@vm_reserved), vector[task1, task2]);
+
+        {
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(vector::contains(&transition_state.actual_processed_tasks, &task1), 1);
+            assert!(vector::contains(&transition_state.actual_processed_tasks, &task2), 2);
+
+            // Check that both tasks have been refunded with depoit fee only
+            let expected_total_charge = 2 * (expected_automation_fee_per_task_1_2 + expected_congestion_fee_per_task_1_2);
+            expected_user_current_balance = expected_user_current_balance - expected_total_charge;
+            expected_registry_current_balance = expected_registry_current_balance + expected_total_charge;
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+            // Check that task1 still exists in pending state
+            check_task_state(ar, task3, exists, PENDING);
+            check_task_state(ar, task2, exists, ACTIVE);
+            check_task_state(ar, task1, exists, ACTIVE);
+        };
+
+        on_charge(create_signer(@vm_reserved), vector[task3]);
+        {
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(fwk_address);
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_STARTED, 5);
+
+            // Check that both tasks have been refunded with depoit fee only
+            let expected_total_charge = expected_automation_fee_per_task_3 + expected_congestion_fee_per_task_3;
+            expected_user_current_balance = expected_user_current_balance - expected_total_charge;
+            expected_registry_current_balance = expected_registry_current_balance + expected_total_charge;
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+            check_task_state(ar, task3, exists, ACTIVE);
+            check_task_state(ar, task2, exists, ACTIVE);
+            check_task_state(ar, task1, exists, ACTIVE);
+            assert!(ar.gas_committed_for_next_epoch == (total_committed_gas - t3_max_gas_amount), 6);
+            assert!(ar.gas_committed_for_this_epoch == (total_committed_gas as u256), 7);
+            expected_total_charge = expected_total_charge + 2 * (expected_automation_fee_per_task_1_2 + expected_congestion_fee_per_task_1_2);
+            assert!(ar.epoch_locked_fees == expected_total_charge, 8);
+            assert!(refund_bookkeeping.total_deposited_automation_fee == 3 * automation_fee_cap, 9);
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_charge_for_tasks_to_be_dropped(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let t1_t2_max_gas_amount = 44_000_000;
+        let t3_max_gas_amount = 11_000_000;
+        let automation_fee_cap = 100_000_000;
+
+        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        let expected_automation_fee_per_task_1_2 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+
+        // 11/100 * 1000 = 110 - automation_epoch_fee_per_second, 7200 epoch duration (PENDING tasks are charge for the first cycle fully)
+        let expected_automation_fee_per_task_3 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 110;
+        // 19% surpasses the threshold, ((1+(19/100))^exponent-1) * 100 = 183 congestion base fee, occupancy 11/100, 7200 epoch duration
+        let expected_congestion_fee_per_task_3 = 183 * 11 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            expected_automation_fee_per_task_1_2,
+            task_exipry_time,
+            ACTIVE);
+        let task2 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let task3 = register_with_state(
+            framework,
+            user,
+            11_000_000,
+            expected_automation_fee_per_task_3 + expected_congestion_fee_per_task_3,
+            task_exipry_time / 2,
+            PENDING);
+
+        let expected_deposit_charge =
+             expected_automation_fee_per_task_1_2  // task1
+            + automation_fee_cap // task2
+            + expected_automation_fee_per_task_3 + expected_congestion_fee_per_task_3; // task3
+
+        let expected_user_current_balance = ACCOUNT_BALANCE - (3 * FLAT_REGISTRATION_FEE_TEST + expected_deposit_charge);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * FLAT_REGISTRATION_FEE_TEST + expected_deposit_charge;
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        // Make sure that user account has only enough balance for task 1 automation fee
+        coin::transfer<SupraCoin>(
+            user,
+            get_registry_fee_address(),
+            expected_user_current_balance);
+        expected_registry_current_balance = expected_registry_current_balance + expected_user_current_balance;
+        expected_user_current_balance = 0;
+
+        let expected_refund_after_charge =
+            expected_automation_fee_per_task_1_2 // task1
+            + expected_automation_fee_per_task_3 + expected_congestion_fee_per_task_3; // task3
+
+        // Update time so task3 is considered as expired.
+        update_global_time_for_test_secs(3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+        on_charge(create_signer(@vm_reserved), vector[task1, task2, task3]);
+
+        {
+            // Check there are no tasks
+            assert!(!has_task_with_id(task1), 1);
+            assert!(!has_task_with_id(task2), 2);
+            assert!(!has_task_with_id(task3), 3);
+
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(fwk_address);
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+            // Check that we are in STARTED state as all expected tasks are handled.
+            assert!(cycle_details.state == CYCLE_STARTED, 0);
+
+            // Check that both tasks have been refunded with depoit fee only
+            expected_user_current_balance = expected_user_current_balance + expected_refund_after_charge;
+            expected_registry_current_balance = expected_registry_current_balance - expected_refund_after_charge;
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+            assert!(ar.gas_committed_for_next_epoch == 0, 4);
+
+            let total_committed_gas = 2 * t1_t2_max_gas_amount + t3_max_gas_amount;
+            assert!(ar.gas_committed_for_this_epoch == (total_committed_gas as u256), 5);
+            assert!(ar.epoch_locked_fees == 0, 6);
+
+            assert!(refund_bookkeeping.total_deposited_automation_fee == 0, 7);
+
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_charge_even_input_is_empty_or_non_existent(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let expected_user_current_balance = ACCOUNT_BALANCE - (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
+        on_charge(create_signer(@vm_reserved), vector[]);
+        on_charge(create_signer(@vm_reserved), vector[5]);
+
+        let ar = borrow_global<AutomationRegistry>(fwk_address);
+        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+        // As long as there was a single task in the registry registry will move to started state
+        assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        let transition_state = std::option::borrow(&cycle_details.transition_state);
+        assert!(vector::is_empty(&transition_state.actual_processed_tasks), 1);
+
+        // Check that no refund has happened
+        check_account_balance(user_address, expected_user_current_balance);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+        // Check that task has been removed from registry
+        assert!(has_task_with_id(task1), 2);
+    }
+
+
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_CHARGE_ACTION, location = Self)]
+    fun check_on_charge_fails_if_task_is_cancelled(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        // Attempt to charge a task that is cancelled
+        on_charge(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_charge_fails_on_started_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        // Attempt to charge in STARTED state
+        on_charge(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_charge_fails_on_suspended_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        // feature is disabled in started state moves registry in suspended state
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        // Attempt to charge in suspended
+        on_charge(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_charge_fails_on_ready_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        // feature is disabled in started state, when registry is empty, moves registry in ready state
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        on_charge(create_signer(@vm_reserved), vector[0]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_refund_and_cleanup_execution(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let exists = true;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task3 = register_with_state(
+            framework,
+            user,
+            11_000_000,
+            automation_fee_cap,
+            task_exipry_time / 2,
+            PENDING);
+        let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
+        let expected_automation_fee_per_task_1_2 = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
+        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
+        let expected_congestion_fee_per_task_1_2 = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3);
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+
+        let expected_remaining_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS - timestamp::now_seconds();
+        let expected_automation_fee_multiplier = calculate_automation_fee_unit_for_current_cycle();
+
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(transition_state.remaining_cycle_duration == expected_remaining_time, 1);
+            assert!(transition_state.automation_fee_per_sec == expected_automation_fee_multiplier, 1);
+
+        };
+
+        // set enough cycle fee to be able to refund
+        set_locked_fee(framework, 10_000_000_000);
+        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2]);
+
+        {
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(vector::contains(&transition_state.actual_processed_tasks, &task1), 1);
+            assert!(vector::contains(&transition_state.actual_processed_tasks, &task2), 2);
+
+            // Check that both tasks have been refunded with depoit fee and remaining cycle fee only
+            let expected_total_deposit_refund = 2 * automation_fee_cap;
+            let expected_fee_refund = 2 * (expected_automation_fee_per_task_1_2 + expected_congestion_fee_per_task_1_2) * 2 / 3;
+            let total_expected_refund = expected_total_deposit_refund + expected_fee_refund;
+            expected_user_current_balance = expected_user_current_balance + total_expected_refund;
+            expected_registry_current_balance = expected_registry_current_balance - total_expected_refund;
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+            // Check that only task1 still exists in pending state
+            check_task_state(ar, task3, exists, PENDING);
+            assert!(!has_task_with_id(task1), 3);
+            assert!(!has_task_with_id(task2), 4);
+        };
+
+        // Empty input does not cause issues
+        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[]);
+
+        // Non existing item does not cause issues
+        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[10, 12]);
+
+        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2, task3]);
+
+        {
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_READY, 5);
+            assert!(std::option::is_none(&cycle_details.transition_state), 6);
+
+            // Check that only depoit fee is refunded from 3rd PENDING task
+            expected_user_current_balance = expected_user_current_balance + automation_fee_cap;
+            expected_registry_current_balance = expected_registry_current_balance - automation_fee_cap;
+            check_account_balance(user_address, expected_user_current_balance);
+            check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+            assert!(ar.epoch_locked_fees == 0, 7);
+            assert!(ar.gas_committed_for_this_epoch == 0, 8);
+            assert!(ar.gas_committed_for_next_epoch == 0, 9);
+
+            assert!(!has_task_with_id(task1), 10);
+            assert!(!has_task_with_id(task2), 11);
+            assert!(!has_task_with_id(task3), 12);
+
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_refund_and_cleanup_even_if_refund_fails(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let expected_user_current_balance = ACCOUNT_BALANCE - 2 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 2 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        // Modify refund-bookkeeping locked deposit amount to cause refund failure
+        {
+            let refund_bookkeeping = borrow_global_mut<AutomationRefundBookkeeping>(fwk_address);
+            refund_bookkeeping.total_deposited_automation_fee = 0;
+        };
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 3);
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+
+        let expected_remaining_time = EPOCH_INTERVAL_FOR_TEST_IN_SECS - timestamp::now_seconds();
+        let expected_automation_fee_multiplier = calculate_automation_fee_unit_for_current_cycle();
+
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(transition_state.remaining_cycle_duration == expected_remaining_time, 1);
+            assert!(transition_state.automation_fee_per_sec == expected_automation_fee_multiplier, 2);
+
+        };
+
+        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2]);
+
+        let ar = borrow_global<AutomationRegistry>(fwk_address);
+        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+        // As long as there was a single task in the registry registry will move to started state
+        assert!(cycle_details.state == CYCLE_READY, 0);
+        assert!(std::option::is_none(&cycle_details.transition_state), 3);
+
+        // Check that no refund has happened
+        check_account_balance(user_address, expected_user_current_balance);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance);
+
+        assert!(ar.epoch_locked_fees == 0, 4);
+        assert!(ar.gas_committed_for_this_epoch == 0, 5);
+        assert!(ar.gas_committed_for_next_epoch == 0, 6);
+
+        // Check that tasks have been removed from registry
+        assert!(!has_task_with_id(task1), 7);
+        assert!(!has_task_with_id(task2), 8);
+
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_on_refund_and_cleanup_transitioned_from_finished_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            PENDING);
+        let expected_user_current_balance = ACCOUNT_BALANCE - 2 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 2 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
+
+        let fwk_address = address_of(framework);
+        let user_address = address_of(user);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Moves to Finished state
+        monitor_cycle_end();
+        // Right after it feature flag is disabled and chain state is reconfgured
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(transition_state.remaining_cycle_duration == 0, 1);
+            assert!(transition_state.automation_fee_per_sec == 0, 1);
+
+        };
+
+        on_refund_and_cleanup(create_signer(@vm_reserved),  vector[task1, task2]);
+
+        let ar = borrow_global<AutomationRegistry>(fwk_address);
+        let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+
+        // As long as there was a single task in the registry registry will move to started state
+        assert!(cycle_details.state == CYCLE_READY, 0);
+        assert!(std::option::is_none(&cycle_details.transition_state), 1);
+
+        // Check that no refund has happened
+        let expected_only_deposit_refund = 2 * automation_fee_cap;
+        check_account_balance(user_address, expected_user_current_balance + expected_only_deposit_refund);
+        check_account_balance(ar.registry_fee_address, expected_registry_current_balance - expected_only_deposit_refund);
+
+        assert!(ar.epoch_locked_fees == 0, 2);
+        assert!(ar.gas_committed_for_this_epoch == 0, 3);
+        assert!(ar.gas_committed_for_next_epoch == 0, 4);
+
+        // Check that tasks have been removed from registry
+        assert!(!has_task_with_id(task1), 5);
+        assert!(!has_task_with_id(task2), 6);
+
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_refund_and_cleanup_fails_on_started_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        // Attempt to refund in STARTED state
+        on_refund_and_cleanup(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_refund_and_cleanup_fails_on_finished_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+        // feature is disabled in started state moves registry in suspended state
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        // Attempt to refund in finished state
+        on_refund_and_cleanup(create_signer(@vm_reserved), vector[task1]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EINVALID_REGISTRY_STATE, location = Self)]
+    fun check_on_refund_and_cleanup_fails_on_ready_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        // feature is disabled in started state, when registry is empty, moves registry in ready state
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        on_refund_and_cleanup(create_signer(@vm_reserved), vector[0]);
+    }
 
     #[test(framework = @supra_framework, user = @0x1cafb)]
-    fun check_automation_task_fee_refund_is_done_with_old_config(
+    fun check_config_updated_from_start_to_suspended_state(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        let fwk_address = address_of(framework);
         initialize_registry_test(framework, user);
-        config_buffer::initialize(framework);
         let t1_t2_max_gas = 44_000_000;
         let t3_max_gas = 11_000_000;
         let automation_fee_cap = 100_000_000;
 
-        let t1 = register_with_state(
+        let _t1 = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
             automation_fee_cap,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
-        let t2 = register_with_state(
+        let _t2 = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
             automation_fee_cap,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, CANCELLED);
-        let t3 = register_with_state(
+        let _t3 = register_with_state(
+            framework,
+            user,
+            t3_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, PENDING);
+        update_config_v2(framework,
+            TTL_UPPER_BOUND_TEST,
+            AUTOMATION_MAX_GAS_TEST * 2,
+            AUTOMATION_BASE_FEE_TEST / 2,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST / 2,
+            CONGESTION_BASE_FEE_TEST / 2,
+            CONGESTION_EXPONENT_TEST - 1,
+            TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS
+        );
+        // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
+        toggle_feature_flag(framework, false);
+        let expected_cycle_duration =
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_STARTED, 1);
+            cycle_details.duration_secs
+        };
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 1);
+            assert!(std::option::is_some(&cycle_details.transition_state), 2);
+            assert!(cycle_details.duration_secs == expected_cycle_duration, 3);
+
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(transition_state.remaining_cycle_duration  == EPOCH_INTERVAL_FOR_TEST_IN_SECS, 4);
+            let expected_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(
+                &config.main_config,
+                (2 * t1_t2_max_gas as u256),
+                config.main_config.registry_max_gas_cap);
+            assert!(transition_state.automation_fee_per_sec  == (expected_fee_per_sec as u64), 4);
+            assert!(transition_state.gas_committed_for_new_cycle == 0, 5);
+            assert!(transition_state.gas_committed_for_next_cycle  == 0, 6);
+            assert!(transition_state.new_cycle_duration  == expected_cycle_duration, 7);
+            assert!(vector::is_empty(&transition_state.actual_processed_tasks), 8);
+            assert!(vector::length(&transition_state.expected_tasks_to_be_processed) == 3, 9);
+
+
+            assert!(config.main_config.automation_base_fee_in_quants_per_sec == AUTOMATION_BASE_FEE_TEST, 10);
+            assert!(config.main_config.congestion_base_fee_in_quants_per_sec == CONGESTION_BASE_FEE_TEST, 11);
+            assert!(config.main_config.congestion_threshold_percentage == CONGESTION_THRESHOLD_TEST, 12);
+            assert!(config.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 13);
+        };
+
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafb)]
+    fun check_config_updated_from_finished_suspended_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        let fwk_address = address_of(framework);
+        initialize_registry_test(framework, user);
+        let t1_t2_max_gas = 44_000_000;
+        let t3_max_gas = 11_000_000;
+        let automation_fee_cap = 100_000_000;
+
+        let _ = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
+        let _ = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, CANCELLED);
+        let _ = register_with_state(
             framework,
             user,
             t3_max_gas,
@@ -3704,54 +4579,200 @@ module supra_framework::automation_registry {
             CONGESTION_BASE_FEE_TEST / 2,
             CONGESTION_EXPONENT_TEST - 1,
             TASK_CAPACITY_TEST,
-            EPOCH_INTERVAL_FOR_TEST_IN_SECS
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2
         );
-        // Disable feature in order to avoid charges and check only refunds.
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
         toggle_feature_flag(framework, false);
-
-        // 3 task has been registered
-        let registration_charges = 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
-        let expected_user_current_balance = ACCOUNT_BALANCE - registration_charges;
-        let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + registration_charges;
-
-        let user_address = signer::address_of(user);
-        check_account_balance(user_address, expected_user_current_balance);
-
-        // 44/100 * 1000 = 440 - automation_epoch_fee_per_second, 7200 epoch duration
-        let expected_automation_fee_per_task = EPOCH_INTERVAL_FOR_TEST_IN_SECS * 440;
-        // 8% surpasses the threshold, ((1+(8/100))^exponent-1) * 100 = 58 congestion base fee, occupancy 44/100, 7200 epoch duration
-        let expected_congestion_fee_per_task = 58 * 44 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100;
-        // Epoch cut short 2 times
-
-        // Refund is expected
-        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        let expected_cycle_duration =
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_FINISHED, 1);
+            cycle_details.duration_secs
+        };
         on_new_epoch();
-        // as account have 2 active tasks with same automation and congestion fees then refund is double + deposit refund for all 3 tasks.
-        let expected_refund = expected_congestion_fee_per_task + expected_automation_fee_per_task + 3 * automation_fee_cap;
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 1);
+            assert!(std::option::is_some(&cycle_details.transition_state), 2);
+            assert!(cycle_details.duration_secs == expected_cycle_duration, 3);
 
-        check_account_balance(user_address, expected_user_current_balance + expected_refund);
-        // Checke registry balance
-        check_account_balance(get_registry_fee_address(), expected_registry_current_balance - expected_refund);
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(transition_state.automation_fee_per_sec  == 0, 4);
+            assert!(transition_state.gas_committed_for_new_cycle == 0, 5);
+            assert!(transition_state.gas_committed_for_next_cycle  == 0, 6);
+            assert!(transition_state.new_cycle_duration  == EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2, 7);
+            assert!(vector::is_empty(&transition_state.actual_processed_tasks), 8);
+            assert!(vector::length(&transition_state.expected_tasks_to_be_processed) == 3, 9);
 
-        // Check that config is updated even if feature is disabled.
+
+            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
+            assert!(config.main_config.automation_base_fee_in_quants_per_sec == AUTOMATION_BASE_FEE_TEST / 2, 10);
+            assert!(config.main_config.congestion_base_fee_in_quants_per_sec == CONGESTION_BASE_FEE_TEST / 2, 11);
+            assert!(config.main_config.congestion_threshold_percentage == CONGESTION_THRESHOLD_TEST / 2, 12);
+            assert!(config.main_config.congestion_exponent == CONGESTION_EXPONENT_TEST - 1 , 13);
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafb)]
+    fun check_config_updated_from_transition_suspended_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         let fwk_address = address_of(framework);
-        let arc = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
-        assert!(arc.main_config.registry_max_gas_cap == AUTOMATION_MAX_GAS_TEST, 14);
-        assert!(arc.main_config.automation_base_fee_in_quants_per_sec == AUTOMATION_BASE_FEE_TEST / 2, 14);
-        assert!(arc.main_config.congestion_threshold_percentage == CONGESTION_THRESHOLD_TEST / 2, 14);
-        assert!(arc.main_config.congestion_base_fee_in_quants_per_sec == CONGESTION_BASE_FEE_TEST / 2, 14);
-        assert!(arc.main_config.congestion_exponent == CONGESTION_EXPONENT_TEST - 1, 14);
-        // Check that if feature is disabled, cleanup happens and no task is available in the registry.
-        assert!(!has_task_with_id(t1), 15);
-        assert!(!has_task_with_id(t2), 15);
-        assert!(!has_task_with_id(t3), 15);
-        assert!(get_task_count() == 0, 15);
-        let ar = borrow_global<AutomationRegistry>(fwk_address);
-        // Check that committed gas for this epoch is sum of active tasks max-gass
-        assert!(ar.gas_committed_for_this_epoch == 0, 16);
-        // Check locked fee is 0 as feature is disabled and no charges have been done.
-        assert!(ar.epoch_locked_fees == 0, 17);
-        assert!(ar.gas_committed_for_next_epoch == 0, 17);
+        initialize_registry_test(framework, user);
+        let t1_t2_max_gas = 44_000_000;
+        let t3_max_gas = 11_000_000;
+        let automation_fee_cap = 100_000_000;
+
+        let _t1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
+        let t2 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, CANCELLED);
+        let _t3 = register_with_state(
+            framework,
+            user,
+            t3_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, PENDING);
+
+        update_config_v2(framework,
+            TTL_UPPER_BOUND_TEST,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST / 2,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST / 2,
+            CONGESTION_BASE_FEE_TEST / 2,
+            CONGESTION_EXPONENT_TEST - 1,
+            TASK_CAPACITY_TEST,
+            EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2
+        );
+
+
+        // Move to FINISHED state
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+
+        // Expected new cylce gas and automation_fee_per_sec. Calculate now to make sure that config update was done.
+        let total_committed_gas_for_new_cycle = t1_t2_max_gas + t3_max_gas;
+        let automation_fee_per_sec_for_new_cycle = calculate_automation_fee_multiplier_for_committed_occupancy(total_committed_gas_for_new_cycle);
+        // Drop one task to mark transition initiated
+        on_drop(create_signer(@vm_reserved), vector[t2]);
+        // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
+        let expected_cycle_duration =
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_FINISHED, 1);
+            cycle_details.duration_secs
+        };
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_FINISHED, 1);
+            assert!(std::option::is_some(&cycle_details.transition_state), 2);
+            assert!(cycle_details.duration_secs == expected_cycle_duration, 3);
+
+            let transition_state = std::option::borrow(&cycle_details.transition_state);
+            assert!(transition_state.automation_fee_per_sec  == automation_fee_per_sec_for_new_cycle, 4);
+            assert!(transition_state.gas_committed_for_new_cycle == total_committed_gas_for_new_cycle, 5);
+            assert!(transition_state.gas_committed_for_next_cycle  == 0, 6);
+            assert!(transition_state.new_cycle_duration  == EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2, 7);
+            assert!(vector::length(&transition_state.actual_processed_tasks) == 1, 8);
+            assert!(vector::length(&transition_state.expected_tasks_to_be_processed) == 3, 9);
+
+
+            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
+            assert!(config.main_config.automation_base_fee_in_quants_per_sec == AUTOMATION_BASE_FEE_TEST / 2, 11);
+            assert!(config.main_config.congestion_base_fee_in_quants_per_sec == CONGESTION_BASE_FEE_TEST / 2, 12);
+            assert!(config.main_config.congestion_threshold_percentage == CONGESTION_THRESHOLD_TEST / 2, 13);
+            assert!(config.main_config.congestion_exponent == CONGESTION_EXPONENT_TEST - 1 , 14);
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafb)]
+    fun check_feature_enable_in_suspended_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        let fwk_address = address_of(framework);
+        initialize_registry_test(framework, user);
+        let t1_max_gas = 44_000_000;
+        let automation_fee_cap = 100_000_000;
+
+        let _t1 = register_with_state(
+            framework,
+            user,
+            t1_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
+        // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 1);
+            assert!(std::option::is_some(&cycle_details.transition_state), 2);
+        };
+        toggle_feature_flag(framework, true);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 1);
+            assert!(std::option::is_some(&cycle_details.transition_state), 2);
+        };
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafb)]
+    fun check_feature_enable_in_ready_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
+        let fwk_address = address_of(framework);
+        initialize_registry_test(framework, user);
+        let t1_max_gas = 44_000_000;
+        let automation_fee_cap = 100_000_000;
+
+        let _t1 = register_with_state(
+            framework,
+            user,
+            t1_max_gas,
+            automation_fee_cap,
+            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS,
+            ACTIVE);
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 1);
+            assert!(std::option::is_some(&cycle_details.transition_state), 2);
+        };
+
+        on_refund_and_cleanup(create_signer(@vm_reserved), vector[0]);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_READY, 3);
+            assert!(std::option::is_none(&cycle_details.transition_state), 4);
+        };
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        toggle_feature_flag(framework, true);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_STARTED, 5);
+            assert!(std::option::is_none(&cycle_details.transition_state), 6);
+        };
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3762,13 +4783,13 @@ module supra_framework::automation_registry {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
 
-        register_with_state(
+        let _ = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
             100_000_000,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
-        register_with_state(
+        let _ = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
@@ -3928,13 +4949,13 @@ module supra_framework::automation_registry {
         initialize_registry_test(framework, user);
         let t1_t2_max_gas = 44_000_000;
 
-        register_with_state(
+        let _ = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
             100_000_000,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
-        register_with_state(
+        let _ = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
@@ -4040,7 +5061,7 @@ module supra_framework::automation_registry {
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
-    fun check_automation_task_fee_withdrawal_on_new_epoch(
+    fun check_automation_task_fee_withdrawal_on_charge(
         framework: &signer,
         user: &signer
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
@@ -4062,7 +5083,7 @@ module supra_framework::automation_registry {
             user,
             t1_t2_max_gas,
             100_000_000,
-            2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
+            3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
         // Not enough balance to pay fee
         let t3 = register_with_state(
             framework,
@@ -4103,10 +5124,14 @@ module supra_framework::automation_registry {
             withdraw_amount);
         let expected_registry_current_balance = expected_registry_current_balance + withdraw_amount;
 
-        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
-        on_new_epoch();
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        let committed_gas_for_new_cycle = 2 * t1_t2_max_gas + t3_max_gas;
 
-        let tcmg = ((2 * t1_t2_max_gas + t3_max_gas) as u256);
+        // Not only charges will be applied but also state will be updated to STARTED as all expected tasks will be processed.
+        on_charge(create_signer(@vm_reserved), vector[t1, t2, t3]);
+
+        let tcmg = (committed_gas_for_new_cycle as u256);
         let user_address = address_of(user);
         let fwk_address = address_of(framework);
 
@@ -4126,6 +5151,11 @@ module supra_framework::automation_registry {
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         assert!(ar.gas_committed_for_this_epoch == tcmg, 4);
         assert!(ar.gas_committed_for_next_epoch == t1_t2_max_gas, 5);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_STARTED, 6);
+            assert!(std::option::is_none(&cycle_details.transition_state), 7);
+        };
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -4278,42 +5308,39 @@ module supra_framework::automation_registry {
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         initialize_registry_test(framework, user);
         let automation_fee_cap = 1000;
+        let max_gas_amount = 200;
 
-        register(user,
-            PAYLOAD,
-            86400,
-            200,
-            200,
+        let t1 = register_with_state(
+            framework,
+            user,
+            max_gas_amount,
             automation_fee_cap,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE,
         );
-        register(user,
-            PAYLOAD,
-            86400,
-            200,
-            200,
+        let t2 = register_with_state(
+            framework,
+            user,
+            max_gas_amount,
             automation_fee_cap,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE,
         );
-        register(user,
-            PAYLOAD,
-            86400,
-            200,
-            200,
+        let t3 = register_with_state(
+            framework,
+            user,
+            max_gas_amount,
             automation_fee_cap,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE,
         );
-        register(user,
-            PAYLOAD,
-            86400,
-            200,
-            200,
+        let t4 = register_with_state(
+            framework,
+            user,
+            max_gas_amount,
             automation_fee_cap,
-            PARENT_HASH,
-            AUX_DATA
+            86400,
+            ACTIVE,
         );
 
         // check user balance after registered new task
@@ -4326,8 +5353,13 @@ module supra_framework::automation_registry {
         check_account_balance(registry_fee_address, expected_registry_balance);
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
-        assert!(800 == get_gas_committed_for_next_epoch(), 1);
+        monitor_cycle_end();
+        let committed_gas_for_new_cycle = 4 * max_gas_amount;
+
+        // Not only charges will be applied but also state will be updated to STARTED as all expected tasks will be processed.
+        on_charge(create_signer(@vm_reserved), vector[t1, t2, t3, t4]);
+
+        assert!(committed_gas_for_new_cycle == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
         let expected_ids = vector<u64>[0, 1, 2, 3];
         vector::for_each(active_task_ids, |task_index| {
@@ -4335,7 +5367,7 @@ module supra_framework::automation_registry {
         });
 
         // 0.002 (*4) - automation_epoch_fee_per_second, 7200 epoch duration
-        let expected_automation_fee = 4 * (200 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000);
+        let expected_automation_fee = 4 * (max_gas_amount * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000);
         expected_current_balance = expected_current_balance - expected_automation_fee;
         expected_registry_balance = expected_registry_balance + expected_automation_fee;
         check_account_balance(user_account, expected_current_balance );
@@ -4354,11 +5386,11 @@ module supra_framework::automation_registry {
         });
         // There is no task with index 2 now.
         assert!(!has_task_with_id(2), 1);
-        assert!(600 == get_gas_committed_for_next_epoch(), 1);
+        assert!(3 * max_gas_amount == get_gas_committed_for_next_epoch(), 1);
 
         // Because the on of the task stopped halfway, the user gets a 50% refund for the unused time.
         // which is equivalent to a 25% refund of the full epoch for single task and deposited fee upon registration
-        let expected_refund = (200 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4 + automation_fee_cap;
+        let expected_refund = (max_gas_amount * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4 + automation_fee_cap;
         expected_current_balance = expected_current_balance + expected_refund;
         expected_registry_balance = expected_registry_balance - expected_refund;
         check_account_balance(user_account, expected_current_balance);
@@ -4369,12 +5401,13 @@ module supra_framework::automation_registry {
         register(user,
             PAYLOAD,
             86400,
-            200,
+            max_gas_amount,
             200,
             1000,
             PARENT_HASH,
             AUX_DATA
         );
+        assert!(has_task_with_id(4), 1);
 
         registration_charges = FLAT_REGISTRATION_FEE_TEST + automation_fee_cap;
         expected_current_balance = expected_current_balance - registration_charges;
@@ -4382,6 +5415,7 @@ module supra_framework::automation_registry {
         check_account_balance(user_account, expected_current_balance);
         check_account_balance(registry_fee_address, expected_registry_balance);
 
+        // Stop newly added task
         stop_tasks(user, vector[4]);
         let active_task_ids = get_active_task_ids();
         let expected_ids = vector<u64>[0, 1, 3];
@@ -4391,7 +5425,7 @@ module supra_framework::automation_registry {
         // There is no task with index 4 and the next task index will be 5.
         assert!(!has_task_with_id(4), 1);
         assert!(get_next_task_index() == 5, 1);
-        assert!(600 == get_gas_committed_for_next_epoch(), 1);
+        assert!(3 * max_gas_amount == get_gas_committed_for_next_epoch(), 1);
 
         // Expected refund for the stopping pending task is only the half of the deposited fee
         expected_refund = automation_fee_cap / REFUND_FACTOR;
@@ -4472,9 +5506,10 @@ module supra_framework::automation_registry {
         check_account_balance(user_address, expected_current_balance);
         check_account_balance(registry_fee_address, expected_registry_balance);
 
-        // Start new epoch
+        // Start new cycle
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
-        on_new_epoch();
+        monitor_cycle_end();
+        on_charge(create_signer(@vm_reserved), vector[0]);
 
         // 0.002 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000;
@@ -4506,6 +5541,34 @@ module supra_framework::automation_registry {
         let refund_automation_fee = (2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000) / 4 + automation_fee_cap;
         check_account_balance( user_address, expected_current_balance + refund_automation_fee );
         check_account_balance( registry_fee_address, expected_registry_balance - refund_automation_fee );
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafe)]
+    #[expected_failure(abort_code = ECYCLE_TRANSITION_IN_PROGRESS, location = Self)]
+    fun check_stopping_in_transition_state(
+        framework: &signer,
+        user: &signer,
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+
+        register(user,
+            PAYLOAD,
+            86400,
+            10,
+            20,
+            1000,
+            PARENT_HASH,
+            AUX_DATA
+        );
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        let fwk_address = address_of(framework);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+        stop_tasks(user, vector[0]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafe)]
@@ -4737,11 +5800,91 @@ module supra_framework::automation_registry {
         on_new_epoch();
     }
 
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_successful_transition_from_finished_to_ready(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+
+        let fwk_address = address_of(framework);
+
+        // Update time so task3 is expired.
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
+        on_drop(create_signer(@vm_reserved), vector[task1]);
+
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // Check that we are still in finished state and processed-task are only task2 and task3
+            assert!(cycle_details.state == CYCLE_FINISHED, 0);
+        };
+
+        // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
+        on_drop(create_signer(@vm_reserved), vector[task2]);
+        {
+            let ar = borrow_global<AutomationRegistry>(fwk_address);
+            assert!(ar.gas_committed_for_next_epoch == 0, 1);
+            assert!(ar.gas_committed_for_this_epoch == 0, 2);
+            assert!(ar.epoch_locked_fees == 0, 3);
+
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            // We move directly to READY state as after drops the cycle moves to STARTED state with empty task
+            // list so there is nothing to refund.
+            assert!(cycle_details.state == CYCLE_READY, 4);
+
+            assert!(!has_task_with_id(task1), 5);
+            assert!(!has_task_with_id(task2), 6);
+        };
+    }
+
+
     #[test]
     fun check_monitor_cycle_end() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
         monitor_cycle_end()
     }
 
+    #[test]
+    fun check_vector_contains_perform() {
+        let tvector = vector[];
+        let count = 0;
+        while (count < 5000) {
+            vector::push_back(&mut tvector, count);
+            count = count + 1;
+        };
+        // vector::contains(&tvector, &4999);
+        while (count > 4950) {
+            vector::contains(&tvector, &count);
+            count = count - 1
+        }
+    }
 }
 
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -177,6 +177,33 @@ module supra_framework::automation_registry {
         task_capacity: u16,
     }
 
+    #[event]
+    /// Automation registry configuration parameters
+    struct AutomationRegistryConfigV2 has store, drop, copy {
+        /// Maximum allowable duration (in seconds) from the registration time that an automation task can run.
+        /// If the expiration time exceeds this duration, the task registration will fail.
+        task_duration_cap_in_secs: u64,
+        /// Maximum gas allocation for automation tasks per epoch
+        /// Exceeding this limit during task registration will cause failure and is used in fee calculation.
+        registry_max_gas_cap: u64,
+        /// Base fee per second for the full capacity of the automation registry, measured in quants/sec.
+        /// The capacity is considered full if the total committed gas of all registered tasks equals registry_max_gas_cap.
+        automation_base_fee_in_quants_per_sec: u64,
+        /// Flat registration fee charged by default for each task.
+        flat_registration_fee_in_quants: u64,
+        /// Ratio (in the range [0;100]) representing the acceptable upper limit of committed gas amount
+        /// relative to registry_max_gas_cap. Beyond this threshold, congestion fees apply.
+        congestion_threshold_percentage: u8,
+        /// Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
+        congestion_base_fee_in_quants_per_sec: u64,
+        /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
+        congestion_exponent: u8,
+        /// Maximum number of tasks that registry can hold.
+        task_capacity: u16,
+        /// Automation cycle duration in secods
+        cycle_duration_secs: u64,
+    }
+
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// It tracks entries both pending and completed, organized by unique indices.
     struct AutomationRegistry has key, store {
@@ -239,7 +266,7 @@ module supra_framework::automation_registry {
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     /// Epoch state. Deprecated since SUPRA_AUTOMATION_CYCLE version.
-    struct AutomationEpochInfo has key, copy, drop {
+    struct AutomationEpochInfo has key, copy {
         /// Epoch expected duration at the beginning of the new epoch, Based on this and actual
         /// epoch_duration which will be (current_time - last_reconfiguration_time) automation tasks
         /// refunds will be calculated.
@@ -250,13 +277,6 @@ module supra_framework::automation_registry {
         epoch_interval: u64,
         /// Current epoch start time which is the same as last_reconfiguration_time
         start_time: u64,
-    }
-
-    #[event]
-    /// Cycle Duration wrapper to store in the config-buffer.
-    struct AutomationCycleDuration has drop, store, copy {
-        /// Automation cycle duration in seconds.
-        duration_secs: u64,
     }
 
     /// Provides information of the current cycle state.
@@ -789,13 +809,6 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_exponent);
 
-        // Update cycle duration in buffer
-        let new_cycle_duration = AutomationCycleDuration {
-            duration_secs: cycle_duration_secs
-        };
-        config_buffer::upsert(copy new_cycle_duration);
-        event::emit(new_cycle_duration);
-
         let automation_registry = borrow_global<AutomationRegistry>(@supra_framework);
 
         assert!(
@@ -803,7 +816,7 @@ module supra_framework::automation_registry {
             EUNACCEPTABLE_AUTOMATION_GAS_LIMIT
         );
 
-        let new_automation_registry_config = AutomationRegistryConfig {
+        let new_automation_registry_config = AutomationRegistryConfigV2 {
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             automation_base_fee_in_quants_per_sec,
@@ -811,16 +824,16 @@ module supra_framework::automation_registry {
             congestion_threshold_percentage,
             congestion_base_fee_in_quants_per_sec,
             congestion_exponent,
-            task_capacity
+            task_capacity,
+            cycle_duration_secs
         };
         config_buffer::upsert(copy new_automation_registry_config);
 
-        // next_epoch_registry_max_gas_cap will be update instantly
+        // next cyle registry max gas cap will be update instantly
         let automation_registry_config = borrow_global_mut<ActiveAutomationRegistryConfig>(@supra_framework);
         automation_registry_config.next_epoch_registry_max_gas_cap = registry_max_gas_cap;
 
         event::emit(new_automation_registry_config);
-
     }
 
     /// Enables the registration process in the automation registry.
@@ -1052,7 +1065,7 @@ module supra_framework::automation_registry {
         update_state_for_migration(
             automation_registry,
             &automation_registry_config,
-            &automation_epoch_info,
+            automation_epoch_info,
             current_time
         );
 
@@ -1071,6 +1084,8 @@ module supra_framework::automation_registry {
         };
         // Emit cycle end which will lead the native layer to start preparation to the new cycle.
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
+        // Update the config to start the cycle with new config.
+        update_config_from_buffer_for_migration(cycle_info);
         on_cycle_end_internal(cycle_info);
     }
 
@@ -1596,7 +1611,7 @@ module supra_framework::automation_registry {
     /// Updates the cycle state if the transition is identified to be finalized.
     ///
     /// As transition happens from suspended state and while transition was in progress
-    ///    - if the feature was enabled back, then the transition will happend direclty to starated state,
+    ///    - if the feature was enabled back, then the transition will happen direclty to starated state,
     ///    - otherwise the transition will be done to the ready state.
     ///
     /// In both cases config will be updated. In this case we will make sure to keep the consistency of state
@@ -1619,8 +1634,10 @@ module supra_framework::automation_registry {
         automation_registry.epoch_active_task_ids = vector[];
         automation_registry.epoch_locked_fees = 0;
 
-        update_config_from_buffer(cycle_info);
         if (features::supra_native_automation_enabled()) {
+            // Update the config in case if transition flow is STARTED -> SUSPENDED-> STARTED.
+            // to reflect new configs for the new cycle if it has been updated during SUSPENDED state processing
+            update_config_from_buffer(cycle_info);
             move_to_started_state(cycle_info)
         } else {
             move_to_ready_state(cycle_info)
@@ -1761,7 +1778,28 @@ module supra_framework::automation_registry {
     }
 
     fun move_to_ready_state(cycle_info: &mut AutomationCycleDetails) {
-        cycle_info.transition_state = std::option::none<TransitionState>();
+        // If the cycle duration updated has been identified during transtion, then the transition state is kept
+        // with reset values except new cycle duration to have it properly set for the next new cycle.
+        // This may happen in case of cycle was ended and feature-flag has been disbaled before any task has
+        // been processed for the cycle transition.
+        // Note that we want to have consistent data in ready state which says that the cycle pointed in the ready state
+        // has been finished/summerized, and we are ready to start the next new cycle. and all the cycle inforamation should
+        // match the finalized/summerized cycle since its start, including cycle duration
+        if (std::option::is_some(&cycle_info.transition_state)) {
+            let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+            if (transition_state.new_cycle_duration == cycle_info.duration_secs) {
+                cycle_info.transition_state = std::option::none<TransitionState>();
+            } else {
+                // Reset all except new cycle duration
+                transition_state.refund_duration = 0;
+                transition_state.automation_fee_per_sec = 0;
+                transition_state.gas_committed_for_new_cycle = 0;
+                transition_state.gas_committed_for_next_cycle = 0;
+                transition_state.locked_fees = 0;
+                transition_state.expected_tasks_to_be_processed = vector[];
+                transition_state.actual_processed_tasks = vector[];
+            }
+        };
         update_cycle_state_to(cycle_info, CYCLE_READY)
     }
 
@@ -1793,6 +1831,7 @@ module supra_framework::automation_registry {
     ) acquires  ActiveAutomationRegistryConfig {
         if (enumerable_map::length(&automation_registry.tasks) == 0) {
             // Registry is empty move to ready state directly
+            // move_to_ready_state(cycle_info);
             update_cycle_state_to(cycle_info, CYCLE_READY);
             return
         };
@@ -1841,17 +1880,23 @@ module supra_framework::automation_registry {
     fun update_state_for_migration(
         automation_registry: &mut AutomationRegistry,
         arc: &AutomationRegistryConfig,
-        aei: &AutomationEpochInfo,
+        aei: AutomationEpochInfo,
         current_time: u64
     ) {
-        let previous_epoch_duration = current_time - aei.start_time;
+        let AutomationEpochInfo {
+            start_time,
+            epoch_interval: _,
+            expected_epoch_duration,
+
+        } = aei;
+        let previous_epoch_duration = current_time - start_time;
         let refund_interval = 0;
         let refund_automation_fee_per_sec = 0;
 
         // If epoch actual duration is greater or equal to expected epoch-duration then there is nothing to refund.
-        if (automation_registry.epoch_locked_fees != 0 && previous_epoch_duration < aei.expected_epoch_duration) {
+        if (automation_registry.epoch_locked_fees != 0 && previous_epoch_duration < expected_epoch_duration) {
             let previous_tcmg = automation_registry.gas_committed_for_this_epoch;
-            refund_interval = aei.expected_epoch_duration - previous_epoch_duration;
+            refund_interval = expected_epoch_duration - previous_epoch_duration;
             // Compute the automation fee multiplier for ended epoch
             refund_automation_fee_per_sec = calculate_automation_fee_multiplier_for_epoch(arc, previous_tcmg, arc.registry_max_gas_cap);
         };
@@ -2231,7 +2276,8 @@ module supra_framework::automation_registry {
     }
 
     /// The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
-    fun update_config_from_buffer(cycle_info: &mut AutomationCycleDetails) acquires ActiveAutomationRegistryConfig {
+    /// This function will be called only during migration and can be removed in subsequent releases
+    fun update_config_from_buffer_for_migration(cycle_info: &mut AutomationCycleDetails) acquires ActiveAutomationRegistryConfig {
         if (config_buffer::does_exist<AutomationRegistryConfig>()) {
             let buffer = config_buffer::extract<AutomationRegistryConfig>();
             let automation_registry_config = &mut borrow_global_mut<ActiveAutomationRegistryConfig>(
@@ -2246,15 +2292,34 @@ module supra_framework::automation_registry {
             automation_registry_config.congestion_exponent = buffer.congestion_exponent;
             automation_registry_config.task_capacity = buffer.task_capacity;
         };
-        if (config_buffer::does_exist<AutomationCycleDuration>()) {
-            let buffer = config_buffer::extract<AutomationCycleDuration>();
-            if (std::option::is_some(&cycle_info.transition_state)) {
-                let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
-                transition_state.new_cycle_duration = buffer.duration_secs;
-            } else {
-                cycle_info.duration_secs = buffer.duration_secs;
-            }
+        // In case if between supra-framework update and migration step the config has been updated using the new API.
+        update_config_from_buffer(cycle_info)
+    }
+
+    /// The function updates the ActiveAutomationRegistryConfig structure with values extracted from the buffer, if the buffer exists.
+    fun update_config_from_buffer(cycle_info: &mut AutomationCycleDetails) acquires ActiveAutomationRegistryConfig {
+        if (!config_buffer::does_exist<AutomationRegistryConfigV2>()) {
+            return
         };
+        let buffer = config_buffer::extract<AutomationRegistryConfigV2>();
+        let automation_registry_config = &mut borrow_global_mut<ActiveAutomationRegistryConfig>(
+            @supra_framework
+        ).main_config;
+        automation_registry_config.task_duration_cap_in_secs = buffer.task_duration_cap_in_secs;
+        automation_registry_config.registry_max_gas_cap = buffer.registry_max_gas_cap;
+        automation_registry_config.automation_base_fee_in_quants_per_sec = buffer.automation_base_fee_in_quants_per_sec;
+        automation_registry_config.flat_registration_fee_in_quants = buffer.flat_registration_fee_in_quants;
+        automation_registry_config.congestion_threshold_percentage = buffer.congestion_threshold_percentage;
+        automation_registry_config.congestion_base_fee_in_quants_per_sec = buffer.congestion_base_fee_in_quants_per_sec;
+        automation_registry_config.congestion_exponent = buffer.congestion_exponent;
+        automation_registry_config.task_capacity = buffer.task_capacity;
+
+        if (std::option::is_some(&cycle_info.transition_state)) {
+            let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
+            transition_state.new_cycle_duration = buffer.cycle_duration_secs;
+        } else {
+            cycle_info.duration_secs = buffer.cycle_duration_secs;
+        }
     }
 
     /// Transfers the specified fee amount from the resource account to the target account.
@@ -5961,7 +6026,139 @@ module supra_framework::automation_registry {
         migrate_v2(framework, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
     }
 
-    #[test]
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_transitions_to_ready_from_suspended(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let task_exists = true;
+        let t1_t2_max_gas_amount = 44_000_000;
+        let t3_max_gas_amount = 11_000_000;
+        let fwk_address = address_of(framework);
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            ACTIVE);
+
+        let new_cycle_duration = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
+        update_config_v2(
+            framework,
+            3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS ,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            new_cycle_duration
+        );
+
+        let expected_cycle_duration = {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_STARTED, 1);
+            cycle_details.duration_secs
+        };
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 2);
+            assert!(std::option::is_some(&cycle_details.transition_state), 3);
+            assert!(cycle_details.duration_secs == expected_cycle_duration, 4);
+            let transition_state = std::option::borrow<TransitionState>(&cycle_details.transition_state);
+            assert!(transition_state.new_cycle_duration == expected_cycle_duration, 5);
+            // updated configs are not read from buffer
+            assert!(config_buffer::does_exist<AutomationRegistryConfigV2>(), 6);
+        };
+
+        // Process tasks to transition to ready state;
+        process_tasks(create_signer(@vm_reserved), vector[task1]);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
+            assert!(cycle_details.state == CYCLE_READY, 7);
+            assert!(std::option::is_none(&cycle_details.transition_state), 8);
+            // still, updated configs are not read from buffer
+            assert!(config_buffer::does_exist<AutomationRegistryConfigV2>(), 9);
+
+        };
+
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    fun check_transitions_to_ready_from_finished_suspended(framework: &signer, user: &signer)
+    acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+        let task_exists = true;
+        let t1_t2_max_gas_amount = 44_000_000;
+        let t3_max_gas_amount = 11_000_000;
+        let fwk_address = address_of(framework);
+
+        let task1 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+
+        let task2 = register_with_state(
+            framework,
+            user,
+            t1_t2_max_gas_amount,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+
+        let new_cycle_duration = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
+        update_config_v2(
+            framework,
+            3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS ,
+            AUTOMATION_MAX_GAS_TEST,
+            AUTOMATION_BASE_FEE_TEST,
+            FLAT_REGISTRATION_FEE_TEST,
+            CONGESTION_THRESHOLD_TEST,
+            CONGESTION_BASE_FEE_TEST,
+            CONGESTION_EXPONENT_TEST,
+            TASK_CAPACITY_TEST,
+            new_cycle_duration
+        );
+        timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        monitor_cycle_end();
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+
+        let expected_cycle_duration = {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            assert!(cycle_details.state == CYCLE_SUSPENDED, 1);
+            cycle_details.duration_secs
+        };
+
+        // Process tasks to transition to ready state;
+        process_tasks(create_signer(@vm_reserved), vector[task1, task2]);
+        {
+            let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
+            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
+            assert!(cycle_details.state == CYCLE_READY, 6);
+            assert!(std::option::is_some(&cycle_details.transition_state), 7);
+            assert!(cycle_details.duration_secs == expected_cycle_duration, 8);
+            let transition_state = std::option::borrow<TransitionState>(&cycle_details.transition_state);
+            assert!(transition_state.new_cycle_duration == new_cycle_duration, 9);
+            assert!(vector::is_empty(&transition_state.expected_tasks_to_be_processed), 10);
+        };
+
+    }
+
+    #[test_only]
     fun check_vector_contains_perform() {
         let tvector = vector[];
         let count = 0;

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -278,8 +278,6 @@ module supra_framework::automation_registry {
         cycle_state_info: AutomationCycleInfo,
         /// The state transitioned from
         old_state: u8,
-        /// Timestamp of the state transition event registration
-        event_time: u64,
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -1758,7 +1756,6 @@ module supra_framework::automation_registry {
         let event = AutomationCycleEvent {
             cycle_state_info: into_automation_cycle_info(cycle_info),
             old_state,
-            event_time: timestamp::now_seconds(),
         };
         event::emit(event)
     }

--- a/aptos-move/framework/supra-framework/sources/block.move
+++ b/aptos-move/framework/supra-framework/sources/block.move
@@ -135,9 +135,6 @@ module supra_framework::block {
         let old_epoch_interval = block_resource.epoch_interval;
         block_resource.epoch_interval = new_epoch_interval;
 
-        // update epoch interval in registry contract
-        automation_registry::update_epoch_interval_in_registry(new_epoch_interval);
-
         if (std::features::module_event_migration_enabled()) {
             event::emit(
                 UpdateEpochInterval { old_epoch_interval, new_epoch_interval },
@@ -219,6 +216,8 @@ module supra_framework::block {
         // transition is the last block in the previous epoch.
         stake::update_performance_statistics(proposer_index, failed_proposer_indices);
         state_storage::on_new_block(reconfiguration::current_epoch());
+
+        automation_registry::monitor_cycle_end();
 
         block_metadata_ref.epoch_interval
     }

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -214,32 +214,20 @@ module supra_framework::genesis {
         transaction_fee::store_supra_coin_mint_cap(supra_framework, mint_cap);
     }
 
-    /// Genesis step 3: Initialize Supra Native Automation.
-    /// DEPRECATED in favoor of initialize_supra_native_automation_v2. It calls deprectead API.
+    /// DEPRECATED
+    ///
+    /// Deprecated in favoor of initialize_supra_native_automation_v2.
     public fun initialize_supra_native_automation(
-        supra_framework: &signer,
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
+        _supra_framework: &signer,
+        _task_duration_cap_in_secs: u64,
+        _registry_max_gas_cap: u64,
+        _automation_base_fee_in_quants_per_sec: u64,
+        _flat_registration_fee_in_quants: u64,
+        _congestion_threshold_percentage: u8,
+        _congestion_base_fee_in_quants_per_sec: u64,
+        _congestion_exponent: u8,
+        _task_capacity: u16,
     ) {
-        let epoch_interval_secs = block::get_epoch_interval_secs();
-        automation_registry::initialize(
-            supra_framework,
-            epoch_interval_secs,
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            automation_base_fee_in_quants_per_sec,
-            flat_registration_fee_in_quants,
-            congestion_threshold_percentage,
-            congestion_base_fee_in_quants_per_sec,
-            congestion_exponent,
-            task_capacity,
-        )
     }
 
     /// Genesis step 3: Initialize Supra Native Automation.
@@ -255,7 +243,7 @@ module supra_framework::genesis {
         task_capacity: u16,
         cycle_duration: u64
     ) {
-        automation_registry::initialize_v2(
+        automation_registry::initialize(
             supra_framework,
             cycle_duration,
             task_duration_cap_in_secs,

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -215,6 +215,7 @@ module supra_framework::genesis {
     }
 
     /// Genesis step 3: Initialize Supra Native Automation.
+    /// DEPRECATED in favoor of initialize_supra_native_automation_v2. It calls deprectead API.
     public fun initialize_supra_native_automation(
         supra_framework: &signer,
         task_duration_cap_in_secs: u64,
@@ -230,6 +231,33 @@ module supra_framework::genesis {
         automation_registry::initialize(
             supra_framework,
             epoch_interval_secs,
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+        )
+    }
+
+    /// Genesis step 3: Initialize Supra Native Automation.
+    public fun initialize_supra_native_automation_v2(
+        supra_framework: &signer,
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+        cycle_duration: u64
+    ) {
+        automation_registry::initialize_v2(
+            supra_framework,
+            cycle_duration,
             task_duration_cap_in_secs,
             registry_max_gas_cap,
             automation_base_fee_in_quants_per_sec,

--- a/aptos-move/framework/supra-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/supra-framework/sources/reconfiguration.move
@@ -6,7 +6,6 @@ module supra_framework::reconfiguration {
     use std::signer;
 
     use supra_framework::account;
-    use supra_framework::automation_registry;
     use supra_framework::chain_status;
     use supra_framework::event;
     use supra_framework::reconfiguration_state;
@@ -159,7 +158,6 @@ module supra_framework::reconfiguration {
         spec {
             assume config_ref.epoch + 1 <= MAX_U64;
         };
-        automation_registry::on_new_epoch();
         config_ref.epoch = config_ref.epoch + 1;
 
         if (std::features::module_event_migration_enabled()) {

--- a/aptos-move/framework/supra-framework/sources/reconfiguration_with_dkg.move
+++ b/aptos-move/framework/supra-framework/sources/reconfiguration_with_dkg.move
@@ -2,6 +2,7 @@
 module supra_framework::reconfiguration_with_dkg {
     use std::features;
     use std::option;
+    use supra_framework::automation_registry;
     use supra_framework::consensus_config;
     use supra_framework::dkg;
     use supra_framework::execution_config;
@@ -54,6 +55,7 @@ module supra_framework::reconfiguration_with_dkg {
         gas_schedule::on_new_epoch(framework);
         std::version::on_new_epoch(framework);
         features::on_new_epoch(framework);
+        automation_registry::on_new_epoch();
         jwk_consensus_config::on_new_epoch(framework);
         jwks::on_new_epoch(framework);
         keyless_account::on_new_epoch(framework);

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -578,7 +578,7 @@ fn initialize_supra_native_automation(session: &mut SessionExt, genesis_config: 
     exec_function(
         session,
         GENESIS_MODULE_NAME,
-        "initialize_supra_native_automation",
+        "initialize_supra_native_automation_v2",
         vec![],
         config.serialize_into_move_values_with_signer(CORE_CODE_ADDRESS),
     );

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -13,7 +13,7 @@ const DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE: u8 = 80;
 const DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 100;
 const DEFAULT_CONGESTION_EXPONENT: u8 = 6;
 const DEFAULT_TASK_CAPACITY: u16 = 500;
-const DEFAULT_CYCLE_DURATION_SECS: u64 = 600;
+const DEFAULT_CYCLE_DURATION_SECS: u64 = 1200;
 
 /// Initial version of configuration parameters for Supra native automation feature
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2025 Supra.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::on_chain_config::OnChainConfig;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::value::{serialize_values, MoveValue};
 use serde::{Deserialize, Serialize};
@@ -14,6 +13,7 @@ const DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE: u8 = 80;
 const DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC: u64 = 100;
 const DEFAULT_CONGESTION_EXPONENT: u8 = 6;
 const DEFAULT_TASK_CAPACITY: u16 = 500;
+const DEFAULT_CYCLE_DURATION_SECS: u64 = 600;
 
 /// Initial version of configuration parameters for Supra native automation feature
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -38,6 +38,8 @@ pub struct AutomationRegistryConfigV1 {
     congestion_exponent: u8,
     /// Maximum number of tasks that registry can hold.
     task_capacity: u16,
+    /// Cycle duration in seconds
+    cycle_duration_secs: u64,
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -51,6 +53,7 @@ impl Default for AutomationRegistryConfigV1 {
             congestion_base_fee_in_quants_per_sec: DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC,
             congestion_exponent: DEFAULT_CONGESTION_EXPONENT,
             task_capacity: DEFAULT_TASK_CAPACITY,
+            cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
         }
     }
 }
@@ -85,6 +88,10 @@ impl AutomationRegistryConfigV1 {
     pub fn task_capacity(&self) -> u16 {
         self.task_capacity
     }
+
+    pub fn cycle_duration_secs(&self) -> u64 {
+        self.cycle_duration_secs
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
@@ -114,6 +121,7 @@ impl AutomationRegistryConfig {
             MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
             MoveValue::U8(config.congestion_exponent()),
             MoveValue::U16(config.task_capacity()),
+            MoveValue::U64(config.cycle_duration_secs()),
         ];
         serialize_values(&arguments)
     }
@@ -123,9 +131,4 @@ impl From<AutomationRegistryConfigV1> for AutomationRegistryConfig {
     fn from(config: AutomationRegistryConfigV1) -> Self {
         Self::V1(config)
     }
-}
-
-impl OnChainConfig for AutomationRegistryConfig {
-    const MODULE_IDENTIFIER: &'static str = "automation_registry";
-    const TYPE_IDENTIFIER: &'static str = "AutomationRegistryConfig";
 }


### PR DESCRIPTION
- Introduced AutomationCycleInfo holding active cycle duration, start time , index and state information
- Introduced AutomationCycleDuration wrapper holding updated cycle duration which will be stored in config-buffer untill next cycle activation
- Introduced `AutomationCycleFinished`, `AutomationCycleStarted` events
- Deprecated the following functions in automation_registry:
   - `initialize` in favor of `initialize_v2`
   - `update_config` in favor of `update_config_v2`
   - `update_epoch_interval_in_registry` in favor of `monitor_cycle_end`o
   - `get_automation_epoch_info` in favor of `get_automation_cycle_info`
- Substitute AutomationEpochInfo utilization with AutomationCycleInfo instead
- Intorduced `migrate_v2` public API guarded by framework signer to support smooth transition from the old version(v1) to new detached automation cycle managment version.

- Updated automation registry initialization at genesis to v2 version.

- Updated `on_new_epoch` to handle `SUPRA_NATIVE_AUTOMATION` feature
   flag updates and correspondingly suspend and restart the automation
   registry lifecycle. No it is called only in scope of `supra_governance::reconfiguration`

- Introduced a dummy native function to check binary upgrade supporting cycle-base automation lifecycle in native layer as well.
- Implemented state transition flow based on the cycle start, end, suspend. For more details on state transition diagram see the [StateDiagram in miro board](https://miro.com/app/board/uXjVLLhWLtE=/?moveToWidget=3458764632410109664&cot=14)

The envisioned migration flow from `v1` to `v2` is the following:                                                                                                                                            
**Assumption:**
- chain is running with automation registry lifecycle corresponding to
epoch transition
- `monitor_cycle_end` API has means to check binary upgrade via
native-function-call which is called in scope of block-metadata
transaction execution, i.e. in scope of block-prologue.

**Update Flow:**
- node binaries are updated which support both versions of automation
registry data processing and extended to track also events of automation
cycle-based lifecycle
- supra-framework is upgraded with script extension which initiates
automation registry lifecycle flow mitgration to cycle-based mode via
`migrate_v2` public function call which emits `AutomationCycleFinished`
event upon successful execution. Note the script should trigger also reconfiguration.
During migration, all the existing tasks will be refunded with epoch-fee charged at the
beginning of the epoch, and will wait of being processed as part of the cycle based flow
- nodes properly updated with new binaries will start cycle-transition
flow upon observing `AutomationCycleFinished` event for the existing
tasks.
- nodes which are not update to a new binary will panic due to failure in
scope of block-metadata transaction execution due to missing
native-function call. This way there will not be source of inconsistent
chain state.
