### PR TITLE
[smr-moonshot 2226] Added a Move feature flag to guard failed proposer metrics feature

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -126,6 +126,7 @@ pub enum FeatureFlag {
     SupraAutomationPayloadGasCheck,
     PrivatePoll,
     SupraAutomationTaskSync,
+    SupraCountFailedProposals,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -323,9 +324,14 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             },
             FeatureFlag::SupraNativeAutomation => AptosFeatureFlag::SUPRA_NATIVE_AUTOMATION,
             FeatureFlag::SupraEthTrie => AptosFeatureFlag::SUPRA_ETH_TRIE,
-            FeatureFlag::SupraAutomationPayloadGasCheck => AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK,
+            FeatureFlag::SupraAutomationPayloadGasCheck => {
+                AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK
+            },
             FeatureFlag::PrivatePoll => AptosFeatureFlag::PRIVATE_POLL,
             FeatureFlag::SupraAutomationTaskSync => AptosFeatureFlag::SUPRA_AUTOMATION_TASK_SYNC,
+            FeatureFlag::SupraCountFailedProposals => {
+                AptosFeatureFlag::SUPRA_COUNT_FAILED_PROPOSALS
+            },
         }
     }
 }
@@ -451,10 +457,15 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::AbortIfMultisigPayloadMismatch
             },
             AptosFeatureFlag::SUPRA_NATIVE_AUTOMATION => FeatureFlag::SupraNativeAutomation,
-            AptosFeatureFlag::SUPRA_ETH_TRIE=> FeatureFlag::SupraEthTrie,
-            AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK => FeatureFlag::SupraAutomationPayloadGasCheck,
+            AptosFeatureFlag::SUPRA_ETH_TRIE => FeatureFlag::SupraEthTrie,
+            AptosFeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK => {
+                FeatureFlag::SupraAutomationPayloadGasCheck
+            },
             AptosFeatureFlag::PRIVATE_POLL => FeatureFlag::PrivatePoll,
             AptosFeatureFlag::SUPRA_AUTOMATION_TASK_SYNC => FeatureFlag::SupraAutomationTaskSync,
+            AptosFeatureFlag::SUPRA_COUNT_FAILED_PROPOSALS => {
+                FeatureFlag::SupraCountFailedProposals
+            },
         }
     }
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -139,6 +139,8 @@ return true.
 -  [Function `supra_private_poll_enabled`](#0x1_features_supra_private_poll_enabled)
 -  [Function `get_supra_automation_task_sync_feature`](#0x1_features_get_supra_automation_task_sync_feature)
 -  [Function `supra_automation_task_sync_enabled`](#0x1_features_supra_automation_task_sync_enabled)
+-  [Function `get_supra_count_failed_proposals_feature`](#0x1_features_get_supra_count_failed_proposals_feature)
+-  [Function `supra_count_failed_proposals_enabled`](#0x1_features_supra_count_failed_proposals_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -897,6 +899,16 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_SUPRA_AUTOMATION_TASK_SYNC">SUPRA_AUTOMATION_TASK_SYNC</a>: u64 = 92;
+</code></pre>
+
+
+
+<a id="0x1_features_SUPRA_COUNT_FAILED_PROPOSALS"></a>
+
+Whether the automation task sync on block basis is enabled.
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SUPRA_COUNT_FAILED_PROPOSALS">SUPRA_COUNT_FAILED_PROPOSALS</a>: u64 = 93;
 </code></pre>
 
 
@@ -3538,6 +3550,54 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_automation_task_sync_enabled">supra_automation_task_sync_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SUPRA_AUTOMATION_TASK_SYNC">SUPRA_AUTOMATION_TASK_SYNC</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_get_supra_count_failed_proposals_feature"></a>
+
+## Function `get_supra_count_failed_proposals_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_supra_count_failed_proposals_feature">get_supra_count_failed_proposals_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_supra_count_failed_proposals_feature">get_supra_count_failed_proposals_feature</a>(): u64 {
+    <a href="features.md#0x1_features_SUPRA_COUNT_FAILED_PROPOSALS">SUPRA_COUNT_FAILED_PROPOSALS</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_supra_count_failed_proposals_enabled"></a>
+
+## Function `supra_count_failed_proposals_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_count_failed_proposals_enabled">supra_count_failed_proposals_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_supra_count_failed_proposals_enabled">supra_count_failed_proposals_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SUPRA_COUNT_FAILED_PROPOSALS">SUPRA_COUNT_FAILED_PROPOSALS</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -727,6 +727,17 @@ module std::features {
         is_enabled(SUPRA_AUTOMATION_TASK_SYNC)
     }
 
+    /// Whether the automation task sync on block basis is enabled.
+    const SUPRA_COUNT_FAILED_PROPOSALS: u64 = 93;
+
+    public fun get_supra_count_failed_proposals_feature(): u64 {
+        SUPRA_COUNT_FAILED_PROPOSALS
+    }
+
+    public fun supra_count_failed_proposals_enabled(): bool acquires Features {
+        is_enabled(SUPRA_COUNT_FAILED_PROPOSALS)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -89,10 +89,11 @@ pub enum FeatureFlag {
     // Keeping 16 bit reserved to have graceful updated from aptos-mainstream in case of new flags have been added
     // Ends up in 11th byte, 0th bit
     SUPRA_NATIVE_AUTOMATION = 88,
-    SUPRA_ETH_TRIE= 89,
+    SUPRA_ETH_TRIE = 89,
     SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK = 90,
     PRIVATE_POLL = 91,
     SUPRA_AUTOMATION_TASK_SYNC = 92,
+    SUPRA_COUNT_FAILED_PROPOSALS = 93,
 }
 
 impl FeatureFlag {
@@ -162,6 +163,7 @@ impl FeatureFlag {
             FeatureFlag::SUPRA_AUTOMATION_PAYLOAD_GAS_CHECK,
             FeatureFlag::PRIVATE_POLL,
             FeatureFlag::SUPRA_AUTOMATION_TASK_SYNC,
+            FeatureFlag::SUPRA_COUNT_FAILED_PROPOSALS,
         ]
     }
 }


### PR DESCRIPTION
Added a `SUPRA_COUNT_FAILED_PROPOSALS` flag to guard reporting failed proposals in smr-moonshot.