### PR TITLE
[smr-moonshot Issue 2009] Created a separate code for missing native function

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -452,6 +452,13 @@ impl BlockAptosVM {
                 sub_status: None,
                 message: Some(err_msg),
             }),
+            Err(BlockExecutionError::FatalBlockExecutorError(
+                PanicError::MissingNativeFunction(err_msg),
+            )) => Err(VMStatus::Error {
+                status_code: StatusCode::MISSING_NATIVE_FUNCTION,
+                sub_status: None,
+                message: Some(err_msg),
+            }),
             Err(BlockExecutionError::FatalVMError(err)) => Err(err),
         }
     }

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -76,6 +76,10 @@ impl ExecutorTask for AptosExecutorTask {
                     ExecutionStatus::DelayedFieldsCodeInvariantError(
                         vm_status.message().cloned().unwrap_or_default(),
                     )
+                } else if vm_status.status_code() == StatusCode::MISSING_NATIVE_FUNCTION {
+                    ExecutionStatus::MissingNativeFunction(
+                        vm_status.message().cloned().unwrap_or_default(),
+                    )
                 } else if AptosVM::should_restart_execution(vm_output.change_set()) {
                     speculative_info!(
                         &log_context,
@@ -101,6 +105,10 @@ impl ExecutorTask for AptosExecutorTask {
                     == StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR
                 {
                     ExecutionStatus::DelayedFieldsCodeInvariantError(
+                        err.message().cloned().unwrap_or_default(),
+                    )
+                } else if err.status_code() == StatusCode::MISSING_NATIVE_FUNCTION {
+                    ExecutionStatus::MissingNativeFunction(
                         err.message().cloned().unwrap_or_default(),
                     )
                 } else {

--- a/aptos-move/aptos-vm/src/errors.rs
+++ b/aptos-move/aptos-vm/src/errors.rs
@@ -138,9 +138,7 @@ pub fn convert_prologue_error(
                 (INVALID_STATE, EINSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT) => {
                     StatusCode::INSUFFICIENT_BALANCE_FOR_REQUIRED_DEPOSIT
                 },
-                (INVALID_STATE, ENO_ACTIVE_AUTOMATION_TASK) => {
-                    StatusCode::NO_ACTIVE_AUTOMATED_TASK
-                },
+                (INVALID_STATE, ENO_ACTIVE_AUTOMATION_TASK) => StatusCode::NO_ACTIVE_AUTOMATED_TASK,
                 (category, reason) => {
                     let err_msg = format!("[aptos_vm] Unexpected prologue Move abort: {:?}::{:?} (Category: {:?} Reason: {:?})",
                     location, code, category, reason);
@@ -230,7 +228,8 @@ pub fn expect_only_successful_execution(
         e @ VMStatus::Error {
             status_code:
                 StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR
-                | StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR,
+                | StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR
+                | StatusCode::MISSING_NATIVE_FUNCTION,
             ..
         } => e,
         status => {

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -531,6 +531,7 @@ impl<T: Transaction> CapturedReads<T> {
     pub(crate) fn capture_delayed_field_read_error<E: std::fmt::Debug>(&mut self, e: &PanicOr<E>) {
         match e {
             PanicOr::CodeInvariantError(_) => self.incorrect_use = true,
+            PanicOr::MissingNativeFunction(_) => self.incorrect_use = true,
             PanicOr::Or(_) => self.speculative_failure = true,
         };
     }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -39,6 +39,9 @@ pub enum ExecutionStatus<O, E> {
     /// Code invariant error was detected during transaction execution, which
     /// can only be caused by the bug in the code.
     DelayedFieldsCodeInvariantError(String),
+    /// Transaction can't be executed because it requires a native function that is present
+    /// framework, but not in the current VM implementation.
+    MissingNativeFunction(String),
 }
 
 /// Inference result of a transaction.

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -38,7 +38,8 @@ macro_rules! forward_on_success_or_skip_rest {
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.$f(),
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
+                | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+                | ExecutionStatus::MissingNativeFunction(_) => vec![],
             })
     }};
 }
@@ -138,7 +139,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             },
             ExecutionStatus::Abort(_)
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
-            | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => BTreeMap::new(),
+            | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+            | ExecutionStatus::MissingNativeFunction(_) => BTreeMap::new(),
         };
 
         if self
@@ -242,6 +244,9 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 ExecutionStatus::DelayedFieldsCodeInvariantError(_) => Err(code_invariant_error(
                     "Delayed field invariant error cannot be committed",
                 )),
+                ExecutionStatus::MissingNativeFunction(msg) => {
+                    Err(PanicError::MissingNativeFunction(msg.clone()))
+                },
             }
         } else {
             Err(code_invariant_error(
@@ -303,7 +308,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 ),
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
+                | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+                | ExecutionStatus::MissingNativeFunction(_) => None,
             })
     }
 
@@ -320,7 +326,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 },
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
+                | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+                | ExecutionStatus::MissingNativeFunction(_) => None,
             })
     }
 
@@ -362,7 +369,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 },
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {
+                | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+                | ExecutionStatus::MissingNativeFunction(_) => {
                     Box::new(empty::<(T::Event, Option<MoveTypeLayout>)>())
                 },
             },
@@ -415,7 +423,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             },
             ExecutionStatus::Abort(_)
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
-            | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {},
+            | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+            | ExecutionStatus::MissingNativeFunction(_) => {},
         };
         Ok(())
     }
@@ -440,7 +449,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.get_write_summary(),
             ExecutionStatus::Abort(_)
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
-            | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => HashSet::new(),
+            | ExecutionStatus::DelayedFieldsCodeInvariantError(_)
+            | ExecutionStatus::MissingNativeFunction(_) => HashSet::new(),
         }
     }
 

--- a/aptos-move/e2e-move-tests/src/tests/lazy_natives.rs
+++ b/aptos-move/e2e-move-tests/src/tests/lazy_natives.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, assert_vm_status, MoveHarness};
+use crate::{assert_success, MoveHarness};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::account_address::AccountAddress;
 use move_core_types::vm_status::StatusCode;
@@ -37,11 +37,16 @@ module 0xcafe::test {
     ));
 
     // Should not be able to call something entry
-    let status = h.run_entry_function(
+    let result = h.try_run_entry_function(
         &acc,
         str::parse("0xcafe::test::something").unwrap(),
         vec![],
         vec![],
     );
-    assert_vm_status!(status, StatusCode::MISSING_DEPENDENCY)
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+
+    assert_eq!(status.status_code(), StatusCode::MISSING_NATIVE_FUNCTION);
+    assert!(status.message().unwrap().contains("`undefined`"));
 }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -503,20 +503,20 @@ impl FakeExecutor {
     /// data store. Panics if execution fails
     pub fn execute_and_apply_transaction(&mut self, transaction: Transaction) -> TransactionOutput {
         let mut outputs = self.execute_transaction_block(vec![transaction]).unwrap();
-        assert_eq!(outputs.len() , 1, "transaction outputs size mismatch");
+        assert_eq!(outputs.len(), 1, "transaction outputs size mismatch");
         let output = outputs.pop().unwrap();
         match output.status() {
             TransactionStatus::Keep(status) => {
                 match status {
-                    ExecutionStatus::Success => {}
-                    ExecutionStatus::OutOfGas => {}
-                    ExecutionStatus::MoveAbort { code,.. } => {
+                    ExecutionStatus::Success => {},
+                    ExecutionStatus::OutOfGas => {},
+                    ExecutionStatus::MoveAbort { code, .. } => {
                         let reason = code & 0xFFFF;
                         let category = ((code >> 16) & 0xFF) as u8;
                         println!("{category}: {reason}");
-                    }
-                    ExecutionStatus::ExecutionFailure { .. } => {}
-                    ExecutionStatus::MiscellaneousError(_) => {}
+                    },
+                    ExecutionStatus::ExecutionFailure { .. } => {},
+                    ExecutionStatus::MiscellaneousError(_) => {},
                 }
                 self.apply_write_set(output.write_set());
                 assert_eq!(
@@ -531,7 +531,6 @@ impl FakeExecutor {
             TransactionStatus::Retry => panic!("transaction status is retry"),
         }
     }
-
 
     fn execute_transaction_block_impl_with_state_view(
         &self,
@@ -682,6 +681,19 @@ impl FakeExecutor {
         txn_output
     }
 
+    pub fn try_execute_transaction(
+        &self,
+        txn: SignedTransaction,
+    ) -> Result<TransactionOutput, VMStatus> {
+        let txn_block = vec![txn];
+        let mut outputs = self.execute_block(txn_block)?;
+        let mut txn_output = outputs
+            .pop()
+            .expect("A block with one transaction should have one output");
+        txn_output.fill_error_status();
+        Ok(txn_output)
+    }
+
     pub fn execute_tagged_transaction(&self, txn: Transaction) -> TransactionOutput {
         let txn_block = vec![txn];
         let mut outputs = self
@@ -715,12 +727,14 @@ impl FakeExecutor {
             |gas_meter| {
                 let gas_profiler = match txn.payload() {
                     TransactionPayload::Script(_) => GasProfiler::new_script(gas_meter),
-                    TransactionPayload::AutomationRegistration(auto_payload) => GasProfiler::new_function(
-                        gas_meter,
-                        auto_payload.module_id().clone(),
-                        auto_payload.function().to_owned(),
-                        auto_payload.ty_args(),
-                    ),
+                    TransactionPayload::AutomationRegistration(auto_payload) => {
+                        GasProfiler::new_function(
+                            gas_meter,
+                            auto_payload.module_id().clone(),
+                            auto_payload.function().to_owned(),
+                            auto_payload.ty_args(),
+                        )
+                    },
                     TransactionPayload::EntryFunction(entry_func) => GasProfiler::new_function(
                         gas_meter,
                         entry_func.module().clone(),

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -142,6 +142,7 @@ impl MVDelayedFieldsError {
     ) -> PanicOr<MVDelayedFieldsError> {
         match err {
             PanicOr::CodeInvariantError(e) => PanicOr::CodeInvariantError(e),
+            PanicOr::MissingNativeFunction(e) => PanicOr::MissingNativeFunction(e),
             PanicOr::Or(DelayedFieldsSpeculativeError::NotFound(_)) => {
                 PanicOr::Or(MVDelayedFieldsError::NotFound)
             },

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -793,6 +793,9 @@ pub enum StatusCode {
     RESERVED_INVARIANT_VIOLATION_ERROR_4 = 2039,
     RESERVED_INVARIANT_VIOLATION_ERROR_5 = 2040,
 
+    // Supra specific invariant violation errors
+    MISSING_NATIVE_FUNCTION = 2100,
+
     // Errors that can arise from binary decoding (deserialization)
     // Deserialization Errors: 3000-3999
     UNKNOWN_BINARY_ERROR = 3000,

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -114,6 +114,8 @@ impl Function {
         let is_entry = def.is_entry;
 
         let (native, is_native) = if def.is_native() {
+            // If a native function is missing an implementation it will succeed to load,
+            // but fail to execute.
             let native = natives.resolve(
                 module_id.address(),
                 module_id.name().as_str(),
@@ -258,7 +260,7 @@ impl Function {
 
     pub(crate) fn get_native(&self) -> PartialVMResult<&UnboxedNativeFunction> {
         self.native.as_deref().ok_or_else(|| {
-            PartialVMError::new(StatusCode::MISSING_DEPENDENCY)
+            PartialVMError::new(StatusCode::MISSING_NATIVE_FUNCTION)
                 .with_message(format!("Missing Native Function `{}`", self.name))
         })
     }

--- a/types/src/delayed_fields.rs
+++ b/types/src/delayed_fields.rs
@@ -18,12 +18,14 @@ use std::fmt::Display;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PanicError {
     CodeInvariantError(String),
+    MissingNativeFunction(String),
 }
 
 impl Display for PanicError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PanicError::CodeInvariantError(e) => write!(f, "{}", e),
+            PanicError::MissingNativeFunction(e) => write!(f, "{}", e),
         }
     }
 }
@@ -34,6 +36,9 @@ impl From<PanicError> for PartialVMError {
             PanicError::CodeInvariantError(msg) => {
                 PartialVMError::new(StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR)
                     .with_message(msg)
+            },
+            PanicError::MissingNativeFunction(msg) => {
+                PartialVMError::new(StatusCode::MISSING_NATIVE_FUNCTION).with_message(msg)
             },
         }
     }


### PR DESCRIPTION
Needed and discussed at [smr-moonshot/#2009](https://github.com/Entropy-Foundation/smr-moonshot/issues/2009).
When a transaction references a native function that wasn't loaded correctly a new special error is emitted.