### PR TITLE
[AN-Issue-1990] Introduced a new native transaction for automation registry bookkeeping

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1387,10 +1387,12 @@ impl TransactionsApi {
                 format!("Script::{}", txn.committed_hash()).to_string()
             },
             TransactionPayload::ModuleBundle(_) => "ModuleBundle::unknown".to_string(),
-            TransactionPayload::AutomationRegistration(auto_payload) => FunctionStats::function_to_key(
-                auto_payload.module_id(),
-                &auto_payload.function().into(),
-            ),
+            TransactionPayload::AutomationRegistration(auto_payload) => {
+                FunctionStats::function_to_key(
+                    auto_payload.module_id(),
+                    &auto_payload.function().into(),
+                )
+            },
             TransactionPayload::EntryFunction(entry_function) => FunctionStats::function_to_key(
                 entry_function.module(),
                 &entry_function.function().into(),

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -3,12 +3,12 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::transaction::AutomationRegistrationParamsV1;
 use crate::{
     transaction::{
-        BlockEpilogueTransaction, DecodedTableData, DeleteModule,
-        DeleteResource, DeleteTableItem, DeletedTableData, MultisigPayload,
-        MultisigTransactionPayload, StateCheckpointTransaction, UserTransactionRequestInner,
-        WriteModule, WriteResource, WriteTableItem,
+        BlockEpilogueTransaction, DecodedTableData, DeleteModule, DeleteResource, DeleteTableItem,
+        DeletedTableData, MultisigPayload, MultisigTransactionPayload, StateCheckpointTransaction,
+        UserTransactionRequestInner, WriteModule, WriteResource, WriteTableItem,
     },
     view::{ViewFunction, ViewRequest},
     Address, Bytecode, DirectWriteSet, EntryFunctionId, EntryFunctionPayload, Event,
@@ -24,6 +24,7 @@ use aptos_logger::{sample, sample::SampleRate};
 use aptos_resource_viewer::AptosValueAnnotator;
 use aptos_storage_interface::DbReader;
 use aptos_types::transaction::automation::RegistrationParams;
+use aptos_types::transaction::Transaction::AutomationRegistryTransaction;
 use aptos_types::{
     access_path::{AccessPath, Path},
     chain_id::ChainId,
@@ -58,7 +59,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use crate::transaction::AutomationRegistrationParamsV1;
 
 const OBJECT_MODULE: &IdentStr = ident_str!("object");
 const OBJECT_STRUCT: &IdentStr = ident_str!("Object");
@@ -242,6 +242,9 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 let payload = self.try_into_transaction_payload(automated_txn.payload().clone())?;
                 (&automated_txn, info, payload, events, timestamp).into()
             },
+            AutomationRegistryTransaction(automated_txn) => {
+                unreachable!("Automation registry transactions exposure to api is not supported ");
+            },
         })
     }
 
@@ -314,8 +317,14 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 let Some(params_v1) = maybe_params_v1 else {
                     bail!("Unsupported automation registration parameters.");
                 };
-                let (inner_payload, max_gas_amount, gas_price_cap, expiration_timestamp_secs, automation_fee_cap, aux_data) =
-                    params_v1.into_inner();
+                let (
+                    inner_payload,
+                    max_gas_amount,
+                    gas_price_cap,
+                    expiration_timestamp_secs,
+                    automation_fee_cap,
+                    aux_data,
+                ) = params_v1.into_inner();
                 let auto_payload = AutomationRegistrationParamsV1 {
                     automated_function: self.try_into_entry_function_payload(inner_payload)?,
                     expiration_timestamp_secs,
@@ -693,7 +702,9 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                     automated_function,
                     expiration_timestamp_secs,
                     max_gas_amount,
-                    gas_price_cap, automation_fee_cap, aux_data,
+                    gas_price_cap,
+                    automation_fee_cap,
+                    aux_data,
                 } = params_v1;
                 let core_automated_function =
                     self.try_into_supra_core_entry_function(automated_function)?;

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -212,7 +212,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [
             max_execution_gas_gov: InternalGas,
             { RELEASE_V1_13.. => "max_execution_gas.gov" },
-            5_000_000_000,
+            6_000_000_000,
         ],
         [
             max_io_gas: InternalGas,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -152,8 +152,9 @@ macro_rules! unwrap_or_discard {
     };
 }
 
-pub(crate) use unwrap_or_discard;
+use crate::automation_registry_transaction_processor::AutomationRegistryTransactionProcessor;
 use crate::gas::check_automation_task_gas;
+pub(crate) use unwrap_or_discard;
 
 pub(crate) fn get_system_transaction_output(
     session: SessionExt,
@@ -2636,6 +2637,13 @@ impl AptosVM {
             },
             Transaction::AutomatedTransaction(txn) => AutomatedTransactionProcessor::new(self)
                 .execute_transaction(resolver, txn, log_context),
+            Transaction::AutomationRegistryTransaction(txn) => {
+                AutomationRegistryTransactionProcessor::new(self).execute_transaction(
+                    resolver,
+                    txn,
+                    log_context,
+                )?
+            },
         })
     }
 

--- a/aptos-move/aptos-vm/src/automation_registry_transaction_processor.rs
+++ b/aptos-move/aptos-vm/src/automation_registry_transaction_processor.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 Supra.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::aptos_vm::{get_or_vm_startup_failure, get_system_transaction_output};
+use crate::counters::SYSTEM_TRANSACTIONS_EXECUTED;
+use crate::errors::discarded_output;
+use crate::move_vm_ext::{AptosMoveResolver, SessionExt, SessionId};
+use crate::AptosVM;
+use aptos_types::account_config;
+use aptos_types::fee_statement::FeeStatement;
+use aptos_types::on_chain_config::FeatureFlag;
+use aptos_types::transaction::automation::AutomationRegistryRecord;
+use aptos_types::transaction::{ExecutionStatus, TransactionStatus};
+use aptos_vm_logging::log_schema::AdapterLogSchema;
+use aptos_vm_types::output::VMOutput;
+use aptos_vm_types::storage::change_set_configs::ChangeSetConfigs;
+use move_binary_format::errors::VMError;
+use move_core_types::vm_status::{StatusCode, VMStatus};
+use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
+use move_vm_types::gas::UnmeteredGasMeter;
+use std::ops::Deref;
+
+pub struct AutomationRegistryTransactionProcessor<'m> {
+    aptos_vm: &'m AptosVM,
+}
+
+impl Deref for AutomationRegistryTransactionProcessor<'_> {
+    type Target = AptosVM;
+
+    fn deref(&self) -> &Self::Target {
+        self.aptos_vm
+    }
+}
+
+impl<'m> AutomationRegistryTransactionProcessor<'m> {
+    pub(crate) fn new(aptos_vm: &'m AptosVM) -> Self {
+        Self { aptos_vm }
+    }
+
+    /// Executes an automation registry transaction using the unmetered gas meter as they are
+    /// considered as system transactions
+    pub fn execute_transaction(
+        &self,
+        resolver: &impl AptosMoveResolver,
+        action_record: &AutomationRegistryRecord,
+        log_context: &AdapterLogSchema,
+    ) -> Result<(VMStatus, VMOutput), VMStatus> {
+        if !self
+            .features()
+            .is_enabled(FeatureFlag::SUPRA_AUTOMATION_CYCLE)
+        {
+            return Ok((
+                VMStatus::Error {
+                    status_code: StatusCode::FEATURE_UNDER_GATING,
+                    sub_status: None,
+                    message: Some(
+                        "The Supra Native Automation cycle is not enabled yet.".to_string(),
+                    ),
+                },
+                discarded_output(StatusCode::FEATURE_UNDER_GATING),
+            ));
+        }
+        let mut gas_meter = UnmeteredGasMeter;
+        let mut session = self.new_session(
+            resolver,
+            SessionId::automation_registry_action(action_record),
+            None,
+        );
+
+        let args = action_record.serialize_args_with_sender(account_config::reserved_vm_address());
+
+        let storage = TraversalStorage::new();
+        let result = session
+            .execute_function_bypass_visibility(
+                action_record.module_id(),
+                action_record.function(),
+                action_record.ty_args(),
+                args,
+                &mut gas_meter,
+                &mut TraversalContext::new(&storage),
+            )
+            .map(|_return_vals| ());
+        SYSTEM_TRANSACTIONS_EXECUTED.inc();
+
+        match result {
+            Ok(_) => {
+                let output = get_system_transaction_output(
+                    session,
+                    FeeStatement::zero(),
+                    ExecutionStatus::Success,
+                    &get_or_vm_startup_failure(&self.storage_gas_params, log_context)?
+                        .change_set_configs,
+                )?;
+                Ok((VMStatus::Executed, output))
+            },
+            Err(vm_err) => self.get_transaction_error_output(
+                session,
+                &get_or_vm_startup_failure(&self.storage_gas_params, log_context)?
+                    .change_set_configs,
+                vm_err,
+            ),
+        }
+    }
+
+    fn get_transaction_error_output(
+        &self,
+        session: SessionExt,
+        change_set_configs: &ChangeSetConfigs,
+        vm_err: VMError,
+    ) -> Result<(VMStatus, VMOutput), VMStatus> {
+        let vm_status = VMStatus::from(vm_err);
+        let (txn_status, aux_data) =
+            TransactionStatus::from_vm_status(vm_status.clone(), false, self.features());
+
+        let change_set = session.finish(change_set_configs)?;
+
+        let output = VMOutput::new(change_set, FeeStatement::zero(), txn_status, aux_data);
+        Ok((vm_status, output))
+    }
+}

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -125,6 +125,7 @@ pub mod validator_txns;
 pub mod verifier;
 mod automated_transaction_processor;
 pub mod aptos_vm_viewer;
+mod automation_registry_transaction_processor;
 
 pub use crate::aptos_vm::{AptosSimulationVM, AptosVM};
 use crate::sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor};

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/session_id.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/session_id.rs
@@ -10,6 +10,7 @@ use aptos_types::{
 };
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
+use aptos_types::transaction::automation::AutomationRegistryRecord;
 
 #[derive(BCSCryptoHash, Clone, CryptoHasher, Deserialize, Serialize)]
 pub enum SessionId {
@@ -50,6 +51,9 @@ pub enum SessionId {
     ValidatorTxn {
         script_hash: Vec<u8>,
     },
+    AutomationRegistryTxn {
+        id: HashValue,
+    }
 }
 
 impl SessionId {
@@ -82,6 +86,12 @@ impl SessionId {
             sender: txn_metadata.sender,
             sequence_number: txn_metadata.sequence_number,
             script_hash: txn_metadata.script_hash.clone(),
+        }
+    }
+
+    pub fn automation_registry_action(record: &AutomationRegistryRecord) -> Self {
+        Self::AutomationRegistryTxn {
+            id: record.hash()
         }
     }
 
@@ -140,6 +150,7 @@ impl SessionId {
             | Self::ValidatorTxn { script_hash } => script_hash,
             Self::BlockMeta { id: _ }
             | Self::Genesis { id: _ }
+            | Self::AutomationRegistryTxn { id: _ }
             | Self::Void
             | Self::BlockMetaExt { id: _ } => vec![],
         }

--- a/aptos-move/e2e-testsuite/src/tests/automated_transactions.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automated_transactions.rs
@@ -4,12 +4,14 @@
 use crate::tests::automation_registration::AutomationRegistrationTestContext;
 use aptos_cached_packages::aptos_framework_sdk_builder;
 use aptos_crypto::HashValue;
-use aptos_types::chain_id::ChainId;
-use aptos_types::on_chain_config::AutomationCycleState;
-use aptos_types::transaction::automated_transaction::{
-    AutomatedTransaction, AutomatedTransactionBuilder, BuilderResult,
+use aptos_types::{
+    chain_id::ChainId,
+    on_chain_config::AutomationCycleState,
+    transaction::{
+        automated_transaction::{AutomatedTransaction, AutomatedTransactionBuilder, BuilderResult},
+        ExecutionStatus, Transaction, TransactionStatus,
+    },
 };
-use aptos_types::transaction::{ExecutionStatus, Transaction, TransactionStatus};
 use move_core_types::vm_status::StatusCode;
 
 #[test]
@@ -152,8 +154,10 @@ fn check_automated_transaction_successful_execution() {
     // Execute registry action to charge and activate the task
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
-    let registry_action = test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![0]);
-    test_context.execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let registry_action =
+        test_context.create_automation_registry_transaction(0, cycle_info.index + 1, 1, vec![0]);
+    test_context
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::STARTED);
 

--- a/aptos-move/e2e-testsuite/src/tests/automated_transactions.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automated_transactions.rs
@@ -5,6 +5,7 @@ use crate::tests::automation_registration::AutomationRegistrationTestContext;
 use aptos_cached_packages::aptos_framework_sdk_builder;
 use aptos_crypto::HashValue;
 use aptos_types::chain_id::ChainId;
+use aptos_types::on_chain_config::AutomationCycleState;
 use aptos_types::transaction::automated_transaction::{
     AutomatedTransaction, AutomatedTransactionBuilder, BuilderResult,
 };
@@ -145,8 +146,16 @@ fn check_automated_transaction_successful_execution() {
         StatusCode::NO_ACTIVE_AUTOMATED_TASK,
     );
 
-    // Moving to the next epoch
-    test_context.advance_chain_time_in_secs(7200);
+    // Moving to the next cycle
+    test_context.advance_chain_time_in_secs(1200);
+
+    // Execute registry action to charge and activate the task
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
+    let registry_action = test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![0]);
+    test_context.execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::STARTED);
 
     // Execute automated transaction one more time which should be success, as task is already become active after epoch change
     let sender_address = test_context.sender_account_address();

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -1,11 +1,16 @@
 // Copyright (c) 2024 Supra.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tests::vm_viewer::to_view_function;
 use aptos_cached_packages::aptos_framework_sdk_builder;
+use aptos_language_e2e_tests::data_store::FakeDataStore;
 use aptos_language_e2e_tests::{
     account::{Account, AccountData},
     executor::FakeExecutor,
 };
+use aptos_types::on_chain_config::{AutomationCycleDetails, AutomationCycleInfo, AutomationCycleState, OnChainConfig};
+use aptos_types::transaction::automation::{AutomationRegistryAction, AutomationRegistryRecord};
+use aptos_types::transaction::Transaction;
 use aptos_types::{
     on_chain_config::FeatureFlag,
     transaction::{
@@ -14,12 +19,13 @@ use aptos_types::{
         TransactionStatus,
     },
 };
-use move_core_types::{account_address::AccountAddress, value::MoveValue, vm_status::StatusCode};
+use aptos_vm::aptos_vm_viewer::AptosVMViewer;
+use move_core_types::{
+    account_address::AccountAddress, value::serialize_values, value::MoveValue,
+    vm_status::StatusCode,
+};
 use std::ops::{Deref, DerefMut};
 use std::time::Instant;
-use aptos_language_e2e_tests::data_store::FakeDataStore;
-use aptos_vm::aptos_vm_viewer::AptosVMViewer;
-use crate::tests::vm_viewer::to_view_function;
 
 const TIMESTAMP_NOW_SECONDS: &str = "0x1::timestamp::now_seconds";
 const ACCOUNT_BALANCE: &str = "0x1::coin::balance";
@@ -28,6 +34,10 @@ const ACCOUNT_SEQ_NUM: &str = "0x1::account::get_sequence_number";
 const AUTOMATION_NEXT_TASK_ID: &str = "0x1::automation_registry::get_next_task_index";
 const AUTOMATION_TASK_DETAILS: &str = "0x1::automation_registry::get_task_details";
 const AUTOMATION_TASK_DETAILS_BULK: &str = "0x1::automation_registry::get_task_details_bulk";
+const AUTOMATION_CYCLE_INFO: &str = "0x1::automation_registry::get_cycle_info";
+const HAS_SENDER_ACTIVE_TASK_WITH_ID: &str =
+    "0x1::automation_registry::has_sender_active_task_with_id";
+const GET_TASK_IDS: &str = "0x1::automation_registry::get_task_ids";
 
 pub(crate) struct AutomationRegistrationTestContext {
     executor: FakeExecutor,
@@ -61,30 +71,56 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn set_supra_native_automation(&mut self, enable: bool) {
-        self.set_feature_flag(FeatureFlag::SUPRA_NATIVE_AUTOMATION, enable);
+        self.toggle_feature_with_registry_reconfig(FeatureFlag::SUPRA_NATIVE_AUTOMATION, enable);
     }
-
 
     pub(crate) fn set_feature_flag(&mut self, flag: FeatureFlag, enable: bool) {
         let acc = AccountAddress::ONE;
-        let flag_value = [flag]
-            .into_iter()
-            .map(|f| f as u64)
-            .collect::<Vec<_>>();
+        let flag_value = [flag].into_iter().map(|f| f as u64).collect::<Vec<_>>();
         let (enabled, disabled) = if enable {
             (flag_value, vec![])
         } else {
             (vec![], flag_value)
         };
-        self.executor
-            .exec("features", "change_feature_flags_internal", vec![], vec![
+        self.executor.exec(
+            "features",
+            "change_feature_flags_internal",
+            vec![],
+            vec![
                 MoveValue::Signer(acc).simple_serialize().unwrap(),
                 bcs::to_bytes(&enabled).unwrap(),
                 bcs::to_bytes(&disabled).unwrap(),
-            ]);
+            ],
+        );
     }
 
+    pub(crate) fn toggle_feature_with_registry_reconfig(
+        &mut self,
+        flag: FeatureFlag,
+        enable: bool,
+    ) {
+        self.set_feature_flag(flag, enable);
 
+        // Here we `automation_registry::on_new_epoch` to have the feature flag changes reflected.
+        // For some reason `supra_governance` apis to reconfigure the chain state was causing issues
+        // on writing the output changeset to the storage in the test-environment
+        // when the function was called twice in the same context.
+        self.executor
+            .exec("automation_registry", "on_new_epoch", vec![], vec![]);
+    }
+
+    pub(crate) fn create_automation_registry_transaction(
+        &self,
+        cycle_id: u64,
+        block_height: u64,
+        task_indexes: Vec<u64>,
+    ) -> AutomationRegistryRecord {
+        AutomationRegistryRecord::new(
+            cycle_id,
+            block_height,
+            AutomationRegistryAction::process(task_indexes),
+        )
+    }
 
     pub(crate) fn new_account_data(&mut self, amount: u64, seq_num: u64) -> AccountData {
         let new_account_data = self.create_raw_account_data(amount, seq_num);
@@ -157,7 +193,8 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn advance_chain_time_in_secs(&mut self, secs: u64) {
-        self.set_block_time(secs * 1_000_000);
+        let chain_current_time = self.chain_time_now();
+        self.set_block_time((chain_current_time + secs) * 1_000_000);
         self.new_block()
     }
 
@@ -173,10 +210,11 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn account_sequence_number(&mut self, account_address: AccountAddress) -> u64 {
-        let view_output =
-            self.execute_view_function(str::parse(ACCOUNT_SEQ_NUM).unwrap(), vec![], vec![
-                account_address.to_vec(),
-            ]);
+        let view_output = self.execute_view_function(
+            str::parse(ACCOUNT_SEQ_NUM).unwrap(),
+            vec![],
+            vec![account_address.to_vec()],
+        );
         let result = view_output.values.expect("Valid result");
         assert_eq!(result.len(), 1);
         bcs::from_bytes::<u64>(&result[0]).unwrap()
@@ -194,42 +232,93 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn get_task_details(&mut self, index: u64) -> AutomationTaskMetaData {
-        let view_output =
-            self.execute_view_function(str::parse(AUTOMATION_TASK_DETAILS).unwrap(), vec![], vec![
-                MoveValue::U64(index)
-                    .simple_serialize()
-                    .expect("Successful serialization"),
-            ]);
+        let view_output = self.execute_view_function(
+            str::parse(AUTOMATION_TASK_DETAILS).unwrap(),
+            vec![],
+            vec![MoveValue::U64(index)
+                .simple_serialize()
+                .expect("Successful serialization")],
+        );
         let result = view_output.values.expect("Valid result");
         assert!(!result.is_empty());
         bcs::from_bytes::<AutomationTaskMetaData>(&result[0])
             .expect("Successful deserialization of AutomationTaskMetaData")
     }
 
-    pub(crate) fn get_task_details_with_vm_viewer(index: u64, vm_viewer: &AptosVMViewer<FakeDataStore>) -> AutomationTaskMetaData {
-        let view_output =
-            vm_viewer.execute_view_function(to_view_function(str::parse(AUTOMATION_TASK_DETAILS).unwrap(), vec![], vec![
-                MoveValue::U64(index)
+    pub(crate) fn get_task_details_with_vm_viewer(
+        index: u64,
+        vm_viewer: &AptosVMViewer<FakeDataStore>,
+    ) -> AutomationTaskMetaData {
+        let view_output = vm_viewer.execute_view_function(
+            to_view_function(
+                str::parse(AUTOMATION_TASK_DETAILS).unwrap(),
+                vec![],
+                vec![MoveValue::U64(index)
                     .simple_serialize()
-                    .expect("Successful serialization"),
-            ]), 50_000);
+                    .expect("Successful serialization")],
+            ),
+            50_000,
+        );
         let result = view_output.values.expect("Valid result");
         assert!(!result.is_empty());
         bcs::from_bytes::<AutomationTaskMetaData>(&result[0])
             .expect("Successful deserialization of AutomationTaskMetaData")
     }
 
-    pub(crate) fn get_task_details_bulk(indexes: Vec<u64>, vm_viewer: &AptosVMViewer<FakeDataStore>) -> Vec<AutomationTaskMetaData> {
-        let view_output =
-            vm_viewer.execute_view_function(to_view_function(str::parse(AUTOMATION_TASK_DETAILS_BULK).unwrap(), vec![], vec![
-                MoveValue::Vector(indexes.into_iter().map(MoveValue::U64).collect())
-                    .simple_serialize()
-                    .expect("Successful serialization"),
-            ]), 50_000);
+    pub(crate) fn get_task_details_bulk(
+        indexes: Vec<u64>,
+        vm_viewer: &AptosVMViewer<FakeDataStore>,
+    ) -> Vec<AutomationTaskMetaData> {
+        let view_output = vm_viewer.execute_view_function(
+            to_view_function(
+                str::parse(AUTOMATION_TASK_DETAILS_BULK).unwrap(),
+                vec![],
+                vec![
+                    MoveValue::Vector(indexes.into_iter().map(MoveValue::U64).collect())
+                        .simple_serialize()
+                        .expect("Successful serialization"),
+                ],
+            ),
+            50_000,
+        );
         let result = view_output.values.expect("Valid result");
         assert!(!result.is_empty());
         bcs::from_bytes::<Vec<AutomationTaskMetaData>>(&result[0])
             .expect("Successful deserialization of Vec<AutomationTaskMetaData>")
+    }
+
+    pub(crate) fn get_cycle_info(&mut self) -> AutomationCycleInfo {
+        let view_output =
+            self.execute_view_function(str::parse(AUTOMATION_CYCLE_INFO).unwrap(), vec![], vec![]);
+        let result = view_output.values.expect("Valid result");
+        assert!(!result.is_empty());
+        bcs::from_bytes::<AutomationCycleInfo>(&result[0])
+            .expect("Successful deserialization of AutomationCycleInfo")
+    }
+
+    pub(crate) fn has_sender_active_task_with_id(
+        &mut self,
+        sender: AccountAddress,
+        task_idx: u64,
+    ) -> bool {
+        let view_output = self.execute_view_function(
+            str::parse(HAS_SENDER_ACTIVE_TASK_WITH_ID).unwrap(),
+            vec![],
+            serialize_values(&[MoveValue::Address(sender), MoveValue::U64(task_idx)]),
+        );
+        let result = view_output.values.expect("Valid result");
+        assert!(!result.is_empty());
+        bcs::from_bytes::<bool>(&result[0])
+            .expect("Successful deserialization of AutomationCycleInfo")
+    }
+
+    pub(crate) fn get_task_ids(&mut self) -> Vec<u64> {
+        let view_output =
+            self.execute_view_function(str::parse(GET_TASK_IDS).unwrap(), vec![], vec![]);
+        let result = view_output.values.expect("Valid result");
+        assert!(!result.is_empty());
+        bcs::from_bytes::<Vec<u64>>(&result[0])
+            .expect("Successful deserialization of AutomationCycleInfo")
     }
 }
 
@@ -291,6 +380,7 @@ fn check_successful_registration() {
 
     // enable the supra native automation, registration should succeed.
     test_context.set_supra_native_automation(true);
+
     let output = test_context.execute_and_apply(automation_txn);
     assert_eq!(
         output.status(),
@@ -362,7 +452,10 @@ fn check_invalid_gas_params_of_automation_task() {
         StatusCode::AUTOMATION_TASK_MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
     );
     let validation_output = test_context.validate_transaction(automation_txn);
-    assert_eq!(validation_output.status(), Some(StatusCode::AUTOMATION_TASK_MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS));
+    assert_eq!(
+        validation_output.status(),
+        Some(StatusCode::AUTOMATION_TASK_MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS)
+    );
 
     let automation_txn = test_context.create_automation_txn(
         0,
@@ -380,7 +473,10 @@ fn check_invalid_gas_params_of_automation_task() {
         StatusCode::AUTOMATION_TASK_MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
     );
     let validation_output = test_context.validate_transaction(automation_txn);
-    assert_eq!(validation_output.status(), Some(StatusCode::AUTOMATION_TASK_MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND));
+    assert_eq!(
+        validation_output.status(),
+        Some(StatusCode::AUTOMATION_TASK_MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND)
+    );
 
     let automation_txn = test_context.create_automation_txn(
         0,
@@ -398,7 +494,10 @@ fn check_invalid_gas_params_of_automation_task() {
         StatusCode::AUTOMATION_TASK_GAS_PRICE_CAP_ABOVE_MAX_BOUND,
     );
     let validation_output = test_context.validate_transaction(automation_txn.clone());
-    assert_eq!(validation_output.status(), Some(StatusCode::AUTOMATION_TASK_GAS_PRICE_CAP_ABOVE_MAX_BOUND));
+    assert_eq!(
+        validation_output.status(),
+        Some(StatusCode::AUTOMATION_TASK_GAS_PRICE_CAP_ABOVE_MAX_BOUND)
+    );
 
     // Check the gas check of inner payload is skipped if feature flag is not enabled
     test_context.set_feature_flag(FeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK, false);
@@ -420,9 +519,11 @@ fn check_task_retrieval_performance() {
     for i in 0..task_count {
         // Prepare inner-entry-function to be automated.
         let dest_account = test_context.new_account_data(0, 0);
-        let inner_entry_function =
-            aptos_framework_sdk_builder::supra_coin_mint(dest_account.address().clone(), (i + 1) * 10)
-                .into_entry_function();
+        let inner_entry_function = aptos_framework_sdk_builder::supra_coin_mint(
+            dest_account.address().clone(),
+            (i + 1) * 10,
+        )
+        .into_entry_function();
 
         let automation_fee_cap = 1000;
         let aux_data = Vec::new();
@@ -457,9 +558,201 @@ fn check_task_retrieval_performance() {
     let mut i = 0;
     let step: u64 = 25;
     while i < task_count {
-        AutomationRegistrationTestContext::get_task_details_bulk((i .. i + step).collect(), &vm_viewer);
-        i = i + step ;
+        AutomationRegistrationTestContext::get_task_details_bulk(
+            (i..i + step).collect(),
+            &vm_viewer,
+        );
+        i = i + step;
     }
     println!("Bulk load time: {:?}", bulk_load.elapsed());
+}
 
+#[test]
+fn check_automation_registry_actions_on_cycle_transition() {
+    // Feature flag is not enabled yet.
+    let mut test_context = AutomationRegistrationTestContext::new();
+    test_context.set_supra_native_automation(true);
+    // Prepare inner-entry-function to be automated.
+    let dest_account = test_context.new_account_data(0, 0);
+    let inner_entry_function =
+        aptos_framework_sdk_builder::supra_coin_mint(dest_account.address().clone(), 100)
+            .into_entry_function();
+
+    let automation_fee_cap = 100_000;
+    let aux_data = Vec::new();
+    let expiration_time = test_context.chain_time_now() + 4000;
+    let automation_txn = test_context.create_automation_txn(
+        0,
+        inner_entry_function.clone(),
+        expiration_time,
+        100,
+        100,
+        automation_fee_cap,
+        aux_data.clone(),
+    );
+    // Expires in the first cycle
+    let task_2_expiry_time = test_context.chain_time_now() + 1500;
+    let automation_txn_2 = test_context.create_automation_txn(
+        1,
+        inner_entry_function.clone(),
+        task_2_expiry_time,
+        100,
+        100,
+        automation_fee_cap,
+        aux_data,
+    );
+
+    let sender_address = test_context.sender_account_address();
+
+    test_context.execute_and_apply(automation_txn);
+    test_context.execute_and_apply(automation_txn_2);
+
+    test_context.advance_chain_time_in_secs(600);
+    // Any task processing request in started state will fail
+    let registry_action = test_context.create_automation_registry_transaction(1, 1, vec![0]);
+    let result = test_context
+        .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let status = result.status().status().expect("Expected execution status");
+    assert!(matches!(
+        status,
+        ExecutionStatus::MoveAbort {
+            location: _,
+            code: _,
+            info: _
+        }
+    ));
+
+    test_context.advance_chain_time_in_secs(600);
+
+    // Execute registry action to have tasks activated
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
+    let registry_action =
+        test_context.create_automation_registry_transaction(cycle_info.index + 1, 2, vec![0, 1]);
+    test_context
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::STARTED);
+    assert!(test_context.has_sender_active_task_with_id(sender_address, 0));
+    assert!(test_context.has_sender_active_task_with_id(sender_address, 1));
+
+    // Move to next cycle
+    test_context.advance_chain_time_in_secs(1200);
+
+    // Execute registry actions to have tasks activated
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
+    let registry_action =
+        test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![0]);
+    test_context
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
+    let cycle_details = AutomationCycleDetails::fetch_config(test_context.data_store()).expect("Expected a cycle details");
+    let transition_state = cycle_details.transition_state.as_ref().expect("Transition state");
+    assert!(transition_state.actual_processed_tasks.contains(&0));
+
+    let registry_action =
+        test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![1]);
+    test_context
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::STARTED);
+
+    // the second task is removed from registry , whereas the first task is still available
+    assert!(test_context.has_sender_active_task_with_id(sender_address, 0));
+    assert!(!test_context.has_sender_active_task_with_id(sender_address, 1));
+    let task_ids = test_context.get_task_ids();
+    assert!(task_ids.contains(&0));
+    assert!(!task_ids.contains(&1));
+}
+
+#[test]
+fn check_automation_registry_actions_on_cycle_suspension() {
+    // Feature flag is not enabled yet.
+    let mut test_context = AutomationRegistrationTestContext::new();
+    test_context.set_supra_native_automation(true);
+    // Prepare inner-entry-function to be automated.
+    let dest_account = test_context.new_account_data(0, 0);
+    let inner_entry_function =
+        aptos_framework_sdk_builder::supra_coin_mint(dest_account.address().clone(), 100)
+            .into_entry_function();
+
+    let automation_fee_cap = 100_000;
+    let aux_data = Vec::new();
+    let expiration_time = test_context.chain_time_now() + 4000;
+    let automation_txn = test_context.create_automation_txn(
+        0,
+        inner_entry_function.clone(),
+        expiration_time,
+        100,
+        100,
+        automation_fee_cap,
+        aux_data.clone(),
+    );
+
+    let sender_address = test_context.sender_account_address();
+
+    test_context.execute_and_apply(automation_txn);
+    test_context.advance_chain_time_in_secs(1200);
+
+    // Execute registry action to have tasks activated
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
+    let registry_action =
+        test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![0]);
+    test_context
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::STARTED);
+    assert_eq!(cycle_info.start_time, 1200);
+    assert!(test_context.has_sender_active_task_with_id(sender_address, 0));
+
+    // Advance the half of the cycle and disable feature
+    test_context.advance_chain_time_in_secs(600);
+    test_context.set_supra_native_automation(false);
+
+    // Execute registry action to have tasks activated
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::SUSPENDED);
+    let registry_action =
+        test_context.create_automation_registry_transaction(cycle_info.index, 2, vec![0]);
+    test_context
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let cycle_info = test_context.get_cycle_info();
+    assert_eq!(cycle_info.state, AutomationCycleState::READY);
+
+    assert!(test_context.get_task_ids().is_empty());
+
+    // Any task processing request in READY state will fail
+    let registry_action =
+        test_context.create_automation_registry_transaction(cycle_info.index, 2, vec![0]);
+    let result = test_context
+        .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    let status = result.status().status().expect("Expected execution status");
+
+    assert!(matches!(
+        status,
+        ExecutionStatus::MoveAbort {
+            location: _,
+            code: _,
+            info: _
+        }
+    ));
+}
+
+#[test]
+fn check_automation_registry_actions_when_automation_cycle_disabled() {
+    // Feature flag is not enabled yet.
+    let mut test_context = AutomationRegistrationTestContext::new();
+    test_context.set_supra_native_automation(true);
+    // Disable feature and check that no automation registry action is processed.
+    test_context.toggle_feature_with_registry_reconfig(FeatureFlag::SUPRA_AUTOMATION_CYCLE, false);
+    let registry_action = test_context.create_automation_registry_transaction(1, 1, vec![0]);
+    let result = test_context
+        .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+    assert!(matches!(
+        result.status().status(),
+        Err(StatusCode::FEATURE_UNDER_GATING)
+    ));
 }

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -3,29 +3,35 @@
 
 use crate::tests::vm_viewer::to_view_function;
 use aptos_cached_packages::aptos_framework_sdk_builder;
-use aptos_language_e2e_tests::data_store::FakeDataStore;
 use aptos_language_e2e_tests::{
     account::{Account, AccountData},
+    data_store::FakeDataStore,
     executor::FakeExecutor,
 };
-use aptos_types::on_chain_config::{AutomationCycleDetails, AutomationCycleInfo, AutomationCycleState, OnChainConfig};
-use aptos_types::transaction::automation::{AutomationRegistryAction, AutomationRegistryRecord};
-use aptos_types::transaction::Transaction;
 use aptos_types::{
-    on_chain_config::FeatureFlag,
+    on_chain_config::{
+        AutomationCycleDetails, AutomationCycleInfo, AutomationCycleState, FeatureFlag,
+        OnChainConfig,
+    },
     transaction::{
-        automation::{AutomationTaskMetaData, RegistrationParams},
-        EntryFunction, ExecutionStatus, SignedTransaction, TransactionOutput, TransactionPayload,
-        TransactionStatus,
+        automation::{
+            AutomationRegistryAction, AutomationRegistryRecord, AutomationTaskMetaData,
+            RegistrationParams,
+        },
+        EntryFunction, ExecutionStatus, SignedTransaction, Transaction, TransactionOutput,
+        TransactionPayload, TransactionStatus,
     },
 };
 use aptos_vm::aptos_vm_viewer::AptosVMViewer;
 use move_core_types::{
-    account_address::AccountAddress, value::serialize_values, value::MoveValue,
+    account_address::AccountAddress,
+    value::{serialize_values, MoveValue},
     vm_status::StatusCode,
 };
-use std::ops::{Deref, DerefMut};
-use std::time::Instant;
+use std::{
+    ops::{Deref, DerefMut},
+    time::Instant,
+};
 
 const TIMESTAMP_NOW_SECONDS: &str = "0x1::timestamp::now_seconds";
 const ACCOUNT_BALANCE: &str = "0x1::coin::balance";
@@ -82,16 +88,12 @@ impl AutomationRegistrationTestContext {
         } else {
             (vec![], flag_value)
         };
-        self.executor.exec(
-            "features",
-            "change_feature_flags_internal",
-            vec![],
-            vec![
+        self.executor
+            .exec("features", "change_feature_flags_internal", vec![], vec![
                 MoveValue::Signer(acc).simple_serialize().unwrap(),
                 bcs::to_bytes(&enabled).unwrap(),
                 bcs::to_bytes(&disabled).unwrap(),
-            ],
-        );
+            ]);
     }
 
     pub(crate) fn toggle_feature_with_registry_reconfig(
@@ -111,11 +113,13 @@ impl AutomationRegistrationTestContext {
 
     pub(crate) fn create_automation_registry_transaction(
         &self,
+        record_index: u64,
         cycle_id: u64,
         block_height: u64,
         task_indexes: Vec<u64>,
     ) -> AutomationRegistryRecord {
         AutomationRegistryRecord::new(
+            record_index,
             cycle_id,
             block_height,
             AutomationRegistryAction::process(task_indexes),
@@ -210,11 +214,10 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn account_sequence_number(&mut self, account_address: AccountAddress) -> u64 {
-        let view_output = self.execute_view_function(
-            str::parse(ACCOUNT_SEQ_NUM).unwrap(),
-            vec![],
-            vec![account_address.to_vec()],
-        );
+        let view_output =
+            self.execute_view_function(str::parse(ACCOUNT_SEQ_NUM).unwrap(), vec![], vec![
+                account_address.to_vec(),
+            ]);
         let result = view_output.values.expect("Valid result");
         assert_eq!(result.len(), 1);
         bcs::from_bytes::<u64>(&result[0]).unwrap()
@@ -232,13 +235,12 @@ impl AutomationRegistrationTestContext {
     }
 
     pub(crate) fn get_task_details(&mut self, index: u64) -> AutomationTaskMetaData {
-        let view_output = self.execute_view_function(
-            str::parse(AUTOMATION_TASK_DETAILS).unwrap(),
-            vec![],
-            vec![MoveValue::U64(index)
-                .simple_serialize()
-                .expect("Successful serialization")],
-        );
+        let view_output =
+            self.execute_view_function(str::parse(AUTOMATION_TASK_DETAILS).unwrap(), vec![], vec![
+                MoveValue::U64(index)
+                    .simple_serialize()
+                    .expect("Successful serialization"),
+            ]);
         let result = view_output.values.expect("Valid result");
         assert!(!result.is_empty());
         bcs::from_bytes::<AutomationTaskMetaData>(&result[0])
@@ -250,13 +252,11 @@ impl AutomationRegistrationTestContext {
         vm_viewer: &AptosVMViewer<FakeDataStore>,
     ) -> AutomationTaskMetaData {
         let view_output = vm_viewer.execute_view_function(
-            to_view_function(
-                str::parse(AUTOMATION_TASK_DETAILS).unwrap(),
-                vec![],
-                vec![MoveValue::U64(index)
+            to_view_function(str::parse(AUTOMATION_TASK_DETAILS).unwrap(), vec![], vec![
+                MoveValue::U64(index)
                     .simple_serialize()
-                    .expect("Successful serialization")],
-            ),
+                    .expect("Successful serialization"),
+            ]),
             50_000,
         );
         let result = view_output.values.expect("Valid result");
@@ -609,18 +609,15 @@ fn check_automation_registry_actions_on_cycle_transition() {
 
     test_context.advance_chain_time_in_secs(600);
     // Any task processing request in started state will fail
-    let registry_action = test_context.create_automation_registry_transaction(1, 1, vec![0]);
+    let registry_action = test_context.create_automation_registry_transaction(0, 1, 1, vec![0]);
     let result = test_context
         .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let status = result.status().status().expect("Expected execution status");
-    assert!(matches!(
-        status,
-        ExecutionStatus::MoveAbort {
-            location: _,
-            code: _,
-            info: _
-        }
-    ));
+    assert!(matches!(status, ExecutionStatus::MoveAbort {
+        location: _,
+        code: _,
+        info: _
+    }));
 
     test_context.advance_chain_time_in_secs(600);
 
@@ -628,7 +625,7 @@ fn check_automation_registry_actions_on_cycle_transition() {
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
     let registry_action =
-        test_context.create_automation_registry_transaction(cycle_info.index + 1, 2, vec![0, 1]);
+        test_context.create_automation_registry_transaction(0, cycle_info.index + 1, 2, vec![0, 1]);
     test_context
         .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let cycle_info = test_context.get_cycle_info();
@@ -643,17 +640,21 @@ fn check_automation_registry_actions_on_cycle_transition() {
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
     let registry_action =
-        test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![0]);
+        test_context.create_automation_registry_transaction(0, cycle_info.index + 1, 1, vec![0]);
     test_context
         .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
-    let cycle_details = AutomationCycleDetails::fetch_config(test_context.data_store()).expect("Expected a cycle details");
-    let transition_state = cycle_details.transition_state.as_ref().expect("Transition state");
+    let cycle_details = AutomationCycleDetails::fetch_config(test_context.data_store())
+        .expect("Expected a cycle details");
+    let transition_state = cycle_details
+        .transition_state
+        .as_ref()
+        .expect("Transition state");
     assert!(transition_state.actual_processed_tasks.contains(&0));
 
     let registry_action =
-        test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![1]);
+        test_context.create_automation_registry_transaction(1, cycle_info.index + 1, 1, vec![1]);
     test_context
         .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let cycle_info = test_context.get_cycle_info();
@@ -700,7 +701,7 @@ fn check_automation_registry_actions_on_cycle_suspension() {
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
     let registry_action =
-        test_context.create_automation_registry_transaction(cycle_info.index + 1, 1, vec![0]);
+        test_context.create_automation_registry_transaction(0, cycle_info.index + 1, 1, vec![0]);
     test_context
         .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let cycle_info = test_context.get_cycle_info();
@@ -716,7 +717,7 @@ fn check_automation_registry_actions_on_cycle_suspension() {
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::SUSPENDED);
     let registry_action =
-        test_context.create_automation_registry_transaction(cycle_info.index, 2, vec![0]);
+        test_context.create_automation_registry_transaction(0, cycle_info.index, 2, vec![0]);
     test_context
         .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let cycle_info = test_context.get_cycle_info();
@@ -726,19 +727,16 @@ fn check_automation_registry_actions_on_cycle_suspension() {
 
     // Any task processing request in READY state will fail
     let registry_action =
-        test_context.create_automation_registry_transaction(cycle_info.index, 2, vec![0]);
+        test_context.create_automation_registry_transaction(0, cycle_info.index, 2, vec![0]);
     let result = test_context
         .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     let status = result.status().status().expect("Expected execution status");
 
-    assert!(matches!(
-        status,
-        ExecutionStatus::MoveAbort {
-            location: _,
-            code: _,
-            info: _
-        }
-    ));
+    assert!(matches!(status, ExecutionStatus::MoveAbort {
+        location: _,
+        code: _,
+        info: _
+    }));
 }
 
 #[test]
@@ -748,7 +746,7 @@ fn check_automation_registry_actions_when_automation_cycle_disabled() {
     test_context.set_supra_native_automation(true);
     // Disable feature and check that no automation registry action is processed.
     test_context.toggle_feature_with_registry_reconfig(FeatureFlag::SUPRA_AUTOMATION_CYCLE, false);
-    let registry_action = test_context.create_automation_registry_transaction(1, 1, vec![0]);
+    let registry_action = test_context.create_automation_registry_transaction(0, 1, 1, vec![0]);
     let result = test_context
         .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action));
     assert!(matches!(

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -572,7 +572,7 @@ Provides information of the current cycle state.
 <code>start_time: u64</code>
 </dt>
 <dd>
- Current cycle start time which is updated with the current chain time when a cycle is increamented.
+ Current cycle start time which is updated with the current chain time when a cycle is incremented.
 </dd>
 <dt>
 <code>duration_secs: u64</code>
@@ -627,8 +627,7 @@ Event emitted for cycle state transition.
 Cycle state.
 
 
-<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> <b>has</b> <b>copy</b>, drop, key
+<pre><code><b>struct</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> <b>has</b> <b>copy</b>, drop, key
 </code></pre>
 
 
@@ -654,7 +653,7 @@ Cycle state.
 <code>start_time: u64</code>
 </dt>
 <dd>
- Current cycle start time which is updated with the current chain time when a cycle is increamented.
+ Current cycle start time which is updated with the current chain time when a cycle is incremented.
 </dd>
 <dt>
 <code>duration_secs: u64</code>
@@ -2075,6 +2074,16 @@ Invalid gas price: it cannot be zero
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_GAS_PRICE">EINVALID_GAS_PRICE</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EINVALID_INPUT_CYCLE_INDEX"></a>
+
+The tasks are requested to be processed from invalid cycle.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_INPUT_CYCLE_INDEX">EINVALID_INPUT_CYCLE_INDEX</a>: u64 = 34;
 </code></pre>
 
 
@@ -3769,7 +3778,7 @@ then lifecycle is restarted.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a> {
-    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>()) {
+    <b>if</b> (!<a href="automation_registry.md#0x1_automation_registry_is_initialized">is_initialized</a>() || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_automation_cycle_enabled">features::supra_automation_cycle_enabled</a>()) {
         <b>return</b>
     };
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
@@ -3960,7 +3969,7 @@ Registers a new automation task entry.
 Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emitted by native layer ahead of cycle transition
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_process_tasks">process_tasks</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_process_tasks">process_tasks</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, cycle_index: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -3969,17 +3978,20 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_process_tasks">process_tasks</a>(vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_process_tasks">process_tasks</a>(
+    vm: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    cycle_index: u64,
+    task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
 ) <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     // Operational constraint: can only be invoked by the VM
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(&vm);
     <b>let</b> cycle_info = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>if</b> (cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>) {
-        <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(task_indexes);
+        <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(cycle_index, task_indexes);
         <b>return</b>
     };
     <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
-    <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(task_indexes);
+    <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(cycle_index, task_indexes);
 }
 </code></pre>
 
@@ -3992,7 +4004,9 @@ Called by MoveVm on <code>AutomationBookkeepingAction::Process</code> action emi
 ## Function `on_cycle_transition`
 
 Traverses the list of the tasks and based on the task state and expiry information either charges or drops
-the task after refunding eligable fees
+the task after refunding eligable fees.
+
+Input cycle index corresponds to the new cycle to which the transition is being done.
 
 Tasks are cheked not to be processed more than once.
 This function should be called only if registry is in CYCLE_FINISHED state, meaning a normal cycle transition is
@@ -4005,7 +4019,7 @@ In case if transition end is detected a start of the new cycle is given
 (if during trasition period suspention is not requested) and corresponding event is emitted.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(cycle_index: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4014,7 +4028,7 @@ In case if transition end is detected a start of the new cycle is given
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_transition">on_cycle_transition</a>(cycle_index: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
         <b>return</b>
@@ -4023,6 +4037,7 @@ In case if transition end is detected a start of the new cycle is given
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_FINISHED">CYCLE_FINISHED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>assert</b>!(cycle_info.index + 1 == cycle_index, <a href="automation_registry.md#0x1_automation_registry_EINVALID_INPUT_CYCLE_INDEX">EINVALID_INPUT_CYCLE_INDEX</a>);
 
     <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
 
@@ -4077,13 +4092,15 @@ In case if transition end is detected a start of the new cycle is given
 Traverses the list of the tasks and refunds automation(if not PENDING) and depoist fees for all tasks
 and removes from registry.
 
+Input cycle index corresponds to the cycle being suspended.
+
 This function is called only if automation feature is disabled, i.e. CYCLE_SUSPENDED state.
 
 After processing input set of tasks the end of suspention process is checked(i.e. all expected tasks has been processed).
 In case if end is identified the registry state is update to CYCLE_READY and corresponding event is emitted.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(cycle_index: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -4092,7 +4109,7 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_on_cycle_suspend">on_cycle_suspend</a>(cycle_index: u64, task_indexes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; )
 <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">AutomationRefundBookkeeping</a>, <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">AutomationRegistry</a>, <a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a> {
 
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&task_indexes)) {
@@ -4102,6 +4119,7 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
     <b>let</b> cycle_info = <b>borrow_global_mut</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_SUSPENDED">CYCLE_SUSPENDED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
     <b>assert</b>!(std::option::is_some(&cycle_info.transition_state), <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
+    <b>assert</b>!(cycle_info.index == cycle_index, <a href="automation_registry.md#0x1_automation_registry_EINVALID_INPUT_CYCLE_INDEX">EINVALID_INPUT_CYCLE_INDEX</a>);
     <b>let</b> transition_state = std::option::borrow_mut(&<b>mut</b> cycle_info.transition_state);
 
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -87,7 +87,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `initialize`](#0x1_automation_registry_initialize)
 -  [Function `monitor_cycle_end`](#0x1_automation_registry_monitor_cycle_end)
 -  [Function `on_new_epoch`](#0x1_automation_registry_on_new_epoch)
--  [Function `update_epoch_interval_in_registry`](#0x1_automation_registry_update_epoch_interval_in_registry)
 -  [Function `register`](#0x1_automation_registry_register)
 -  [Function `process_tasks`](#0x1_automation_registry_process_tasks)
 -  [Function `on_cycle_transition`](#0x1_automation_registry_on_cycle_transition)
@@ -3815,32 +3814,6 @@ then lifecycle is restarted.
         // Otherwise wait of the cycle transition <b>to</b> end and then feature flag value will be taken into <a href="account.md#0x1_account">account</a>.
     }
     // If in already SUSPENED state or in READY state then do nothing.
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_update_epoch_interval_in_registry"></a>
-
-## Function `update_epoch_interval_in_registry`
-
-Update epoch interval in registry while actually update happens in block module
-Deprecated since SUPRA_AUTOMATION_CYCLE feature release in favor of monitor_cycle_end
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_update_epoch_interval_in_registry">update_epoch_interval_in_registry</a>(_epoch_interval_microsecs: u64) {
-    <b>assert</b>!(<b>false</b>, <a href="automation_registry.md#0x1_automation_registry_EDEPRECATED_SINCE_V2">EDEPRECATED_SINCE_V2</a>);
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1238,12 +1238,6 @@ module supra_framework::automation_registry {
         // If in already SUSPENED state or in READY state then do nothing.
     }
 
-    /// Update epoch interval in registry while actually update happens in block module
-    /// Deprecated since SUPRA_AUTOMATION_CYCLE feature release in favor of monitor_cycle_end
-    public(friend) fun update_epoch_interval_in_registry(_epoch_interval_microsecs: u64) {
-        assert!(false, EDEPRECATED_SINCE_V2);
-    }
-
     // Private Native VM referenced api
 
     /// Registers a new automation task entry.
@@ -6092,7 +6086,7 @@ module supra_framework::automation_registry {
         };
 
         // Process tasks to transition to ready state;
-        process_tasks(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), 1, vector[task1]);
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
             let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
@@ -6157,7 +6151,7 @@ module supra_framework::automation_registry {
         };
 
         // Process tasks to transition to ready state;
-        process_tasks(create_signer(@vm_reserved), vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved), 1, vector[task1, task2]);
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
             let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -97,6 +97,8 @@ module supra_framework::automation_registry {
     const ECYCLE_TRANSITION_IN_PROGRESS: u64 = 32;
     /// Attempt to run operation in invalid registry state.
     const EINVALID_REGISTRY_STATE: u64 = 33;
+    /// The tasks are requested to be processed from invalid cycle.
+    const EINVALID_INPUT_CYCLE_INDEX: u64 = 34;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -285,7 +287,7 @@ module supra_framework::automation_registry {
         index: u64,
         /// State of the current cycle.
         state: u8,
-        /// Current cycle start time which is updated with the current chain time when a cycle is increamented.
+        /// Current cycle start time which is updated with the current chain time when a cycle is incremented.
         start_time: u64,
         /// Automation cycle duration in seconds.
         duration_secs: u64,
@@ -300,14 +302,15 @@ module supra_framework::automation_registry {
         old_state: u8,
     }
 
-    #[resource_group_member(group = supra_framework::object::ObjectGroup)]
+    // Unless we provide view API to get the details, it should not be part of any resouce group to be
+    // able to fetch via OnChainConfig API
     /// Cycle state.
     struct AutomationCycleDetails has key, copy, drop {
         /// Cycle index corresponding to the current state. Incremented when a transition to the new cycle is finalized.
         index: u64,
         /// State of the current cycle.
         state: u8,
-        /// Current cycle start time which is updated with the current chain time when a cycle is increamented.
+        /// Current cycle start time which is updated with the current chain time when a cycle is incremented.
         start_time: u64,
         /// Automation cycle duration in seconds for the current cycle.
         duration_secs: u64,
@@ -1196,7 +1199,7 @@ module supra_framework::automation_registry {
     /// If native automation feature is enabled and automation lifecycle has been in CYCLE_READY state,
     /// then lifecycle is restarted.
     public(friend) fun on_new_epoch() acquires AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRegistry {
-        if (!is_initialized()) {
+        if (!is_initialized() || !features::supra_automation_cycle_enabled()) {
             return
         };
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
@@ -1339,23 +1342,28 @@ module supra_framework::automation_registry {
 
 
     /// Called by MoveVm on `AutomationBookkeepingAction::Process` action emitted by native layer ahead of cycle transition
-    fun process_tasks(vm: signer, task_indexes: vector<u64>
+    fun process_tasks(
+        vm: signer,
+        cycle_index: u64,
+        task_indexes: vector<u64>
     ) acquires AutomationCycleDetails, AutomationRegistry, AutomationRefundBookkeeping, ActiveAutomationRegistryConfig {
         // Operational constraint: can only be invoked by the VM
         system_addresses::assert_vm(&vm);
         let cycle_info = borrow_global<AutomationCycleDetails>(@supra_framework);
         if (cycle_info.state == CYCLE_FINISHED) {
-            on_cycle_transition(task_indexes);
+            on_cycle_transition(cycle_index, task_indexes);
             return
         };
         assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
-        on_cycle_suspend(task_indexes);
+        on_cycle_suspend(cycle_index, task_indexes);
     }
 
     // Private helper functions
 
     /// Traverses the list of the tasks and based on the task state and expiry information either charges or drops
-    /// the task after refunding eligable fees
+    /// the task after refunding eligable fees.
+    ///
+    /// Input cycle index corresponds to the new cycle to which the transition is being done.
     ///
     /// Tasks are cheked not to be processed more than once.
     /// This function should be called only if registry is in CYCLE_FINISHED state, meaning a normal cycle transition is
@@ -1366,7 +1374,7 @@ module supra_framework::automation_registry {
     ///
     /// In case if transition end is detected a start of the new cycle is given
     /// (if during trasition period suspention is not requested) and corresponding event is emitted.
-    fun on_cycle_transition(task_indexes: vector<u64>)
+    fun on_cycle_transition(cycle_index: u64, task_indexes: vector<u64>)
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
         if (vector::is_empty(&task_indexes)) {
             return
@@ -1375,6 +1383,7 @@ module supra_framework::automation_registry {
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         assert!(cycle_info.state == CYCLE_FINISHED, EINVALID_REGISTRY_STATE);
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+        assert!(cycle_info.index + 1 == cycle_index, EINVALID_INPUT_CYCLE_INDEX);
 
         let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
 
@@ -1420,11 +1429,13 @@ module supra_framework::automation_registry {
     /// Traverses the list of the tasks and refunds automation(if not PENDING) and depoist fees for all tasks
     /// and removes from registry.
     ///
+    /// Input cycle index corresponds to the cycle being suspended.
+    ///
     /// This function is called only if automation feature is disabled, i.e. CYCLE_SUSPENDED state.
     ///
     /// After processing input set of tasks the end of suspention process is checked(i.e. all expected tasks has been processed).
     /// In case if end is identified the registry state is update to CYCLE_READY and corresponding event is emitted.
-    fun on_cycle_suspend(task_indexes: vector<u64> )
+    fun on_cycle_suspend(cycle_index: u64, task_indexes: vector<u64> )
     acquires AutomationCycleDetails, AutomationRefundBookkeeping, AutomationRegistry, ActiveAutomationRegistryConfig {
 
         if (vector::is_empty(&task_indexes)) {
@@ -1434,6 +1445,7 @@ module supra_framework::automation_registry {
         let cycle_info = borrow_global_mut<AutomationCycleDetails>(@supra_framework);
         assert!(cycle_info.state == CYCLE_SUSPENDED, EINVALID_REGISTRY_STATE);
         assert!(std::option::is_some(&cycle_info.transition_state), EINVALID_REGISTRY_STATE);
+        assert!(cycle_info.index == cycle_index, EINVALID_INPUT_CYCLE_INDEX);
         let transition_state = std::option::borrow_mut(&mut cycle_info.transition_state);
 
 
@@ -3578,7 +3590,7 @@ module supra_framework::automation_registry {
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        process_tasks(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[0]);
 
         // 10 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 10 * EPOCH_INTERVAL_FOR_TEST_IN_SECS;
@@ -3619,7 +3631,7 @@ module supra_framework::automation_registry {
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        process_tasks(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved),2, vector[0]);
 
         has_task_with_id(0);
 
@@ -3683,7 +3695,7 @@ module supra_framework::automation_registry {
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        process_tasks(create_signer(@vm_reserved), vector[task2, task3]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task2, task3]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -3738,7 +3750,7 @@ module supra_framework::automation_registry {
         // Make sure we are in FINISHED state
         monitor_cycle_end();
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        process_tasks(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task1]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -3781,8 +3793,8 @@ module supra_framework::automation_registry {
         // Make sure we are in FINISHED state
         monitor_cycle_end();
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        process_tasks(create_signer(@vm_reserved), vector[]);
-        process_tasks(create_signer(@vm_reserved), vector[5]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[5]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -3818,7 +3830,7 @@ module supra_framework::automation_registry {
             task_exipry_time,
             ACTIVE);
         // Attempt to drop in STARTED state
-        process_tasks(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task1]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3831,7 +3843,7 @@ module supra_framework::automation_registry {
         // feature is disabled in started state, when registry is empty, moves registry in ready state
         toggle_feature_flag(framework, false);
         on_new_epoch();
-        process_tasks(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[0]);
     }
 
 
@@ -3895,9 +3907,9 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
-        process_tasks(create_signer(@vm_reserved), vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved), 2,vector[task1, task2]);
         // Also check that processed tasks are ignored and charging is done only once
-        process_tasks(create_signer(@vm_reserved), vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved), 2,vector[task1, task2]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -3921,7 +3933,7 @@ module supra_framework::automation_registry {
             check_task_state(ar, task1, exists, ACTIVE);
         };
 
-        process_tasks(create_signer(@vm_reserved), vector[task3]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task3]);
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
             let refund_bookkeeping = borrow_global<AutomationRefundBookkeeping>(fwk_address);
@@ -4022,7 +4034,7 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
-        process_tasks(create_signer(@vm_reserved), vector[task1, task2, task3]);
+        process_tasks(create_signer(@vm_reserved),2,  vector[task1, task2, task3]);
 
         {
             // Check there are no tasks
@@ -4115,7 +4127,7 @@ module supra_framework::automation_registry {
 
         // set enough cycle fee to be able to refund
         set_locked_fee(framework, 10_000_000_000);
-        process_tasks(create_signer(@vm_reserved),  vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[task1, task2]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -4142,12 +4154,12 @@ module supra_framework::automation_registry {
         };
 
         // Empty input does not cause issues
-        process_tasks(create_signer(@vm_reserved),  vector[]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[]);
 
         // Non existing item does not cause issues
-        process_tasks(create_signer(@vm_reserved),  vector[10, 12]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[10, 12]);
 
-        process_tasks(create_signer(@vm_reserved),  vector[task1, task2, task3]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[task1, task2, task3]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -4226,7 +4238,7 @@ module supra_framework::automation_registry {
 
         };
 
-        process_tasks(create_signer(@vm_reserved),  vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[task1, task2]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -4294,7 +4306,7 @@ module supra_framework::automation_registry {
 
         };
 
-        process_tasks(create_signer(@vm_reserved),  vector[task1, task2]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[task1, task2]);
 
         let ar = borrow_global<AutomationRegistry>(fwk_address);
         let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
@@ -4523,7 +4535,7 @@ module supra_framework::automation_registry {
         let total_committed_gas_for_new_cycle = t1_t2_max_gas + t3_max_gas;
         let automation_fee_per_sec_for_new_cycle = calculate_automation_fee_multiplier_for_committed_occupancy(total_committed_gas_for_new_cycle);
         // Drop one task to mark transition initiated
-        process_tasks(create_signer(@vm_reserved), vector[t2]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[t2]);
         // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
         let expected_cycle_duration =
         {
@@ -4615,7 +4627,7 @@ module supra_framework::automation_registry {
             assert!(std::option::is_some(&cycle_details.transition_state), 2);
         };
 
-        process_tasks(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), 1, vector[0]);
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
             assert!(cycle_details.state == CYCLE_READY, 3);
@@ -4986,7 +4998,7 @@ module supra_framework::automation_registry {
         let committed_gas_for_new_cycle = 2 * t1_t2_max_gas + t3_max_gas;
 
         // Not only charges will be applied but also state will be updated to STARTED as all expected tasks will be processed.
-        process_tasks(create_signer(@vm_reserved), vector[t1, t2, t3]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[t1, t2, t3]);
 
         let tcmg = (committed_gas_for_new_cycle as u256);
         let user_address = address_of(user);
@@ -5214,7 +5226,7 @@ module supra_framework::automation_registry {
         let committed_gas_for_new_cycle = 4 * max_gas_amount;
 
         // Not only charges will be applied but also state will be updated to STARTED as all expected tasks will be processed.
-        process_tasks(create_signer(@vm_reserved), vector[t1, t2, t3, t4]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[t1, t2, t3, t4]);
 
         assert!(committed_gas_for_new_cycle == get_gas_committed_for_next_epoch(), 1);
         let active_task_ids = get_active_task_ids();
@@ -5366,7 +5378,7 @@ module supra_framework::automation_registry {
         // Start new cycle
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        process_tasks(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[0]);
 
         // 0.002 - automation_epoch_fee_per_second, 7200 epoch duration
         let expected_automation_fee = 2000 * EPOCH_INTERVAL_FOR_TEST_IN_SECS / 100000;
@@ -5643,6 +5655,7 @@ module supra_framework::automation_registry {
     //  - last epoch identifies all tasks are expired
     // #[test(framework = @supra_framework, user = @0x1cafe)]
     fun process_tasks_in_batch_performance(
+        cycle_index:u64,
     ) acquires AutomationRegistry, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping, AutomationCycleDetails {
         let task_indexes = get_task_ids();
         let count = vector::length(&task_indexes);
@@ -5651,7 +5664,7 @@ module supra_framework::automation_registry {
         while (i < count) {
             let vm_signer = create_signer(@vm_reserved);
             let task_partition = vector::range(i, i + batch);
-            process_tasks(vm_signer, task_partition);
+            process_tasks(vm_signer, cycle_index, task_partition);
             i = i + batch;
         };
     }
@@ -5672,17 +5685,17 @@ module supra_framework::automation_registry {
 
         timestamp::update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        process_tasks_in_batch_performance();
+        process_tasks_in_batch_performance(2);
 
         timestamp::update_global_time_for_test_secs(
             EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS
         );
         monitor_cycle_end();
-        process_tasks_in_batch_performance();
+        process_tasks_in_batch_performance(3);
 
         timestamp::update_global_time_for_test_secs(3 * EPOCH_INTERVAL_FOR_TEST_IN_SECS);
         monitor_cycle_end();
-        process_tasks_in_batch_performance();
+        process_tasks_in_batch_performance(4);
     }
 
 
@@ -5722,7 +5735,7 @@ module supra_framework::automation_registry {
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        process_tasks(create_signer(@vm_reserved), vector[task1]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task1]);
 
         toggle_feature_flag(framework, false);
         on_new_epoch();
@@ -5733,7 +5746,7 @@ module supra_framework::automation_registry {
         };
 
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        process_tasks(create_signer(@vm_reserved), vector[task2]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task2]);
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
             assert!(ar.gas_committed_for_next_epoch == 0, 1);
@@ -5844,7 +5857,7 @@ module supra_framework::automation_registry {
 
         // Process the single task which will lead to the state to be updated to STARTED again
         recent_chain_time = timestamp::now_seconds();
-        process_tasks(create_signer(@vm_reserved), vector[0]);
+        process_tasks(create_signer(@vm_reserved), 3, vector[0]);
         check_cycle_state(CYCLE_STARTED, 3, recent_chain_time, EPOCH_INTERVAL_FOR_TEST_IN_SECS);
     }
 
@@ -5955,7 +5968,7 @@ module supra_framework::automation_registry {
 
         // Process tasks and check the registry state after it
         let total_committed_gas_for_new_cycle = t1_t2_max_gas_amount + t3_max_gas_amount; // task 2 was cancelled.
-        process_tasks(create_signer(@vm_reserved), vector[task1, task2, task3]);
+        process_tasks(create_signer(@vm_reserved), 1, vector[task1, task2, task3]);
         check_cycle_state(CYCLE_STARTED, 1, timestamp::now_seconds(), EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
 
         {

--- a/execution/executor-types/src/parsed_transaction_output.rs
+++ b/execution/executor-types/src/parsed_transaction_output.rs
@@ -141,6 +141,7 @@ impl TransactionsWithParsedOutput {
             | Transaction::BlockMetadataExt(_)
             | Transaction::UserTransaction(_)
             | Transaction::AutomatedTransaction(_)
+            | Transaction::AutomationRegistryTransaction(_)
             | Transaction::ValidatorTransaction(_) => false,
             Transaction::GenesisTransaction(_)
             | Transaction::StateCheckpoint(_)

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -336,6 +336,7 @@ pub fn update_counters_for_processed_chunk<T, O>(
             Some(Transaction::BlockEpilogue(_)) => "block_epilogue",
             Some(Transaction::ValidatorTransaction(_)) => "validator_transaction",
             Some(Transaction::AutomatedTransaction(_)) => "automated_transaction",
+            Some(Transaction::AutomationRegistryTransaction(_)) => "automation_registry_transaction",
             None => "unknown",
         };
 

--- a/storage/backup/backup-cli/src/backup_types/transaction/analysis.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/analysis.rs
@@ -120,6 +120,7 @@ impl TransactionAnalysis {
             | BlockMetadataExt(_)
             | StateCheckpoint(_)
             | BlockEpilogue(_)
+            | AutomationRegistryTransaction(_)
             | ValidatorTransaction(_) => bcs::serialized_size(txn).expect("Txn should serialize"),
         }
     }

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -5,6 +5,7 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::value::{serialize_values, MoveValue};
 use serde::{Deserialize, Serialize};
 use crate::on_chain_config::OnChainConfig;
+use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
 
 const ONE_MONTH_IN_SECS: u64 = 2_626_560;
 const DEFAULT_REGISTRY_MAX_GAS_CAP: u64 = 100_000_000;
@@ -135,16 +136,17 @@ impl From<AutomationRegistryConfigV1> for AutomationRegistryConfig {
 }
 
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[repr(u8)]
 pub enum AutomationCycleState {
+    #[default]
     READY = 0,
     STARTED,
     FINISHED,
     SUSPENDED
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AutomationCycleInfo {
     /// Current cycle id. Incremented when a start of a new cycle is given.
     pub index: u64,
@@ -161,9 +163,14 @@ pub struct AutomationCycleEvent {
     /// Updated cycle state information.
     pub cycle_state_info: AutomationCycleInfo,
     /// The state transitioned from
-    pub old_state: u8,
+    pub old_state: AutomationCycleState,
     /// Timestamp of the state transition event registration
     pub event_time: u64,
+}
+
+impl MoveStructType for AutomationCycleEvent {
+    const MODULE_NAME: &'static IdentStr = ident_str!("automation_registry");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("AutomationCycleEvent");
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -201,6 +208,17 @@ pub struct AutomationCycleDetails {
     pub duration_secs: u64,
     /// Intermediate state of cycle transition to next one or suspended state.
     pub transition_state: Option<AutomationCycleTransitionState>,
+}
+
+impl From<AutomationCycleDetails> for AutomationCycleInfo {
+    fn from(details: AutomationCycleDetails) -> Self {
+        Self {
+            index: details.index,
+            state: details.state,
+            start_time: details.start_time,
+            duration_secs: details.duration_secs,
+        }
+    }
 }
 
 impl OnChainConfig for AutomationCycleDetails {

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -164,8 +164,6 @@ pub struct AutomationCycleEvent {
     pub cycle_state_info: AutomationCycleInfo,
     /// The state transitioned from
     pub old_state: AutomationCycleState,
-    /// Timestamp of the state transition event registration
-    pub event_time: u64,
 }
 
 impl MoveStructType for AutomationCycleEvent {

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -4,6 +4,7 @@
 use move_core_types::account_address::AccountAddress;
 use move_core_types::value::{serialize_values, MoveValue};
 use serde::{Deserialize, Serialize};
+use crate::on_chain_config::OnChainConfig;
 
 const ONE_MONTH_IN_SECS: u64 = 2_626_560;
 const DEFAULT_REGISTRY_MAX_GAS_CAP: u64 = 100_000_000;
@@ -132,3 +133,78 @@ impl From<AutomationRegistryConfigV1> for AutomationRegistryConfig {
         Self::V1(config)
     }
 }
+
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum AutomationCycleState {
+    READY = 0,
+    STARTED,
+    FINISHED,
+    SUSPENDED
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationCycleInfo {
+    /// Current cycle id. Incremented when a start of a new cycle is given.
+    pub index: u64,
+    /// State of the current cycle.
+    pub state: AutomationCycleState,
+    /// Current cycle start time which is updated with the current chain time when a cycle is incremented.
+    pub start_time: u64,
+    /// Automation cycle duration in seconds.
+    pub duration_secs: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationCycleEvent {
+    /// Updated cycle state information.
+    pub cycle_state_info: AutomationCycleInfo,
+    /// The state transitioned from
+    pub old_state: u8,
+    /// Timestamp of the state transition event registration
+    pub event_time: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationCycleTransitionState {
+    /// Refund duration of automation fees when automation feature/cycle is suspended.
+    pub refund_duration: u64,
+    /// Duration of the new cycle to charge fees for.
+    pub new_cycle_duration: u64,
+    /// Calculated automation fee per second for a new cycle or for refund period.
+    pub automation_fee_per_sec: u64,
+    /// Gas committed for the new cycle being transitioned.
+    pub gas_committed_for_new_cycle: u64,
+    /// Gas committed for the next cycle.
+    pub gas_committed_for_next_cycle: u64,
+    /// Total fee charged from users for the new cycle, which is not withdrawable.
+    pub locked_fees: u64,
+    /// List of the tasks to be processed during transition.
+    pub expected_tasks_to_be_processed: Vec<u64>,
+    /// So far processed tasks during transition
+    /// In case if transition spans between multiple blocks then
+    /// upon recovery execution component will know the breaking point and can recover from it.
+    pub actual_processed_tasks: Vec<u64>
+}
+
+/// On-chain Automation Cycle Details.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationCycleDetails {
+    /// Cycle index corresponding to the current state. Incremented when a transition to the new cycle is finalized.
+    pub index: u64,
+    /// State of the current cycle.
+    pub state: AutomationCycleState,
+    /// Current cycle start time which is updated with the current chain time when a cycle is incremented.
+    pub start_time: u64,
+    /// Automation cycle duration in seconds for the current cycle.
+    pub duration_secs: u64,
+    /// Intermediate state of cycle transition to next one or suspended state.
+    pub transition_state: Option<AutomationCycleTransitionState>,
+}
+
+impl OnChainConfig for AutomationCycleDetails {
+    const MODULE_IDENTIFIER: &'static str = "automation_registry";
+    const TYPE_IDENTIFIER: &'static str = "AutomationCycleDetails";
+}
+

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -23,6 +23,7 @@ use std::{collections::HashMap, fmt, fmt::Debug, sync::Arc};
 mod approved_execution_hashes;
 mod aptos_features;
 mod aptos_version;
+mod automation_registry;
 mod chain_id;
 mod commit_history;
 mod consensus_config;
@@ -36,7 +37,6 @@ mod timed_features;
 mod timestamp;
 mod transaction_fee;
 mod validator_set;
-mod automation_registry;
 
 pub use self::{
     approved_execution_hashes::ApprovedExecutionHashes,
@@ -44,12 +44,17 @@ pub use self::{
     aptos_version::{
         AptosVersion, APTOS_MAX_KNOWN_VERSION, APTOS_VERSION_2, APTOS_VERSION_3, APTOS_VERSION_4,
     },
+    automation_registry::{
+        AutomationCycleDetails, AutomationCycleEvent, AutomationCycleInfo, AutomationCycleState,
+        AutomationRegistryConfig, AutomationRegistryConfigV1, AutomationCycleTransitionState
+    },
     commit_history::CommitHistoryResource,
     consensus_config::{
         AnchorElectionMode, ConsensusAlgorithmConfig, ConsensusConfigV1, DagConsensusConfigV1,
         LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig, ProposerElectionType,
         ValidatorTxnConfig,
     },
+    evm_config::OnChainEvmConfig,
     execution_config::{
         BlockGasLimitType, ExecutionConfigV1, ExecutionConfigV2, ExecutionConfigV4,
         OnChainExecutionConfig, TransactionDeduperType, TransactionShufflerType,
@@ -65,8 +70,6 @@ pub use self::{
     timestamp::CurrentTimeMicroseconds,
     transaction_fee::TransactionFeeBurnCap,
     validator_set::{ConsensusScheme, ValidatorSet},
-    evm_config::OnChainEvmConfig,
-    automation_registry::{AutomationRegistryConfig, AutomationRegistryConfigV1}
 };
 
 /// To register an on-chain config in Rust:

--- a/types/src/transaction/automation.rs
+++ b/types/src/transaction/automation.rs
@@ -367,7 +367,7 @@ impl AutomationRegistryAction {
         MoveValue::Vector(value_indexes)
     }
 
-    /// Returns a tuple of min and mox task indexes included in the action.
+    /// Returns a tuple of min and max task indexes included in the action.
     pub fn task_range(&self) -> (u64, u64) {
         let AutomationRegistryAction::Process { task_indexes } = self;
         (

--- a/types/src/transaction/automation.rs
+++ b/types/src/transaction/automation.rs
@@ -555,16 +555,16 @@ impl AutomationRegistryRecordBuilder {
 
     pub fn build(self) -> Result<AutomationRegistryRecord, String> {
         let Some(action) = self.action else {
-            return Err("AutomationRegistryRecordBuilder must have an action".to_string());
+            return Err("AutomationRegistryRecord must have an action".to_string());
         };
         let Some(cycle_id) = self.cycle_id else {
-            return Err("AutomationRegistryRecordBuilder must have a cycle id".to_string());
+            return Err("AutomationRegistryRecord must have a cycle id".to_string());
         };
         let Some(block_height) = self.block_height else {
-            return Err("AutomationRegistryRecordBuilder must have a block height".to_string());
+            return Err("AutomationRegistryRecord must have a block height".to_string());
         };
         let Some(record_index) = self.record_index else {
-            return Err("AutomationRegistryRecordBuilder must have a block height".to_string());
+            return Err("AutomationRegistryRecord must have an index ".to_string());
         };
         Ok(AutomationRegistryRecord::new(
             record_index,

--- a/types/src/transaction/automation.rs
+++ b/types/src/transaction/automation.rs
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::transaction::{EntryFunction, Transaction};
+use aptos_crypto::HashValue;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::{IdentStr, Identifier};
 use move_core_types::language_storage::{ModuleId, TypeTag, CORE_CODE_ADDRESS};
 use move_core_types::value::{serialize_values, MoveValue};
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use aptos_crypto::HashValue;
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 
 struct AutomationTransactionEntryRef {
     module_id: ModuleId,
@@ -352,7 +353,9 @@ impl AutomationRegistryAction {
     }
 
     pub fn process_task(task_index: u64) -> Self {
-        AutomationRegistryAction::Process { task_indexes: vec![task_index] }
+        AutomationRegistryAction::Process {
+            task_indexes: vec![task_index],
+        }
     }
 
     pub fn as_move_value(&self) -> MoveValue {
@@ -362,6 +365,15 @@ impl AutomationRegistryAction {
             .map(|v| MoveValue::U64(*v))
             .collect::<Vec<_>>();
         MoveValue::Vector(value_indexes)
+    }
+
+    /// Returns a tuple of min and mox task indexes included in the action.
+    pub fn task_range(&self) -> (u64, u64) {
+        let AutomationRegistryAction::Process { task_indexes } = self;
+        (
+            task_indexes.iter().min().copied().unwrap_or(u64::MAX),
+            task_indexes.iter().max().copied().unwrap_or(u64::MAX),
+        )
     }
 
     /// Module id containing automation registry target function.
@@ -384,6 +396,8 @@ impl AutomationRegistryAction {
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AutomationRegistryRecord {
+    /// Index of the record. Should be unique in set of the records shceduled in scope of the same block.
+    index: u64,
     /// Index of the new cycle to be moved to.
     cycle_id: u64,
     /// Height of the block in scope of which registry action is requested/scheduled.
@@ -392,14 +406,31 @@ pub struct AutomationRegistryRecord {
     action: AutomationRegistryAction,
 }
 
-impl AutomationRegistryRecord {
+impl PartialOrd<Self> for AutomationRegistryRecord {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let this_range = self.action.task_range();
+        let other_range = other.action.task_range();
+        this_range.partial_cmp(&other_range)
+    }
+}
 
+impl Ord for AutomationRegistryRecord {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let this_range = self.action.task_range();
+        let other_range = other.action.task_range();
+        this_range.cmp(&other_range)
+    }
+}
+
+impl AutomationRegistryRecord {
     pub fn new(
+        record_index: u64,
         cycle_id: u64,
         block_height: u64,
         action: AutomationRegistryAction,
     ) -> AutomationRegistryRecord {
         Self {
+            index: record_index,
             cycle_id,
             block_height,
             action,
@@ -417,10 +448,9 @@ impl AutomationRegistryRecord {
 
     pub fn hash(&self) -> HashValue {
         HashValue::keccak_256_of(
-            &bcs::to_bytes(self)
-                .expect("AutomationRegistryRecord serialization should never fail"))
+            &bcs::to_bytes(self).expect("AutomationRegistryRecord serialization should never fail"),
+        )
     }
-
 
     /// Module id containing automation registry target function.
     pub fn module_id(&self) -> &ModuleId {
@@ -436,6 +466,22 @@ impl AutomationRegistryRecord {
     pub fn ty_args(&self) -> Vec<TypeTag> {
         self.action.ty_args()
     }
+
+    pub fn index(&self) -> u64 {
+        self.index
+    }
+
+    pub fn cycle_id(&self) -> u64 {
+        self.cycle_id
+    }
+
+    pub fn block_height(&self) -> u64 {
+        self.block_height
+    }
+
+    pub fn action(&self) -> &AutomationRegistryAction {
+        &self.action
+    }
 }
 
 impl From<AutomationRegistryRecord> for Transaction {
@@ -444,8 +490,9 @@ impl From<AutomationRegistryRecord> for Transaction {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AutomationRegistryRecordBuilder {
+    record_index: Option<u64>,
     action: Option<AutomationRegistryAction>,
     cycle_id: Option<u64>,
     block_height: Option<u64>,
@@ -456,8 +503,21 @@ impl AutomationRegistryRecordBuilder {
         Self {
             action: None,
             cycle_id: Some(cycle_id),
+            record_index: None,
             block_height: None,
         }
+    }
+
+    pub fn task_range(&self) -> (u64, u64) {
+        if self.action.is_none() {
+            return (u64::MAX, u64::MAX);
+        }
+        self.action.as_ref().unwrap().task_range()
+    }
+
+    pub fn with_record_index(mut self, record_index: u64) -> Self {
+        self.record_index = Some(record_index);
+        self
     }
 
     pub fn with_action(mut self, action: AutomationRegistryAction) -> Self {
@@ -484,6 +544,7 @@ impl AutomationRegistryRecordBuilder {
                 .into_iter()
                 .map(AutomationRegistryAction::process_task)
                 .map(|action| Self {
+                    record_index: None,
                     action: Some(action),
                     cycle_id: self.cycle_id,
                     block_height: self.block_height,
@@ -502,7 +563,11 @@ impl AutomationRegistryRecordBuilder {
         let Some(block_height) = self.block_height else {
             return Err("AutomationRegistryRecordBuilder must have a block height".to_string());
         };
+        let Some(record_index) = self.record_index else {
+            return Err("AutomationRegistryRecordBuilder must have a block height".to_string());
+        };
         Ok(AutomationRegistryRecord::new(
+            record_index,
             cycle_id,
             block_height,
             action,

--- a/types/src/transaction/automation.rs
+++ b/types/src/transaction/automation.rs
@@ -1,13 +1,16 @@
 // Copyright (c) 2025 Supra.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transaction::EntryFunction;
+use crate::transaction::{EntryFunction, Transaction};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::{IdentStr, Identifier};
 use move_core_types::language_storage::{ModuleId, TypeTag, CORE_CODE_ADDRESS};
 use move_core_types::value::{serialize_values, MoveValue};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+use aptos_crypto::HashValue;
 
 struct AutomationTransactionEntryRef {
     module_id: ModuleId,
@@ -23,11 +26,10 @@ static AUTOMATION_REGISTRATION_ENTRY: Lazy<AutomationTransactionEntryRef> =
         function: Identifier::new("register").unwrap(),
     });
 
-
 /// Represents set of parameters required to register automation task.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RegistrationParams {
-    V1(RegistrationParamsV1)
+    V1(RegistrationParamsV1),
 }
 impl RegistrationParams {
     pub fn new_v1(
@@ -38,7 +40,7 @@ impl RegistrationParams {
         automation_fee_cap_for_epoch: u64,
         aux_data: Vec<Vec<u8>>,
     ) -> RegistrationParams {
-        RegistrationParams::V1(RegistrationParamsV1::new (
+        RegistrationParams::V1(RegistrationParamsV1::new(
             automated_function,
             expiration_timestamp_secs,
             max_gas_amount,
@@ -121,7 +123,7 @@ pub struct RegistrationParamsV1 {
     /// which will require all components upgrade( not only supra-framework/state but also node)
     /// then it is advised to add a new version of registration parameters and have the new parameter properly
     /// integrated in the automation-task/automated-transaction execution flow.
-    aux_data: Vec<Vec<u8>>
+    aux_data: Vec<Vec<u8>>,
 }
 
 impl RegistrationParamsV1 {
@@ -177,7 +179,11 @@ impl RegistrationParamsV1 {
         sender: AccountAddress,
         parent_hash: Vec<u8>,
     ) -> Vec<Vec<u8>> {
-        let aux_move_args = self.aux_data.iter().map(|item| MoveValue::vector_u8(item.clone())).collect();
+        let aux_move_args = self
+            .aux_data
+            .iter()
+            .map(|item| MoveValue::vector_u8(item.clone()))
+            .collect();
         serialize_values(&[
             MoveValue::Address(sender),
             MoveValue::vector_u8(bcs::to_bytes(&self.automated_function).unwrap()),
@@ -321,5 +327,185 @@ impl AutomationTaskMetaData {
 
     pub fn locked_fee_for_next_epoch(&self) -> u64 {
         self.locked_fee_for_next_epoch
+    }
+}
+
+static AUTOMATION_REGISTRY_PROCESS_TASKS_ENTRY: Lazy<AutomationTransactionEntryRef> =
+    Lazy::new(|| AutomationTransactionEntryRef {
+        module_id: ModuleId::new(
+            CORE_CODE_ADDRESS,
+            Identifier::new("automation_registry").unwrap(),
+        ),
+        function: Identifier::new("process_tasks").unwrap(),
+    });
+
+/// Action to be performed on automation registry.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub enum AutomationRegistryAction {
+    Process { task_indexes: Vec<u64> },
+}
+
+impl AutomationRegistryAction {
+    pub fn process(task_indexes: Vec<u64>) -> Self {
+        AutomationRegistryAction::Process { task_indexes }
+    }
+
+    pub fn process_task(task_index: u64) -> Self {
+        AutomationRegistryAction::Process { task_indexes: vec![task_index] }
+    }
+
+    pub fn as_move_value(&self) -> MoveValue {
+        let AutomationRegistryAction::Process { task_indexes } = self;
+        let value_indexes = task_indexes
+            .iter()
+            .map(|v| MoveValue::U64(*v))
+            .collect::<Vec<_>>();
+        MoveValue::Vector(value_indexes)
+    }
+
+    /// Module id containing automation registry target function.
+    pub fn module_id(&self) -> &ModuleId {
+        &AUTOMATION_REGISTRY_PROCESS_TASKS_ENTRY.module_id
+    }
+
+    /// Action function name accepting enclosed tasks.
+    pub fn function(&self) -> &IdentStr {
+        &AUTOMATION_REGISTRY_PROCESS_TASKS_ENTRY.function
+    }
+
+    /// Type arguments required by action function.
+    pub fn ty_args(&self) -> Vec<TypeTag> {
+        vec![]
+    }
+}
+
+/// Automation Registry transaction payload to be executed on cycle transition.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct AutomationRegistryRecord {
+    /// Index of the new cycle to be moved to.
+    cycle_id: u64,
+    /// Height of the block in scope of which registry action is requested/scheduled.
+    block_height: u64,
+    /// Action to perform in scope of the request.
+    action: AutomationRegistryAction,
+}
+
+impl AutomationRegistryRecord {
+
+    pub fn new(
+        cycle_id: u64,
+        block_height: u64,
+        action: AutomationRegistryAction,
+    ) -> AutomationRegistryRecord {
+        Self {
+            cycle_id,
+            block_height,
+            action,
+        }
+    }
+
+    pub fn serialize_args_with_sender(&self, sender: AccountAddress) -> Vec<Vec<u8>> {
+        let action_as_value = self.action.as_move_value();
+        serialize_values(&[
+            MoveValue::Address(sender),
+            MoveValue::U64(self.cycle_id),
+            action_as_value,
+        ])
+    }
+
+    pub fn hash(&self) -> HashValue {
+        HashValue::keccak_256_of(
+            &bcs::to_bytes(self)
+                .expect("AutomationRegistryRecord serialization should never fail"))
+    }
+
+
+    /// Module id containing automation registry target function.
+    pub fn module_id(&self) -> &ModuleId {
+        self.action.module_id()
+    }
+
+    /// Action  function name accepting enclosed parameters.
+    pub fn function(&self) -> &IdentStr {
+        self.action.function()
+    }
+
+    /// Type arguments required by registration function.
+    pub fn ty_args(&self) -> Vec<TypeTag> {
+        self.action.ty_args()
+    }
+}
+
+impl From<AutomationRegistryRecord> for Transaction {
+    fn from(value: AutomationRegistryRecord) -> Self {
+        Transaction::AutomationRegistryTransaction(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AutomationRegistryRecordBuilder {
+    action: Option<AutomationRegistryAction>,
+    cycle_id: Option<u64>,
+    block_height: Option<u64>,
+}
+
+impl AutomationRegistryRecordBuilder {
+    pub fn new(cycle_id: u64) -> Self {
+        Self {
+            action: None,
+            cycle_id: Some(cycle_id),
+            block_height: None,
+        }
+    }
+
+    pub fn with_action(mut self, action: AutomationRegistryAction) -> Self {
+        self.action = Some(action);
+        self
+    }
+
+    pub fn with_cycle_id(mut self, cycle_id: u64) -> Self {
+        self.cycle_id = Some(cycle_id);
+        self
+    }
+
+    pub fn with_block_height(mut self, block_height: u64) -> Self {
+        self.block_height = Some(block_height);
+        self
+    }
+
+    /// Splits the existing record builder into single task based actions if possible.
+    /// If no action is specified the same instance is returned.
+    pub fn split(mut self) -> Vec<Self> {
+        match self.action.take() {
+            None => vec![self],
+            Some(AutomationRegistryAction::Process { task_indexes }) => task_indexes
+                .into_iter()
+                .map(AutomationRegistryAction::process_task)
+                .map(|action| Self {
+                    action: Some(action),
+                    cycle_id: self.cycle_id,
+                    block_height: self.block_height,
+                })
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    pub fn build(self) -> Result<AutomationRegistryRecord, String> {
+        let Some(action) = self.action else {
+            return Err("AutomationRegistryRecordBuilder must have an action".to_string());
+        };
+        let Some(cycle_id) = self.cycle_id else {
+            return Err("AutomationRegistryRecordBuilder must have a cycle id".to_string());
+        };
+        let Some(block_height) = self.block_height else {
+            return Err("AutomationRegistryRecordBuilder must have a block height".to_string());
+        };
+        Ok(AutomationRegistryRecord::new(
+            cycle_id,
+            block_height,
+            action,
+        ))
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -61,7 +61,7 @@ use crate::serde_helper::vec_bytes;
 #[cfg(any(test, feature = "fuzzing"))]
 use crate::state_store::create_empty_sharded_state_updates;
 use crate::transaction::automated_transaction::AutomatedTransaction;
-use crate::transaction::automation::RegistrationParams;
+use crate::transaction::automation::{AutomationRegistryRecord, RegistrationParams};
 use crate::{
     block_metadata_ext::BlockMetadataExt, contract_event::TransactionEvent, executable::ModulePath,
     fee_statement::FeeStatement, proof::accumulator::InMemoryEventAccumulator,
@@ -2017,6 +2017,9 @@ pub enum Transaction {
     /// Verification is skipped for this type of transaction as it is auto-generated from state
     /// and is considered as `SignatureVerifiedTransaction::Valid` by default
     AutomatedTransaction(AutomatedTransaction),
+
+    /// An automation registry function/action to be executed on cycle state transition.
+    AutomationRegistryTransaction(AutomationRegistryRecord),
 }
 
 impl From<BlockMetadataExt> for Transaction {
@@ -2074,6 +2077,7 @@ impl Transaction {
             Transaction::ValidatorTransaction(vt) => vt.type_name(),
             Transaction::BlockMetadataExt(_) => "block_metadata_ext",
             Transaction::AutomatedTransaction(_) => "automated_transaction",
+            Transaction::AutomationRegistryTransaction(_) => "automation_registry_transaction",
         }
     }
 
@@ -2090,6 +2094,7 @@ impl Transaction {
             | Transaction::BlockMetadata(_)
             | Transaction::BlockMetadataExt(_)
             | Transaction::AutomatedTransaction(_)
+            | Transaction::AutomationRegistryTransaction(_)
             | Transaction::ValidatorTransaction(_) => false,
         }
     }

--- a/types/src/unit_tests/automation.rs
+++ b/types/src/unit_tests/automation.rs
@@ -4,7 +4,10 @@
 use crate::chain_id::ChainId;
 use crate::move_utils::MemberId;
 use crate::transaction::automated_transaction::{AutomatedTransactionBuilder, BuilderResult};
-use crate::transaction::automation::{AutomationTaskMetaData, RegistrationParams};
+use crate::transaction::automation::{
+    AutomationRegistryAction, AutomationRegistryRecordBuilder, AutomationTaskMetaData,
+    RegistrationParams,
+};
 use crate::transaction::{EntryFunction, TransactionPayload};
 use aptos_crypto::HashValue;
 use move_core_types::account_address::AccountAddress;
@@ -208,4 +211,59 @@ fn automated_txn_build() {
         builder_with_no_expiry_time.clone().build(),
         BuilderResult::MissingValue(_)
     ));
+}
+
+#[test]
+fn check_automation_registry_record() {
+    let r_builder = AutomationRegistryRecordBuilder::new(1);
+    assert!(r_builder.clone().build().is_err());
+
+    let r_builder = r_builder.with_record_index(2);
+    assert!(r_builder.clone().build().is_err());
+
+    let r_builder = r_builder.with_block_height(42);
+    assert!(r_builder.clone().build().is_err());
+
+    let action = AutomationRegistryAction::process(vec![12, 36, 45]);
+
+    let r_builder = r_builder.with_action(action);
+    let record = r_builder.clone().build().unwrap();
+    assert_eq!(record.index(), 2);
+    assert_eq!(record.cycle_id(), 1);
+    assert_eq!(record.action().task_range(), (12, 45));
+
+    let split_builders = r_builder.split();
+    assert_eq!(split_builders.len(), 3);
+
+    // Fails as the record index is reset, but cycle_id and block height is reserved
+    split_builders.iter().for_each(|builder| {
+        assert!(builder.clone().build().is_err());
+    });
+    split_builders
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, builder)| {
+            let builder = builder.with_record_index(i as u64);
+            let single_task_record = builder.build().unwrap();
+            assert_eq!(single_task_record.cycle_id(), record.cycle_id());
+            assert_eq!(single_task_record.block_height(), record.block_height());
+            let task_range = single_task_record.action().task_range();
+            assert_eq!(task_range.0, task_range.1);
+        });
+
+    let mut task_indexes = vec![50, 68, 12, 36, 45];
+    let r_builder = AutomationRegistryRecordBuilder::new(2)
+        .with_action(AutomationRegistryAction::process(task_indexes.clone()));
+    assert_eq!(r_builder.task_range(), (12, 68));
+
+    let mut split_builders = r_builder.split();
+    split_builders.sort_by_key(|b| b.task_range());
+    task_indexes.sort();
+    split_builders
+        .into_iter()
+        .enumerate()
+        .for_each(|(idx, builder)| {
+            let task_index = task_indexes[idx];
+            assert_eq!(builder.task_range(), (task_index, task_index));
+        });
 }


### PR DESCRIPTION

- Created a new transaction payload `AutomationRegistryRecord`, and enclosed in a new `Transaction::AutomationRegistryTransaction` variant

- Created counterpart of automation cycle related structions in native layer as well 
    - `AutomationCycleState` 
    - `AutomtaionCycleInfo`
    - `AutomationCycleEvent` 
    - `AutomationCycleDetails`

- Updated `automation_registry::process_tasks` to accept cycle-index for which tasks are requested to be processed, and added check for it

- Updated and added unit tests to check cycle state updates, and bookkeeping transactions execution