### PR TITLE
[AN-Issue-2093] Fail on on out of order task processing during transition

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -7,7 +7,7 @@
 use crate::{
     gas_feature_versions::{RELEASE_V1_14, RELEASE_V1_8, RELEASE_V1_9_SKIPPED},
     gas_schedule::NativeGasParameters,
-    ver::gas_feature_versions::{RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_16_SUPRA_V1_6_0},
+    ver::gas_feature_versions::{RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_16_SUPRA_V1_6_0, RELEASE_V1_16_SUPRA_V1_7_0},
 };
 use aptos_gas_algebra::{
     InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerArg, InternalGasPerByte,
@@ -329,5 +329,8 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [object_exists_at_per_item_loaded: InternalGas, { 7.. => "object.exists_at.per_item_loaded" }, 1470],
         [string_utils_base: InternalGas, { 8.. => "string_utils.format.base" }, 1102],
         [string_utils_per_byte: InternalGasPerByte, { 8.. =>"string_utils.format.per_byte" }, 3],
+
+        // Gas for vector utils. Referenced the value of vector_swap_base from instr.rs
+        [vector_utils_per_swap: InternalGasPerByte, { RELEASE_V1_16_SUPRA_V1_7_0.. =>"vector_utils.format.per_swap" }, 1102],
     ]
 );

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -73,7 +73,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_16_SUPRA_V1_6_0;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_16_SUPRA_V1_7_0;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -88,4 +88,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_16: u64 = 21;
     pub const RELEASE_V1_16_SUPRA_V1_5_1: u64 = 22;
     pub const RELEASE_V1_16_SUPRA_V1_6_0: u64 = 23;
+    pub const RELEASE_V1_16_SUPRA_V1_7_0: u64 = 24;
 }

--- a/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
+++ b/aptos-move/e2e-testsuite/src/tests/automation_registration.rs
@@ -639,10 +639,25 @@ fn check_automation_registry_actions_on_cycle_transition() {
     // Execute registry actions to have tasks activated
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
-    let registry_action =
+    let registry_action_for_task1 =
+        test_context.create_automation_registry_transaction(0, cycle_info.index + 1, 1, vec![1]);
+
+    let registry_action_for_task0 =
         test_context.create_automation_registry_transaction(0, cycle_info.index + 1, 1, vec![0]);
+
+    // Check that out of order execution will fail
+    let result = test_context
+        .execute_tagged_transaction(Transaction::AutomationRegistryTransaction(registry_action_for_task1.clone()));
+    let status = result.status().status().expect("Expected execution status");
+
+    assert!(matches!(status, ExecutionStatus::MoveAbort {
+        location: _,
+        code: _,
+        info: _
+    }));
+
     test_context
-        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action_for_task0));
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::FINISHED);
     let cycle_details = AutomationCycleDetails::fetch_config(test_context.data_store())
@@ -651,12 +666,10 @@ fn check_automation_registry_actions_on_cycle_transition() {
         .transition_state
         .as_ref()
         .expect("Transition state");
-    assert!(transition_state.actual_processed_tasks.contains(&0));
+    assert_eq!(transition_state.next_task_index_position, 1);
 
-    let registry_action =
-        test_context.create_automation_registry_transaction(1, cycle_info.index + 1, 1, vec![1]);
     test_context
-        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action));
+        .execute_and_apply_transaction(Transaction::AutomationRegistryTransaction(registry_action_for_task1));
     let cycle_info = test_context.get_cycle_info();
     assert_eq!(cycle_info.state, AutomationCycleState::STARTED);
 

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -22,6 +22,7 @@ pub mod transaction_context;
 pub mod type_info;
 pub mod util;
 mod automation_registry_callbacks;
+pub mod vector_utils;
 
 use crate::natives::cryptography::multi_ed25519;
 use aggregator_natives::{aggregator, aggregator_factory, aggregator_v2};
@@ -98,6 +99,7 @@ pub fn all_natives(
         dispatchable_fungible_asset::make_all(builder)
     );
     add_natives_from_module!("automation_registry", automation_registry_callbacks::make_all(builder));
+    add_natives_from_module!("vector_utils", vector_utils::make_all(builder));
 
     make_table_from_iter(framework_addr, natives)
 }

--- a/aptos-move/framework/src/natives/vector_utils.rs
+++ b/aptos-move/framework/src/natives/vector_utils.rs
@@ -1,0 +1,80 @@
+// Copyright © Supra
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_native_interface::{
+    safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
+    SafeNativeResult,
+};
+use move_vm_runtime::native_functions::NativeFunction;
+use move_vm_types::{loaded_data::runtime_types::Type, values::Value};
+use smallvec::{smallvec, SmallVec};
+use std::collections::VecDeque;
+
+const MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING: u64 = 0x01_0002;
+
+/***************************************************************************************************
+* native fun sort vector by key in ascending order.
+
+* accepts 2 vectors one is the key of u64 type based on which sorting is done, the other one is the values
+* in the original vector to be sorted.
+*
+**************************************************************************************************/
+fn native_sort_vector_u64_by_key(
+    _context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert_eq!(args.len(), 2);
+
+    let keys: Vec<u64> = safely_pop_arg!(args, Vec<u64>);
+    let values: Vec<u64> = safely_pop_arg!(args, Vec<u64>);
+    if keys.len() != values.len() {
+        return Err(SafeNativeError::Abort {
+            abort_code: MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING,
+        });
+    }
+    let mut pairs = keys.into_iter().zip(values).collect::<Vec<_>>();
+    pairs.sort_by_key(|(k, _v)| *k);
+    let result = pairs.into_iter().map(|(_, v)| v).collect::<Vec<_>>();
+
+    let result = Value::vector_u64(result);
+    Ok(smallvec![result])
+}
+
+/***************************************************************************************************
+* native fun sort vector of u64 in ascending order.
+
+* accepts a vector of u64 values and returns sorted version in ascending order.
+*
+**************************************************************************************************/
+fn native_sort_vector_u64(
+    _context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert_eq!(args.len(), 1);
+    let mut values: Vec<u64> = safely_pop_arg!(args, Vec<u64>);
+    values.sort();
+    let result = Value::vector_u64(values);
+    Ok(smallvec![result])
+}
+/***************************************************************************************************
+ * module
+ *
+ **************************************************************************************************/
+pub fn make_all(
+    builder: &SafeNativeBuilder,
+) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
+    let natives = [
+        (
+            "native_sort_vector_u64_by_key",
+            native_sort_vector_u64_by_key as RawSafeNative,
+        ),
+        (
+            "native_sort_vector_u64",
+            native_sort_vector_u64 as RawSafeNative,
+        ),
+    ];
+
+    builder.make_named_natives(natives)
+}

--- a/aptos-move/framework/src/natives/vector_utils.rs
+++ b/aptos-move/framework/src/natives/vector_utils.rs
@@ -1,16 +1,15 @@
 // Copyright © Supra
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_gas_schedule::gas_params::natives::aptos_framework::VECTOR_UTILS_PER_SWAP;
 use aptos_native_interface::{
-    safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
-    SafeNativeResult,
+    safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeResult,
 };
+use move_core_types::gas_algebra::NumBytes;
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{loaded_data::runtime_types::Type, values::Value};
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
-
-const MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING: u64 = 0x01_0002;
 
 /***************************************************************************************************
 * native fun sort vector by key in ascending order.
@@ -20,7 +19,7 @@ const MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING: u64 = 0x01_0002;
 *
 **************************************************************************************************/
 fn native_sort_vector_u64_by_key(
-    _context: &mut SafeNativeContext,
+    context: &mut SafeNativeContext,
     _ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
@@ -28,11 +27,10 @@ fn native_sort_vector_u64_by_key(
 
     let keys: Vec<u64> = safely_pop_arg!(args, Vec<u64>);
     let values: Vec<u64> = safely_pop_arg!(args, Vec<u64>);
-    if keys.len() != values.len() {
-        return Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING,
-        });
-    }
+
+    let complexity = (((values.len() as f64).log2() + 1.0) as usize) * values.len();
+    context.charge(VECTOR_UTILS_PER_SWAP * NumBytes::new(complexity as u64))?;
+
     let mut pairs = keys.into_iter().zip(values).collect::<Vec<_>>();
     pairs.sort_by_key(|(k, _v)| *k);
     let result = pairs.into_iter().map(|(_, v)| v).collect::<Vec<_>>();
@@ -48,12 +46,14 @@ fn native_sort_vector_u64_by_key(
 *
 **************************************************************************************************/
 fn native_sort_vector_u64(
-    _context: &mut SafeNativeContext,
+    context: &mut SafeNativeContext,
     _ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 1);
     let mut values: Vec<u64> = safely_pop_arg!(args, Vec<u64>);
+    let complexity = (((values.len() as f64).log2() + 1.0) as usize) * values.len();
+    context.charge(VECTOR_UTILS_PER_SWAP * NumBytes::new(complexity as u64))?;
     values.sort();
     let result = Value::vector_u64(values);
     Ok(smallvec![result])

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -122,7 +122,6 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `update_config_from_buffer`](#0x1_automation_registry_update_config_from_buffer)
 -  [Function `transfer_fee_to_account_internal`](#0x1_automation_registry_transfer_fee_to_account_internal)
 -  [Function `check_registration_task_duration`](#0x1_automation_registry_check_registration_task_duration)
--  [Function `sort_vector`](#0x1_automation_registry_sort_vector)
 -  [Function `upscale_from_u8`](#0x1_automation_registry_upscale_from_u8)
 -  [Function `upscale_from_u64`](#0x1_automation_registry_upscale_from_u64)
 -  [Function `upscale_from_u256`](#0x1_automation_registry_upscale_from_u256)
@@ -146,6 +145,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
+<b>use</b> <a href="../../supra-stdlib/doc/vector_utils.md#0x1_vector_utils">0x1::vector_utils</a>;
 </code></pre>
 
 
@@ -4106,7 +4106,7 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
     // Sort task indexes <b>as</b> order is important
-    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_indexes);
+    task_indexes = sort_vector_u64(task_indexes);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
         <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
             <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
@@ -4185,7 +4185,7 @@ Traverses all input task indexes and either drops or tries to charge automation 
     <b>let</b> current_cycle_end_time = current_time + transition_state.new_cycle_duration;
 
     // Sort task indexes <b>to</b> charge automation fees in the tasks chronological order
-    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_ids);
+    task_ids = sort_vector_u64(task_ids);
 
     // Process each active task and calculate fee for the epoch for the tasks
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_ids, |task_index| {
@@ -4605,7 +4605,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
         <b>return</b>
     };
     <b>let</b> expected_tasks_to_be_processed = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> expected_tasks_to_be_processed);
+    expected_tasks_to_be_processed = sort_vector_u64(expected_tasks_to_be_processed);
     <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
         refund_duration: 0,
         new_cycle_duration: cycle_info.duration_secs,
@@ -4794,7 +4794,7 @@ In all cases if there are no tasks in registry the state will be updated directl
         <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
         <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
         <b>let</b> expected_tasks_to_be_processed = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
-        <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> expected_tasks_to_be_processed);
+        expected_tasks_to_be_processed = sort_vector_u64(expected_tasks_to_be_processed);
         <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
             refund_duration: cycle_end_time - current_time,
             new_cycle_duration: cycle_info.duration_secs,
@@ -5658,41 +5658,6 @@ Transfers the specified fee amount from the resource account to the target accou
         expiry_time &gt; (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
         <a href="automation_registry.md#0x1_automation_registry_EEXPIRY_BEFORE_NEXT_CYCLE">EEXPIRY_BEFORE_NEXT_CYCLE</a>
     );
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_sort_vector"></a>
-
-## Function `sort_vector`
-
-Insertion sort implementation for vector
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(input: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
-    <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(input);
-    <b>let</b> i = 1;
-    <b>while</b> (i &lt; len) {
-        <b>let</b> j = i;
-        <b>let</b> to_be_sorted = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, j);
-        <b>while</b> (j &gt; 0 && to_be_sorted &lt; *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(input, j - 1)) {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(input, j, j - 1);
-            j = j - 1;
-        };
-        i = i + 1;
-    };
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -48,8 +48,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Constants](#@Constants_0)
 -  [Function `is_transition_finalized`](#0x1_automation_registry_is_transition_finalized)
 -  [Function `is_transition_in_progress`](#0x1_automation_registry_is_transition_in_progress)
--  [Function `append_processed_task`](#0x1_automation_registry_append_processed_task)
--  [Function `already_processed`](#0x1_automation_registry_already_processed)
+-  [Function `mark_task_processed`](#0x1_automation_registry_mark_task_processed)
 -  [Function `is_initialized`](#0x1_automation_registry_is_initialized)
 -  [Function `is_feature_enabled_and_initialized`](#0x1_automation_registry_is_feature_enabled_and_initialized)
 -  [Function `get_next_task_index`](#0x1_automation_registry_get_next_task_index)
@@ -479,14 +478,16 @@ Holds intermediate state data of the automation cycle transition from END->START
 </dt>
 <dd>
  List of the tasks to be processed during transition.
+ This list is sorted in ascending order.
+ The requirement is that all tasks are processed in the order of their registration. Which should be true
+ especially for cycle fee charges before new cycle start.
 </dd>
 <dt>
-<code>actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;</code>
+<code>next_task_index_position: u64</code>
 </dt>
 <dd>
- So far processed tasks during transition
- In case if transition spans between multiple blocks then
- upon recovery execution component will know the breaking point and can recover from it.
+ Position of the task index in the expected_tasks_to_be_processed to be processed next.
+ It is incremented when an expected task is successfully processed.
 </dd>
 </dl>
 
@@ -2037,6 +2038,16 @@ The gas committed for next epoch value is underflow after remove old max gas
 
 
 
+<a id="0x1_automation_registry_EINCONSISTENT_TRANSITION_STATE"></a>
+
+Attempt to process a task when expected list of the tasks has been alrady processed.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINCONSISTENT_TRANSITION_STATE">EINCONSISTENT_TRANSITION_STATE</a>: u64 = 35;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_EINSUFFICIENT_AUTOMATION_FEE_CAP_FOR_EPOCH"></a>
 
 Automation fee capacity for the epoch should not be less than estimated one.
@@ -2079,7 +2090,7 @@ Invalid gas price: it cannot be zero
 
 <a id="0x1_automation_registry_EINVALID_INPUT_CYCLE_INDEX"></a>
 
-The tasks are requested to be processed from invalid cycle.
+The tasks are requested to be processed for invalid cycle.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EINVALID_INPUT_CYCLE_INDEX">EINVALID_INPUT_CYCLE_INDEX</a>: u64 = 34;
@@ -2143,6 +2154,16 @@ Auxiliary data during registration is not supported
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_ENO_AUX_DATA_SUPPORTED">ENO_AUX_DATA_SUPPORTED</a>: u64 = 14;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_EOUT_OF_ORDER_TASK_PROCESSING_REQUEST"></a>
+
+The out of order task processing has been identified during transition.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_EOUT_OF_ORDER_TASK_PROCESSING_REQUEST">EOUT_OF_ORDER_TASK_PROCESSING_REQUEST</a>: u64 = 36;
 </code></pre>
 
 
@@ -2312,7 +2333,7 @@ The length of the transaction hash.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_finalized">is_transition_finalized</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>): bool {
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.expected_tasks_to_be_processed) == <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.actual_processed_tasks)
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.expected_tasks_to_be_processed) == state.next_task_index_position
 }
 </code></pre>
 
@@ -2336,7 +2357,7 @@ The length of the transaction hash.
 
 
 <pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_is_transition_in_progress">is_transition_in_progress</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>): bool {
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.actual_processed_tasks) != 0
+    state.next_task_index_position != 0
 }
 </code></pre>
 
@@ -2344,13 +2365,13 @@ The length of the transaction hash.
 
 </details>
 
-<a id="0x1_automation_registry_append_processed_task"></a>
+<a id="0x1_automation_registry_mark_task_processed"></a>
 
-## Function `append_processed_task`
+## Function `mark_task_processed`
 
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_mark_task_processed">mark_task_processed</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64)
 </code></pre>
 
 
@@ -2359,33 +2380,11 @@ The length of the transaction hash.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64) {
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> state.actual_processed_tasks, task_index);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_automation_registry_already_processed"></a>
-
-## Function `already_processed`
-
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, task_index: u64): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(state: &<a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64): bool {
-    // TODO: maybe <b>use</b> <b>native</b> function <b>if</b> too expensive
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_contains">vector::contains</a>(&state.actual_processed_tasks, &task_index)
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_mark_task_processed">mark_task_processed</a>(state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a>, task_index: u64) {
+    <b>assert</b>!(state.next_task_index_position &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&state.expected_tasks_to_be_processed), <a href="automation_registry.md#0x1_automation_registry_EINCONSISTENT_TRANSITION_STATE">EINCONSISTENT_TRANSITION_STATE</a>);
+    <b>let</b> expected_task = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&state.expected_tasks_to_be_processed, state.next_task_index_position);
+    <b>assert</b>!(expected_task == &task_index, <a href="automation_registry.md#0x1_automation_registry_EOUT_OF_ORDER_TASK_PROCESSING_REQUEST">EOUT_OF_ORDER_TASK_PROCESSING_REQUEST</a>);
+    state.next_task_index_position = state.next_task_index_position + 1;
 }
 </code></pre>
 
@@ -4106,6 +4105,8 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
     );
     <b>let</b> removed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>let</b> epoch_locked_fees = <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.epoch_locked_fees;
+    // Sort task indexes <b>as</b> order is important
+    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> task_indexes);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
         <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
             <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
@@ -4137,7 +4138,7 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
                 task.locked_fee_for_next_epoch,
                 task.locked_fee_for_next_epoch);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
-            <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(transition_state, task_index);
+            <a href="automation_registry.md#0x1_automation_registry_mark_task_processed">mark_task_processed</a>(transition_state, task_index);
         };
     });
 
@@ -4236,10 +4237,10 @@ If the task is already processed or missing from the registry then nothing is do
     intermediate_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_IntermediateStateOfEpochChange">IntermediateStateOfEpochChange</a>,
 )
 {
-    <b>if</b> (<a href="automation_registry.md#0x1_automation_registry_already_processed">already_processed</a>(transition_state,task_index) || !<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
+    <b>if</b> (!<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index)) {
         <b>return</b>
     };
-    <a href="automation_registry.md#0x1_automation_registry_append_processed_task">append_processed_task</a>(transition_state, task_index);
+    <a href="automation_registry.md#0x1_automation_registry_mark_task_processed">mark_task_processed</a>(transition_state, task_index);
     <b>let</b> task_meta = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks, task_index);
     <b>if</b> (task_meta.state == <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a> || task_meta.expiry_time &lt;= current_time) {
         <a href="automation_registry.md#0x1_automation_registry_refund_deposit_and_drop">refund_deposit_and_drop</a>(task_index, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>, refund_bookkeeping, resource_signer, &<b>mut</b> intermediate_state.removed_tasks);
@@ -4603,6 +4604,8 @@ Note it is expected that committed_occupancy does not include currnet task's occ
         <a href="automation_registry.md#0x1_automation_registry_move_to_started_state">move_to_started_state</a>(cycle_info);
         <b>return</b>
     };
+    <b>let</b> expected_tasks_to_be_processed = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+    <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> expected_tasks_to_be_processed);
     <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
         refund_duration: 0,
         new_cycle_duration: cycle_info.duration_secs,
@@ -4610,8 +4613,8 @@ Note it is expected that committed_occupancy does not include currnet task's occ
         gas_committed_for_new_cycle: <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.gas_committed_for_next_epoch,
         gas_committed_for_next_cycle: 0,
         locked_fees: 0,
-        expected_tasks_to_be_processed: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks),
-        actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+        expected_tasks_to_be_processed,
+        next_task_index_position: 0
     };
     cycle_info.transition_state = std::option::some(transition_state);
     // During cycle transition we <b>update</b> config only after transition state is created in order <b>to</b> have new cycle
@@ -4696,7 +4699,7 @@ Note it is expected that committed_occupancy does not include currnet task's occ
             transition_state.gas_committed_for_next_cycle = 0;
             transition_state.locked_fees = 0;
             transition_state.expected_tasks_to_be_processed = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-            transition_state.actual_processed_tasks = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+            transition_state.next_task_index_position = 0;
         }
     };
     <a href="automation_registry.md#0x1_automation_registry_update_cycle_state_to">update_cycle_state_to</a>(cycle_info, <a href="automation_registry.md#0x1_automation_registry_CYCLE_READY">CYCLE_READY</a>)
@@ -4790,6 +4793,8 @@ In all cases if there are no tasks in registry the state will be updated directl
         <b>assert</b>!(current_time &lt; cycle_end_time, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
         <b>assert</b>!(cycle_info.state == <a href="automation_registry.md#0x1_automation_registry_CYCLE_STARTED">CYCLE_STARTED</a>, <a href="automation_registry.md#0x1_automation_registry_EINVALID_REGISTRY_STATE">EINVALID_REGISTRY_STATE</a>);
         <b>let</b> active_config = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfig">ActiveAutomationRegistryConfig</a>&gt;(@supra_framework);
+        <b>let</b> expected_tasks_to_be_processed = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks);
+        <a href="automation_registry.md#0x1_automation_registry_sort_vector">sort_vector</a>(&<b>mut</b> expected_tasks_to_be_processed);
         <b>let</b> transition_state = <a href="automation_registry.md#0x1_automation_registry_TransitionState">TransitionState</a> {
             refund_duration: cycle_end_time - current_time,
             new_cycle_duration: cycle_info.duration_secs,
@@ -4797,8 +4802,8 @@ In all cases if there are no tasks in registry the state will be updated directl
             gas_committed_for_new_cycle: 0,
             gas_committed_for_next_cycle: 0,
             locked_fees: 0,
-            expected_tasks_to_be_processed: <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_map_list">enumerable_map::get_map_list</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.tasks),
-            actual_processed_tasks: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
+            expected_tasks_to_be_processed,
+            next_task_index_position: 0
         };
         cycle_info.transition_state = std::option::some(transition_state);
     } <b>else</b> {

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -26,6 +26,7 @@ module supra_framework::automation_registry {
     use std::signer::address_of;
     #[test_only]
     use supra_framework::timestamp::update_global_time_for_test_secs;
+    use supra_std::vector_utils::sort_vector_u64;
 
     friend supra_framework::block;
     friend supra_framework::genesis;
@@ -1459,7 +1460,7 @@ module supra_framework::automation_registry {
         let removed_tasks = vector[];
         let epoch_locked_fees = automation_registry.epoch_locked_fees;
         // Sort task indexes as order is important
-        sort_vector(&mut task_indexes);
+        task_indexes = sort_vector_u64(task_indexes);
         vector::for_each(task_indexes, |task_index| {
             if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
                 let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
@@ -1518,7 +1519,7 @@ module supra_framework::automation_registry {
         let current_cycle_end_time = current_time + transition_state.new_cycle_duration;
 
         // Sort task indexes to charge automation fees in the tasks chronological order
-        sort_vector(&mut task_ids);
+        task_ids = sort_vector_u64(task_ids);
 
         // Process each active task and calculate fee for the epoch for the tasks
         vector::for_each(task_ids, |task_index| {
@@ -1758,7 +1759,7 @@ module supra_framework::automation_registry {
             return
         };
         let expected_tasks_to_be_processed = enumerable_map::get_map_list(&automation_registry.tasks);
-        sort_vector(&mut expected_tasks_to_be_processed);
+        expected_tasks_to_be_processed = sort_vector_u64(expected_tasks_to_be_processed);
         let transition_state = TransitionState {
             refund_duration: 0,
             new_cycle_duration: cycle_info.duration_secs,
@@ -1867,7 +1868,7 @@ module supra_framework::automation_registry {
             assert!(cycle_info.state == CYCLE_STARTED, EINVALID_REGISTRY_STATE);
             let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
             let expected_tasks_to_be_processed = enumerable_map::get_map_list(&automation_registry.tasks);
-            sort_vector(&mut expected_tasks_to_be_processed);
+            expected_tasks_to_be_processed = sort_vector_u64(expected_tasks_to_be_processed);
             let transition_state = TransitionState {
                 refund_duration: cycle_end_time - current_time,
                 new_cycle_duration: cycle_info.duration_secs,
@@ -2372,21 +2373,6 @@ module supra_framework::automation_registry {
             expiry_time > (automation_cycle_info.start_time + automation_cycle_info.duration_secs),
             EEXPIRY_BEFORE_NEXT_CYCLE
         );
-    }
-
-    /// Insertion sort implementation for vector
-    fun sort_vector(input: &mut vector<u64>) {
-        let len = vector::length(input);
-        let i = 1;
-        while (i < len) {
-            let j = i;
-            let to_be_sorted = *vector::borrow(input, j);
-            while (j > 0 && to_be_sorted < *vector::borrow(input, j - 1)) {
-                vector::swap(input, j, j - 1);
-                j = j - 1;
-            };
-            i = i + 1;
-        };
     }
 
     fun upscale_from_u8(value: u8): u256 { (value as u256) * DECIMAL }
@@ -5175,7 +5161,7 @@ module supra_framework::automation_registry {
     #[test]
     fun check_sort_vector() {
         let task_fee_vec = vector[5, 3, 1, 4, 2];
-        sort_vector(&mut task_fee_vec);
+        task_fee_vec = sort_vector_u64(task_fee_vec);
         let i = 0;
         while (i < 5) {
             let item = vector::borrow(&task_fee_vec, i);

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -97,8 +97,12 @@ module supra_framework::automation_registry {
     const ECYCLE_TRANSITION_IN_PROGRESS: u64 = 32;
     /// Attempt to run operation in invalid registry state.
     const EINVALID_REGISTRY_STATE: u64 = 33;
-    /// The tasks are requested to be processed from invalid cycle.
+    /// The tasks are requested to be processed for invalid cycle.
     const EINVALID_INPUT_CYCLE_INDEX: u64 = 34;
+    /// Attempt to process a task when expected list of the tasks has been alrady processed.
+    const EINCONSISTENT_TRANSITION_STATE: u64 = 35;
+    /// The out of order task processing has been identified during transition.
+    const EOUT_OF_ORDER_TASK_PROCESSING_REQUEST: u64 = 36;
 
     /// The length of the transaction hash.
     const TXN_HASH_LENGTH: u64 = 32;
@@ -243,27 +247,27 @@ module supra_framework::automation_registry {
         /// Total fee charged from users for the new cycle, which is not withdrawable.
         locked_fees: u64,
         /// List of the tasks to be processed during transition.
+        /// This list is sorted in ascending order.
+        /// The requirement is that all tasks are processed in the order of their registration. Which should be true
+        /// especially for cycle fee charges before new cycle start.
         expected_tasks_to_be_processed: vector<u64>,
-        /// So far processed tasks during transition
-        /// In case if transition spans between multiple blocks then
-        /// upon recovery execution component will know the breaking point and can recover from it.
-        actual_processed_tasks: vector<u64>
+        /// Position of the task index in the expected_tasks_to_be_processed to be processed next.
+        /// It is incremented when an expected task is successfully processed.
+        next_task_index_position: u64
     }
 
     fun is_transition_finalized(state: &TransitionState): bool {
-        vector::length(&state.expected_tasks_to_be_processed) == vector::length(&state.actual_processed_tasks)
+        vector::length(&state.expected_tasks_to_be_processed) == state.next_task_index_position
     }
     fun is_transition_in_progress(state: &TransitionState): bool {
-        vector::length(&state.actual_processed_tasks) != 0
+        state.next_task_index_position != 0
     }
 
-    fun append_processed_task(state: &mut TransitionState, task_index: u64) {
-        vector::push_back(&mut state.actual_processed_tasks, task_index);
-    }
-
-    fun already_processed(state: &TransitionState, task_index: u64): bool {
-        // TODO: maybe use native function if too expensive
-        vector::contains(&state.actual_processed_tasks, &task_index)
+    fun mark_task_processed(state: &mut TransitionState, task_index: u64) {
+        assert!(state.next_task_index_position < vector::length(&state.expected_tasks_to_be_processed), EINCONSISTENT_TRANSITION_STATE);
+        let expected_task = vector::borrow(&state.expected_tasks_to_be_processed, state.next_task_index_position);
+        assert!(expected_task == &task_index, EOUT_OF_ORDER_TASK_PROCESSING_REQUEST);
+        state.next_task_index_position = state.next_task_index_position + 1;
     }
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
@@ -502,6 +506,7 @@ module supra_framework::automation_registry {
         owner: address,
         amount: u64,
     }
+
     #[event]
     /// Event emitted when on new epoch inconsistent state of the registry has been identified.
     /// When automation is in suspended state, there are no tasks expected.
@@ -1453,6 +1458,8 @@ module supra_framework::automation_registry {
         );
         let removed_tasks = vector[];
         let epoch_locked_fees = automation_registry.epoch_locked_fees;
+        // Sort task indexes as order is important
+        sort_vector(&mut task_indexes);
         vector::for_each(task_indexes, |task_index| {
             if (enumerable_map::contains(&automation_registry.tasks, task_index)) {
                 let task = enumerable_map::remove_value(&mut automation_registry.tasks, task_index);
@@ -1484,7 +1491,7 @@ module supra_framework::automation_registry {
                     task.locked_fee_for_next_epoch,
                     task.locked_fee_for_next_epoch);
                 vector::push_back(&mut removed_tasks, task_index);
-                append_processed_task(transition_state, task_index);
+                mark_task_processed(transition_state, task_index);
             };
         });
 
@@ -1543,10 +1550,10 @@ module supra_framework::automation_registry {
         intermediate_state: &mut IntermediateStateOfEpochChange,
     )
     {
-        if (already_processed(transition_state,task_index) || !enumerable_map::contains(&automation_registry.tasks, task_index)) {
+        if (!enumerable_map::contains(&automation_registry.tasks, task_index)) {
             return
         };
-        append_processed_task(transition_state, task_index);
+        mark_task_processed(transition_state, task_index);
         let task_meta = enumerable_map::get_value_mut(&mut automation_registry.tasks, task_index);
         if (task_meta.state == CANCELLED || task_meta.expiry_time <= current_time) {
             refund_deposit_and_drop(task_index, automation_registry, refund_bookkeeping, resource_signer, &mut intermediate_state.removed_tasks);
@@ -1750,6 +1757,8 @@ module supra_framework::automation_registry {
             move_to_started_state(cycle_info);
             return
         };
+        let expected_tasks_to_be_processed = enumerable_map::get_map_list(&automation_registry.tasks);
+        sort_vector(&mut expected_tasks_to_be_processed);
         let transition_state = TransitionState {
             refund_duration: 0,
             new_cycle_duration: cycle_info.duration_secs,
@@ -1757,8 +1766,8 @@ module supra_framework::automation_registry {
             gas_committed_for_new_cycle: automation_registry.gas_committed_for_next_epoch,
             gas_committed_for_next_cycle: 0,
             locked_fees: 0,
-            expected_tasks_to_be_processed: enumerable_map::get_map_list(&automation_registry.tasks),
-            actual_processed_tasks: vector[]
+            expected_tasks_to_be_processed,
+            next_task_index_position: 0
         };
         cycle_info.transition_state = std::option::some(transition_state);
         // During cycle transition we update config only after transition state is created in order to have new cycle
@@ -1803,7 +1812,7 @@ module supra_framework::automation_registry {
                 transition_state.gas_committed_for_next_cycle = 0;
                 transition_state.locked_fees = 0;
                 transition_state.expected_tasks_to_be_processed = vector[];
-                transition_state.actual_processed_tasks = vector[];
+                transition_state.next_task_index_position = 0;
             }
         };
         update_cycle_state_to(cycle_info, CYCLE_READY)
@@ -1857,6 +1866,8 @@ module supra_framework::automation_registry {
             assert!(current_time < cycle_end_time, EINVALID_REGISTRY_STATE);
             assert!(cycle_info.state == CYCLE_STARTED, EINVALID_REGISTRY_STATE);
             let active_config = borrow_global<ActiveAutomationRegistryConfig>(@supra_framework);
+            let expected_tasks_to_be_processed = enumerable_map::get_map_list(&automation_registry.tasks);
+            sort_vector(&mut expected_tasks_to_be_processed);
             let transition_state = TransitionState {
                 refund_duration: cycle_end_time - current_time,
                 new_cycle_duration: cycle_info.duration_secs,
@@ -1864,8 +1875,8 @@ module supra_framework::automation_registry {
                 gas_committed_for_new_cycle: 0,
                 gas_committed_for_next_cycle: 0,
                 locked_fees: 0,
-                expected_tasks_to_be_processed: enumerable_map::get_map_list(&automation_registry.tasks),
-                actual_processed_tasks: vector[]
+                expected_tasks_to_be_processed,
+                next_task_index_position: 0
             };
             cycle_info.transition_state = std::option::some(transition_state);
         } else {
@@ -3656,8 +3667,8 @@ module supra_framework::automation_registry {
             user,
             44_000_000,
             automation_fee_cap,
-            task_exipry_time,
-            PENDING);
+            task_exipry_time / 2,
+            ACTIVE);
         let task2 = register_with_state(
             framework,
             user,
@@ -3670,8 +3681,8 @@ module supra_framework::automation_registry {
             user,
             11_000_000,
             automation_fee_cap,
-            task_exipry_time / 2,
-            ACTIVE);
+            task_exipry_time,
+            PENDING);
         let expected_user_current_balance = ACCOUNT_BALANCE - 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
         let expected_registry_current_balance = REGISTRY_DEFAULT_BALANCE + 3 * (FLAT_REGISTRATION_FEE_TEST + automation_fee_cap);
 
@@ -3679,7 +3690,7 @@ module supra_framework::automation_registry {
         let fwk_address = address_of(framework);
         let user_address = address_of(user);
 
-        // Update time so task3 is expired.
+        // Update time so task1 is expired.
         update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2);
         // Make sure we are in FINISHED state
         monitor_cycle_end();
@@ -3689,7 +3700,7 @@ module supra_framework::automation_registry {
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
         // Make sure that we attempt to drop only cancelled and expired tasks, to avoid any asserts in this scenario
-        process_tasks(create_signer(@vm_reserved), 2, vector[task2, task3]);
+        process_tasks(create_signer(@vm_reserved), 2, vector[task1, task2]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -3698,17 +3709,16 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(vector::contains(&transition_state.actual_processed_tasks, &task2), 1);
-            assert!(vector::contains(&transition_state.actual_processed_tasks, &task3), 2);
+            assert!(transition_state.next_task_index_position == 2, 1);
 
             // Check that both tasks have been refunded with depoit fee only
             let expected_total_deposit_refund = 2 * automation_fee_cap;
             check_account_balance(user_address, expected_user_current_balance + expected_total_deposit_refund);
             check_account_balance(ar.registry_fee_address, expected_registry_current_balance - expected_total_deposit_refund);
-            // Check that only task1 still exists in pending state
-            check_task_state(ar, task1, exists, PENDING);
-            assert!(!has_task_with_id(task2), 3);
-            assert!(!has_task_with_id(task3), 4);
+            // Check that only task3 still exists in pending state
+            check_task_state(ar, task3, exists, PENDING);
+            assert!(!has_task_with_id(task1), 3);
+            assert!(!has_task_with_id(task2), 4);
         };
     }
 
@@ -3796,7 +3806,7 @@ module supra_framework::automation_registry {
         // As long as there was a single task in the registry registry will move to started state
         assert!(cycle_details.state == CYCLE_FINISHED, 0);
         let transition_state = std::option::borrow(&cycle_details.transition_state);
-        assert!(vector::is_empty(&transition_state.actual_processed_tasks), 1);
+        assert!(transition_state.next_task_index_position == 0, 1);
 
         // Check that no refund has happened
         check_account_balance(user_address, expected_user_current_balance);
@@ -3804,6 +3814,68 @@ module supra_framework::automation_registry {
 
         // Check that task has been removed from registry
         assert!(has_task_with_id(task1), 2);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EOUT_OF_ORDER_TASK_PROCESSING_REQUEST, location = Self)]
+    fun check_tasks_processing_out_of_order_fails_in_finished_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let _task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+
+        update_global_time_for_test_secs(EPOCH_INTERVAL_FOR_TEST_IN_SECS);
+        // Make sure we are in FINISHED state
+        monitor_cycle_end();
+        // Start processing from task 2
+        process_tasks(create_signer(@vm_reserved), 2, vector[task2]);
+    }
+
+    #[test(framework = @supra_framework, user = @0x1cafa)]
+    #[expected_failure(abort_code = EOUT_OF_ORDER_TASK_PROCESSING_REQUEST, location = Self)]
+    fun check_tasks_processing_out_of_order_fails_in_suspended_state(
+        framework: &signer,
+        user: &signer
+    ) acquires AutomationRegistry, AutomationCycleDetails, ActiveAutomationRegistryConfig, AutomationRefundBookkeeping {
+        initialize_registry_test(framework, user);
+        let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
+        let automation_fee_cap = 100_000_000;
+
+        let _task1 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+        let task2 = register_with_state(
+            framework,
+            user,
+            44_000_000,
+            automation_fee_cap,
+            task_exipry_time,
+            CANCELLED);
+
+        toggle_feature_flag(framework, false);
+        on_new_epoch();
+        process_tasks(create_signer(@vm_reserved), 1, vector[task2]);
     }
 
     #[test(framework = @supra_framework, user = @0x1cafa)]
@@ -3902,8 +3974,6 @@ module supra_framework::automation_registry {
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
         };
         process_tasks(create_signer(@vm_reserved), 2,vector[task1, task2]);
-        // Also check that processed tasks are ignored and charging is done only once
-        process_tasks(create_signer(@vm_reserved), 2,vector[task1, task2]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -3912,8 +3982,7 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_FINISHED, 0);
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(vector::contains(&transition_state.actual_processed_tasks, &task1), 1);
-            assert!(vector::contains(&transition_state.actual_processed_tasks, &task2), 2);
+            assert!(transition_state.next_task_index_position == 2, 1);
 
             // Check that both tasks have been refunded with depoit fee only
             let expected_total_charge = 2 * (expected_automation_fee_per_task_1_2 + expected_congestion_fee_per_task_1_2);
@@ -4130,8 +4199,7 @@ module supra_framework::automation_registry {
             // Check that we are still in finished state and processed-task are only task2 and task3
             assert!(cycle_details.state == CYCLE_SUSPENDED, 0);
             let transition_state = std::option::borrow(&cycle_details.transition_state);
-            assert!(vector::contains(&transition_state.actual_processed_tasks, &task1), 1);
-            assert!(vector::contains(&transition_state.actual_processed_tasks, &task2), 2);
+            assert!(transition_state.next_task_index_position == 2, 1);
 
             // Check that both tasks have been refunded with depoit fee and remaining cycle fee only
             let expected_total_deposit_refund = 2 * automation_fee_cap;
@@ -4153,7 +4221,7 @@ module supra_framework::automation_registry {
         // Non existing item does not cause issues
         process_tasks(create_signer(@vm_reserved),  1, vector[10, 12]);
 
-        process_tasks(create_signer(@vm_reserved),  1, vector[task1, task2, task3]);
+        process_tasks(create_signer(@vm_reserved),  1, vector[task3]);
 
         {
             let ar = borrow_global<AutomationRegistry>(fwk_address);
@@ -4390,7 +4458,7 @@ module supra_framework::automation_registry {
             assert!(transition_state.gas_committed_for_new_cycle == 0, 5);
             assert!(transition_state.gas_committed_for_next_cycle  == 0, 6);
             assert!(transition_state.new_cycle_duration  == expected_cycle_duration, 7);
-            assert!(vector::is_empty(&transition_state.actual_processed_tasks), 8);
+            assert!(transition_state.next_task_index_position == 0, 8);
             assert!(vector::length(&transition_state.expected_tasks_to_be_processed) == 3, 9);
 
 
@@ -4466,7 +4534,7 @@ module supra_framework::automation_registry {
             assert!(transition_state.gas_committed_for_new_cycle == 0, 5);
             assert!(transition_state.gas_committed_for_next_cycle  == 0, 6);
             assert!(transition_state.new_cycle_duration  == EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2, 7);
-            assert!(vector::is_empty(&transition_state.actual_processed_tasks), 8);
+            assert!(transition_state.next_task_index_position == 0, 8);
             assert!(vector::length(&transition_state.expected_tasks_to_be_processed) == 3, 9);
 
 
@@ -4489,13 +4557,13 @@ module supra_framework::automation_registry {
         let t3_max_gas = 11_000_000;
         let automation_fee_cap = 100_000_000;
 
-        let _t1 = register_with_state(
+        let t1 = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
             automation_fee_cap,
             2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS, ACTIVE);
-        let t2 = register_with_state(
+        let _t2 = register_with_state(
             framework,
             user,
             t1_t2_max_gas,
@@ -4528,8 +4596,8 @@ module supra_framework::automation_registry {
         // Expected new cylce gas and automation_fee_per_sec. Calculate now to make sure that config update was done.
         let total_committed_gas_for_new_cycle = t1_t2_max_gas + t3_max_gas;
         let automation_fee_per_sec_for_new_cycle = calculate_automation_fee_multiplier_for_committed_occupancy(total_committed_gas_for_new_cycle);
-        // Drop one task to mark transition initiated
-        process_tasks(create_signer(@vm_reserved), 2, vector[t2]);
+        // Process one task to mark transition initiated
+        process_tasks(create_signer(@vm_reserved), 2, vector[t1]);
         // Disable feature and call on new epoch to check that when transition to suspened state from started no config is updated
         let expected_cycle_duration =
         {
@@ -4548,9 +4616,9 @@ module supra_framework::automation_registry {
             let transition_state = std::option::borrow(&cycle_details.transition_state);
             assert!(transition_state.automation_fee_per_sec  == automation_fee_per_sec_for_new_cycle, 4);
             assert!(transition_state.gas_committed_for_new_cycle == total_committed_gas_for_new_cycle, 5);
-            assert!(transition_state.gas_committed_for_next_cycle  == 0, 6);
+            assert!(transition_state.gas_committed_for_next_cycle  == t1_t2_max_gas, 6);
             assert!(transition_state.new_cycle_duration  == EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2, 7);
-            assert!(vector::length(&transition_state.actual_processed_tasks) == 1, 8);
+            assert!(transition_state.next_task_index_position == 1, 8);
             assert!(vector::length(&transition_state.expected_tasks_to_be_processed) == 3, 9);
 
 
@@ -6039,9 +6107,7 @@ module supra_framework::automation_registry {
         initialize_registry_test(framework, user);
         let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
         let automation_fee_cap = 100_000_000;
-        let task_exists = true;
         let t1_t2_max_gas_amount = 44_000_000;
-        let t3_max_gas_amount = 11_000_000;
         let fwk_address = address_of(framework);
 
         let task1 = register_with_state(
@@ -6075,7 +6141,6 @@ module supra_framework::automation_registry {
         on_new_epoch();
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
-            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
             assert!(cycle_details.state == CYCLE_SUSPENDED, 2);
             assert!(std::option::is_some(&cycle_details.transition_state), 3);
             assert!(cycle_details.duration_secs == expected_cycle_duration, 4);
@@ -6089,7 +6154,6 @@ module supra_framework::automation_registry {
         process_tasks(create_signer(@vm_reserved), 1, vector[task1]);
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
-            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
             assert!(cycle_details.state == CYCLE_READY, 7);
             assert!(std::option::is_none(&cycle_details.transition_state), 8);
             // still, updated configs are not read from buffer
@@ -6105,9 +6169,7 @@ module supra_framework::automation_registry {
         initialize_registry_test(framework, user);
         let task_exipry_time = 2 * EPOCH_INTERVAL_FOR_TEST_IN_SECS + EPOCH_INTERVAL_FOR_TEST_IN_SECS / 2;
         let automation_fee_cap = 100_000_000;
-        let task_exists = true;
         let t1_t2_max_gas_amount = 44_000_000;
-        let t3_max_gas_amount = 11_000_000;
         let fwk_address = address_of(framework);
 
         let task1 = register_with_state(
@@ -6154,7 +6216,6 @@ module supra_framework::automation_registry {
         process_tasks(create_signer(@vm_reserved), 1, vector[task1, task2]);
         {
             let cycle_details = borrow_global<AutomationCycleDetails>(fwk_address);
-            let config = borrow_global<ActiveAutomationRegistryConfig>(fwk_address);
             assert!(cycle_details.state == CYCLE_READY, 6);
             assert!(std::option::is_some(&cycle_details.transition_state), 7);
             assert!(cycle_details.duration_secs == expected_cycle_duration, 8);

--- a/aptos-move/framework/supra-stdlib/doc/overview.md
+++ b/aptos-move/framework/supra-stdlib/doc/overview.md
@@ -17,6 +17,7 @@ This is the reference documentation of the Supra standard library extension.
 -  [`0x1::bls12381_scalar`](bls12381_scalar.md#0x1_bls12381_scalar)
 -  [`0x1::enumerable_map`](enumerable_map.md#0x1_enumerable_map)
 -  [`0x1::eth_trie`](eth_trie.md#0x1_eth_trie)
+-  [`0x1::vector_utils`](vector_utils.md#0x1_vector_utils)
 
 
 [move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/supra-stdlib/doc/vector_utils.md
+++ b/aptos-move/framework/supra-stdlib/doc/vector_utils.md
@@ -5,6 +5,7 @@
 
 
 
+-  [Constants](#@Constants_0)
 -  [Function `sort_vector_u64`](#0x1_vector_utils_sort_vector_u64)
 -  [Function `sort_vector_u64_by_keys`](#0x1_vector_utils_sort_vector_u64_by_keys)
 -  [Function `native_sort_vector_u64`](#0x1_vector_utils_native_sort_vector_u64)
@@ -12,6 +13,21 @@
 
 
 <pre><code></code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_vector_utils_EINVALID_VECTOR_LENGHT"></a>
+
+Input vectors length does not match.
+
+
+<pre><code><b>const</b> <a href="vector_utils.md#0x1_vector_utils_EINVALID_VECTOR_LENGHT">EINVALID_VECTOR_LENGHT</a>: u64 = 1;
+</code></pre>
 
 
 
@@ -45,7 +61,7 @@ Sorts values in ascending order.
 ## Function `sort_vector_u64_by_keys`
 
 Sorts values based on the input keys in ascending order.
-The keys and values should match in lenght, otherwise function will abort.
+The keys and values should match in length, otherwise function will abort.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64_by_keys">sort_vector_u64_by_keys</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
@@ -58,6 +74,7 @@ The keys and values should match in lenght, otherwise function will abort.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64_by_keys">sort_vector_u64_by_keys</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&keys) != <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&values), <a href="vector_utils.md#0x1_vector_utils_EINVALID_VECTOR_LENGHT">EINVALID_VECTOR_LENGHT</a>);
     <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64_by_key">native_sort_vector_u64_by_key</a>(keys, values)
 }
 </code></pre>
@@ -94,7 +111,6 @@ Sorts values in ascending order.
 ## Function `native_sort_vector_u64_by_key`
 
 Sorts values based on the input keys in ascending order.
-The keys and values should match in lenght, otherwise function will abort.
 
 
 <pre><code><b>fun</b> <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64_by_key">native_sort_vector_u64_by_key</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;

--- a/aptos-move/framework/supra-stdlib/doc/vector_utils.md
+++ b/aptos-move/framework/supra-stdlib/doc/vector_utils.md
@@ -12,7 +12,8 @@
 -  [Function `native_sort_vector_u64_by_key`](#0x1_vector_utils_native_sort_vector_u64_by_key)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+</code></pre>
 
 
 
@@ -21,12 +22,12 @@
 ## Constants
 
 
-<a id="0x1_vector_utils_EINVALID_VECTOR_LENGHT"></a>
+<a id="0x1_vector_utils_EVECTORS_LENGTH_MISMATCH"></a>
 
 Input vectors length does not match.
 
 
-<pre><code><b>const</b> <a href="vector_utils.md#0x1_vector_utils_EINVALID_VECTOR_LENGHT">EINVALID_VECTOR_LENGHT</a>: u64 = 1;
+<pre><code><b>const</b> <a href="vector_utils.md#0x1_vector_utils_EVECTORS_LENGTH_MISMATCH">EVECTORS_LENGTH_MISMATCH</a>: u64 = 2;
 </code></pre>
 
 
@@ -74,7 +75,7 @@ The keys and values should match in length, otherwise function will abort.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64_by_keys">sort_vector_u64_by_keys</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&keys) != <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&values), <a href="vector_utils.md#0x1_vector_utils_EINVALID_VECTOR_LENGHT">EINVALID_VECTOR_LENGHT</a>);
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&keys) == <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&values), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="vector_utils.md#0x1_vector_utils_EVECTORS_LENGTH_MISMATCH">EVECTORS_LENGTH_MISMATCH</a>));
     <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64_by_key">native_sort_vector_u64_by_key</a>(keys, values)
 }
 </code></pre>

--- a/aptos-move/framework/supra-stdlib/doc/vector_utils.md
+++ b/aptos-move/framework/supra-stdlib/doc/vector_utils.md
@@ -1,0 +1,117 @@
+
+<a id="0x1_vector_utils"></a>
+
+# Module `0x1::vector_utils`
+
+
+
+-  [Function `sort_vector_u64`](#0x1_vector_utils_sort_vector_u64)
+-  [Function `sort_vector_u64_by_keys`](#0x1_vector_utils_sort_vector_u64_by_keys)
+-  [Function `native_sort_vector_u64`](#0x1_vector_utils_native_sort_vector_u64)
+-  [Function `native_sort_vector_u64_by_key`](#0x1_vector_utils_native_sort_vector_u64_by_key)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="0x1_vector_utils_sort_vector_u64"></a>
+
+## Function `sort_vector_u64`
+
+Sorts values in ascending order.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64">sort_vector_u64</a>(values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64">sort_vector_u64</a>(values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
+    <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64">native_sort_vector_u64</a>(values)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_vector_utils_sort_vector_u64_by_keys"></a>
+
+## Function `sort_vector_u64_by_keys`
+
+Sorts values based on the input keys in ascending order.
+The keys and values should match in lenght, otherwise function will abort.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64_by_keys">sort_vector_u64_by_keys</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_sort_vector_u64_by_keys">sort_vector_u64_by_keys</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
+    <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64_by_key">native_sort_vector_u64_by_key</a>(keys, values)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_vector_utils_native_sort_vector_u64"></a>
+
+## Function `native_sort_vector_u64`
+
+Sorts values in ascending order.
+
+
+<pre><code><b>fun</b> <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64">native_sort_vector_u64</a>(values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64">native_sort_vector_u64</a>(values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_vector_utils_native_sort_vector_u64_by_key"></a>
+
+## Function `native_sort_vector_u64_by_key`
+
+Sorts values based on the input keys in ascending order.
+The keys and values should match in lenght, otherwise function will abort.
+
+
+<pre><code><b>fun</b> <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64_by_key">native_sort_vector_u64_by_key</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="vector_utils.md#0x1_vector_utils_native_sort_vector_u64_by_key">native_sort_vector_u64_by_key</a>(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;;
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/supra-stdlib/sources/vector_utils.move
+++ b/aptos-move/framework/supra-stdlib/sources/vector_utils.move
@@ -1,0 +1,20 @@
+module supra_std::vector_utils {
+
+    /// Sorts values in ascending order.
+    public fun sort_vector_u64(values: vector<u64>) : vector<u64> {
+        native_sort_vector_u64(values)
+    }
+
+    /// Sorts values based on the input keys in ascending order.
+    /// The keys and values should match in lenght, otherwise function will abort.
+    public fun sort_vector_u64_by_keys(keys: vector<u64>, values: vector<u64>) : vector<u64> {
+        native_sort_vector_u64_by_key(keys, values)
+    }
+
+    /// Sorts values in ascending order.
+    native fun native_sort_vector_u64(values: vector<u64>): vector<u64>;
+
+    /// Sorts values based on the input keys in ascending order.
+    /// The keys and values should match in lenght, otherwise function will abort.
+    native fun native_sort_vector_u64_by_key(keys: vector<u64>, values: vector<u64>): vector<u64>;
+}

--- a/aptos-move/framework/supra-stdlib/sources/vector_utils.move
+++ b/aptos-move/framework/supra-stdlib/sources/vector_utils.move
@@ -1,9 +1,12 @@
 module supra_std::vector_utils {
 
+    use std::error;
     use std::vector;
 
     /// Input vectors length does not match.
-    const EINVALID_VECTOR_LENGHT: u64 = 1;
+    // std::vector has error constant which value is 0x20002 for similar cases,
+    // reporting this error via error::out_or_range will result to the same value.
+    const EVECTORS_LENGTH_MISMATCH: u64 = 2;
 
     /// Sorts values in ascending order.
     public fun sort_vector_u64(values: vector<u64>) : vector<u64> {
@@ -13,7 +16,7 @@ module supra_std::vector_utils {
     /// Sorts values based on the input keys in ascending order.
     /// The keys and values should match in length, otherwise function will abort.
     public fun sort_vector_u64_by_keys(keys: vector<u64>, values: vector<u64>) : vector<u64> {
-        assert!(vector::length(&keys) != vector::length(&values), EINVALID_VECTOR_LENGHT);
+        assert!(vector::length(&keys) == vector::length(&values), error::out_of_range(EVECTORS_LENGTH_MISMATCH));
         native_sort_vector_u64_by_key(keys, values)
     }
 
@@ -40,11 +43,25 @@ module supra_std::vector_utils {
     }
 
     #[test]
-    fun check_vector_u64() {
+    fun check_vector_u64_sort() {
         let values = create_vector(500);
-        let sorted = sort_vector_u64(values);
-        // vector::enumerate_ref(&sorted, |idx, v| {
-        //     assert!(idx == *v, 1);
-        // });
+        let sorted_values = sort_vector_u64(values);
+        assert!(vector::length(&sorted_values) == 500, 1);
+    }
+
+    #[test]
+    fun check_vector_u64_sort_by_key() {
+        let values = create_vector(5);
+        let keys = create_vector(5);
+        let sorted_values = sort_vector_u64_by_keys(keys, values);
+        assert!(vector::length(&sorted_values) == 5, 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0x20002, location = Self)]
+    fun check_vector_u64_sort_by_key_failure() {
+        let values = create_vector(5);
+        let keys = create_vector(4);
+        let sorted_values = sort_vector_u64_by_keys(keys, values);
     }
 }

--- a/aptos-move/framework/supra-stdlib/sources/vector_utils.move
+++ b/aptos-move/framework/supra-stdlib/sources/vector_utils.move
@@ -1,13 +1,19 @@
 module supra_std::vector_utils {
 
+    use std::vector;
+
+    /// Input vectors length does not match.
+    const EINVALID_VECTOR_LENGHT: u64 = 1;
+
     /// Sorts values in ascending order.
     public fun sort_vector_u64(values: vector<u64>) : vector<u64> {
         native_sort_vector_u64(values)
     }
 
     /// Sorts values based on the input keys in ascending order.
-    /// The keys and values should match in lenght, otherwise function will abort.
+    /// The keys and values should match in length, otherwise function will abort.
     public fun sort_vector_u64_by_keys(keys: vector<u64>, values: vector<u64>) : vector<u64> {
+        assert!(vector::length(&keys) != vector::length(&values), EINVALID_VECTOR_LENGHT);
         native_sort_vector_u64_by_key(keys, values)
     }
 
@@ -15,6 +21,30 @@ module supra_std::vector_utils {
     native fun native_sort_vector_u64(values: vector<u64>): vector<u64>;
 
     /// Sorts values based on the input keys in ascending order.
-    /// The keys and values should match in lenght, otherwise function will abort.
     native fun native_sort_vector_u64_by_key(keys: vector<u64>, values: vector<u64>): vector<u64>;
+
+
+    #[test_only]
+    fun create_vector(size: u64): vector<u64> {
+        let i = 0;
+        let result = vector<u64>[];
+        while (i < size) {
+            if (i % 5 > 3) {
+                vector::push_back(&mut result, i)
+            } else {
+                vector::insert(&mut result, 0, i)
+            };
+            i = i + 1
+        };
+        result
+    }
+
+    #[test]
+    fun check_vector_u64() {
+        let values = create_vector(500);
+        let sorted = sort_vector_u64(values);
+        // vector::enumerate_ref(&sorted, |idx, v| {
+        //     assert!(idx == *v, 1);
+        // });
+    }
 }

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -185,12 +185,14 @@ pub struct AutomationCycleTransitionState {
     pub gas_committed_for_next_cycle: u64,
     /// Total fee charged from users for the new cycle, which is not withdrawable.
     pub locked_fees: u64,
-    /// List of the tasks to be processed during transition.
+    /// List of the tasks still to be processed during transition.
+    /// This list should be sorted in ascending order.
+    /// The requirement is that all tasks are processed in the order of their registration. Which should be true
+    /// especially for cycle fee charges before new cycle start.
     pub expected_tasks_to_be_processed: Vec<u64>,
-    /// So far processed tasks during transition
-    /// In case if transition spans between multiple blocks then
-    /// upon recovery execution component will know the breaking point and can recover from it.
-    pub actual_processed_tasks: Vec<u64>
+    /// Position of the task index in the expected_tasks_to_be_processed to be processed next.
+    /// It is incremented when an expected task is successfully processed.
+    pub next_task_index_position: u64
 }
 
 /// On-chain Automation Cycle Details.


### PR DESCRIPTION

- Updated transition state to have expoected tasks to be processed during transition sorted. This will allow to track the processing order
- Removed `actual_processed_task_indexes` and added a position indicator pointing to the task position that expected to be processed next. This allowed to have fix also for ticket https://github.com/Entropy-Foundation/smr-moonshot/issues/2119

Partially fixes: https://github.com/Entropy-Foundation/smr-moonshot/issues/2093