### PR TITLE
Retrieves specific metadata details of an automation task entry by its task index.

### DIFF
--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -478,26 +478,31 @@ module supra_framework::automation_registry {
         enumerable_map::get_value(&automation_task_metadata.tasks, task_index)
     }
 
-    #[view]
     /// Retrieves specific metadata details of an automation task entry by its task index.
     ///
-    /// Returns a tuple with the following fields:
-    /// 1. `u64` - The expiry time of the task.
-    /// 2. `u64` - The maximum gas amount allowed for the task.
-    /// 3. `u64` - The gas price cap for executing the task.
-    /// 4. `u64` - The automation fee cap for the current epoch.
-    /// 5. `u64` - The time at which the task was registered.
-    /// 6. `u8`  - The state of the task.
-    /// 7. `u64` - The locked fee reserved for the next epoch execution.
-    public fun get_task_scalar_data(task_index: u64): (u64, u64, u64, u64, u64, u8, u64) acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
-        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
+    /// 1. `address`                 - The owner of the task.
+    /// 2. `vector<u8>`              - The payload transaction (encoded).
+    /// 3. `u64`                     - The expiry time of the task (timestamp).
+    /// 4. `vector<u8>`              - The hash of the transaction.
+    /// 5. `u64`                     - The maximum gas amount allowed for the task.
+    /// 6. `u64`                     - The gas price cap for executing the task.
+    /// 7. `u64`                     - The automation fee cap for the current epoch.
+    /// 8. `vector<vector<u8>>`      - Auxiliary data related to the task (can be multiple items).
+    /// 9. `u64`                     - The time at which the task was registered (timestamp).
+    /// 10. `u8`                     - The state of the task (e.g., active, cancelled, completed).
+    /// 11. `u64`                    - The locked fee reserved for the next epoch execution.
+    public fun deconstruct_task_metadata(
+        task_metadata: &AutomationTaskMetaData
+    ): (address, vector<u8>, u64, vector<u8>, u64, u64, u64, vector<vector<u8>>, u64, u8, u64) {
         (
+            task_metadata.owner,
+            task_metadata.payload_tx,
             task_metadata.expiry_time,
+            task_metadata.tx_hash,
             task_metadata.max_gas_amount,
             task_metadata.gas_price_cap,
             task_metadata.automation_fee_cap_for_epoch,
+            task_metadata.aux_data,
             task_metadata.registration_time,
             task_metadata.state,
             task_metadata.locked_fee_for_next_epoch
@@ -511,33 +516,6 @@ module supra_framework::automation_registry {
         assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
         let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
         task_metadata.owner
-    }
-
-    #[view]
-    /// Retrieves the payload transaction data of a task by its task index.
-    public fun get_task_payload(task_index: u64): vector<u8> acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
-        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
-        task_metadata.payload_tx
-    }
-
-    #[view]
-    /// Retrieves the registered transaction hash of a task by its task index.
-    public fun get_task_tx_hash(task_index: u64): vector<u8> acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
-        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
-        task_metadata.tx_hash
-    }
-
-    #[view]
-    /// Retrieves the auxiliary data of a task by its task index.
-    public fun get_task_aux_data(task_index: u64): vector<vector<u8>> acquires AutomationRegistry {
-        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
-        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
-        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
-        task_metadata.aux_data
     }
 
     #[view]

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -479,6 +479,43 @@ module supra_framework::automation_registry {
     }
 
     #[view]
+    /// Retrieves specific metadata details of an automation task entry by its task index.
+    ///
+    /// Returns a tuple with the following fields:
+    /// 1. `address`                 - The owner of the task.
+    /// 2. `vector<u8>`              - The payload transaction (encoded).
+    /// 3. `u64`                     - The expiry time of the task (timestamp).
+    /// 4. `vector<u8>`              - The hash of the transaction.
+    /// 5. `u64`                     - The maximum gas amount allowed for the task.
+    /// 6. `u64`                     - The gas price cap for executing the task.
+    /// 7. `u64`                     - The automation fee cap for the current epoch.
+    /// 8. `vector<vector<u8>>`      - Auxiliary data related to the task (can be multiple items).
+    /// 9. `u64`                     - The time at which the task was registered (timestamp).
+    /// 10. `u8`                     - The state of the task (e.g., active, cancelled, completed).
+    /// 11. `u64`                    - The locked fee reserved for the next epoch execution.
+    public fun get_task_metadata_details(
+        task_index: u64
+    ): (address, vector<u8>, u64, vector<u8>, u64, u64, u64, vector<vector<u8>>, u64, u8, u64)
+    acquires AutomationRegistry {
+        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
+        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
+        (
+            task_metadata.owner,
+            task_metadata.payload_tx,
+            task_metadata.expiry_time,
+            task_metadata.tx_hash,
+            task_metadata.max_gas_amount,
+            task_metadata.gas_price_cap,
+            task_metadata.automation_fee_cap_for_epoch,
+            task_metadata.aux_data,
+            task_metadata.registration_time,
+            task_metadata.state,
+            task_metadata.locked_fee_for_next_epoch
+        )
+    }
+
+    #[view]
     /// Retrieves the details of a automation tasks entry by their task index.
     /// If a task does not exist, it is not included in the result, and no error is reported
     public fun get_task_details_bulk(task_indexes: vector<u64>): vector<AutomationTaskMetaData> acquires AutomationRegistry {

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -482,37 +482,62 @@ module supra_framework::automation_registry {
     /// Retrieves specific metadata details of an automation task entry by its task index.
     ///
     /// Returns a tuple with the following fields:
-    /// 1. `address`                 - The owner of the task.
-    /// 2. `vector<u8>`              - The payload transaction (encoded).
-    /// 3. `u64`                     - The expiry time of the task (timestamp).
-    /// 4. `vector<u8>`              - The hash of the transaction.
-    /// 5. `u64`                     - The maximum gas amount allowed for the task.
-    /// 6. `u64`                     - The gas price cap for executing the task.
-    /// 7. `u64`                     - The automation fee cap for the current epoch.
-    /// 8. `vector<vector<u8>>`      - Auxiliary data related to the task (can be multiple items).
-    /// 9. `u64`                     - The time at which the task was registered (timestamp).
-    /// 10. `u8`                     - The state of the task (e.g., active, cancelled, completed).
-    /// 11. `u64`                    - The locked fee reserved for the next epoch execution.
-    public fun get_task_metadata_details(
-        task_index: u64
-    ): (address, vector<u8>, u64, vector<u8>, u64, u64, u64, vector<vector<u8>>, u64, u8, u64)
-    acquires AutomationRegistry {
+    /// 1. `u64` - The expiry time of the task.
+    /// 2. `u64` - The maximum gas amount allowed for the task.
+    /// 3. `u64` - The gas price cap for executing the task.
+    /// 4. `u64` - The automation fee cap for the current epoch.
+    /// 5. `u64` - The time at which the task was registered.
+    /// 6. `u8`  - The state of the task.
+    /// 7. `u64` - The locked fee reserved for the next epoch execution.
+    public fun get_task_scalar_data(task_index: u64): (u64, u64, u64, u64, u64, u8, u64) acquires AutomationRegistry {
         let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
         assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
         let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
         (
-            task_metadata.owner,
-            task_metadata.payload_tx,
             task_metadata.expiry_time,
-            task_metadata.tx_hash,
             task_metadata.max_gas_amount,
             task_metadata.gas_price_cap,
             task_metadata.automation_fee_cap_for_epoch,
-            task_metadata.aux_data,
             task_metadata.registration_time,
             task_metadata.state,
             task_metadata.locked_fee_for_next_epoch
         )
+    }
+
+    #[view]
+    /// Retrieves the owner address of a task by its task index.
+    public fun get_task_owner(task_index: u64): address acquires AutomationRegistry {
+        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
+        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
+        task_metadata.owner
+    }
+
+    #[view]
+    /// Retrieves the payload transaction data of a task by its task index.
+    public fun get_task_payload(task_index: u64): vector<u8> acquires AutomationRegistry {
+        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
+        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
+        task_metadata.payload_tx
+    }
+
+    #[view]
+    /// Retrieves the registered transaction hash of a task by its task index.
+    public fun get_task_tx_hash(task_index: u64): vector<u8> acquires AutomationRegistry {
+        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
+        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
+        task_metadata.tx_hash
+    }
+
+    #[view]
+    /// Retrieves the auxiliary data of a task by its task index.
+    public fun get_task_aux_data(task_index: u64): vector<vector<u8>> acquires AutomationRegistry {
+        let automation_task_metadata = borrow_global<AutomationRegistry>(@supra_framework);
+        assert!(enumerable_map::contains(&automation_task_metadata.tasks, task_index), EAUTOMATION_TASK_NOT_FOUND);
+        let task_metadata = enumerable_map::get_value(&automation_task_metadata.tasks, task_index);
+        task_metadata.aux_data
     }
 
     #[view]

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -151,13 +151,13 @@ impl MoveTool {
 
 #[derive(Parser)]
 pub struct FrameworkPackageArgs {
-    /// Git revision or branch for the Aptos framework
+    /// Git revision or branch for the Supra framework
     ///
     /// This is mutually exclusive with `--framework-local-dir`
     #[clap(long, group = "framework_package_args")]
     pub(crate) framework_git_rev: Option<String>,
 
-    /// Local framework directory for the Aptos framework
+    /// Local framework directory for the Supra framework
     ///
     /// This is mutually exclusive with `--framework-git-rev`
     #[clap(long, value_parser, group = "framework_package_args")]


### PR DESCRIPTION
create new function `get_task_metadata_details` to retrieves specific metadata details of an automation task entry by its task index.