### PR TITLE
[AN-Issue-2181] Introduced automation_registry API to get record max task count

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -407,14 +407,7 @@ impl AptosVM {
         gas_meter: &impl AptosGasMeter,
         storage_fee_refund: u64,
     ) -> FeeStatement {
-        let gas_used = Self::gas_used(txn_data.max_gas_amount(), gas_meter);
-        FeeStatement::new(
-            gas_used,
-            u64::from(gas_meter.execution_gas_used()),
-            u64::from(gas_meter.io_gas_used()),
-            u64::from(gas_meter.storage_fee_used()),
-            storage_fee_refund,
-        )
+        Self::fee_statement_from_gas_meter_for_gas(txn_data.max_gas_amount, gas_meter, storage_fee_refund)
     }
 
     pub(crate) fn fee_statement_from_gas_meter_for_gas(

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -417,6 +417,21 @@ impl AptosVM {
         )
     }
 
+    pub(crate) fn fee_statement_from_gas_meter_for_gas(
+        max_gas: Gas,
+        gas_meter: &impl AptosGasMeter,
+        storage_fee_refund: u64,
+    ) -> FeeStatement {
+        let gas_used = Self::gas_used(max_gas, gas_meter);
+        FeeStatement::new(
+            gas_used,
+            u64::from(gas_meter.execution_gas_used()),
+            u64::from(gas_meter.io_gas_used()),
+            u64::from(gas_meter.storage_fee_used()),
+            storage_fee_refund,
+        )
+    }
+
     pub(crate) fn failed_transaction_cleanup(
         &self,
         prologue_change_set: VMChangeSet,

--- a/aptos-move/aptos-vm/src/automation_registry_transaction_processor.rs
+++ b/aptos-move/aptos-vm/src/automation_registry_transaction_processor.rs
@@ -17,8 +17,8 @@ use aptos_vm_types::storage::change_set_configs::ChangeSetConfigs;
 use move_binary_format::errors::VMError;
 use move_core_types::vm_status::{StatusCode, VMStatus};
 use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
-use move_vm_types::gas::UnmeteredGasMeter;
 use std::ops::Deref;
+use crate::gas::make_prod_gas_meter;
 
 pub struct AutomationRegistryTransactionProcessor<'m> {
     aptos_vm: &'m AptosVM,
@@ -60,7 +60,18 @@ impl<'m> AutomationRegistryTransactionProcessor<'m> {
                 discarded_output(StatusCode::FEATURE_UNDER_GATING),
             ));
         }
-        let mut gas_meter = UnmeteredGasMeter;
+        let gas_params =
+            get_or_vm_startup_failure(&self.gas_params_internal(), log_context)?
+                .vm
+                .clone();
+        let max_gas_amount = gas_params.txn.maximum_number_of_gas_units;
+        let mut gas_meter = make_prod_gas_meter(
+            self.gas_feature_version(),
+            gas_params,
+            get_or_vm_startup_failure(&self.storage_gas_params, log_context)?.clone(),
+            false,
+            max_gas_amount,
+        );
         let mut session = self.new_session(
             resolver,
             SessionId::automation_registry_action(action_record),
@@ -82,11 +93,12 @@ impl<'m> AutomationRegistryTransactionProcessor<'m> {
             .map(|_return_vals| ());
         SYSTEM_TRANSACTIONS_EXECUTED.inc();
 
+        let fee_statement = AptosVM::fee_statement_from_gas_meter_for_gas(max_gas_amount.into(), &gas_meter, 0);
         match result {
             Ok(_) => {
                 let output = get_system_transaction_output(
                     session,
-                    FeeStatement::zero(),
+                    fee_statement,
                     ExecutionStatus::Success,
                     &get_or_vm_startup_failure(&self.storage_gas_params, log_context)?
                         .change_set_configs,
@@ -97,6 +109,7 @@ impl<'m> AutomationRegistryTransactionProcessor<'m> {
                 session,
                 &get_or_vm_startup_failure(&self.storage_gas_params, log_context)?
                     .change_set_configs,
+                fee_statement,
                 vm_err,
             ),
         }
@@ -106,6 +119,7 @@ impl<'m> AutomationRegistryTransactionProcessor<'m> {
         &self,
         session: SessionExt,
         change_set_configs: &ChangeSetConfigs,
+        fee_statement: FeeStatement,
         vm_err: VMError,
     ) -> Result<(VMStatus, VMOutput), VMStatus> {
         let vm_status = VMStatus::from(vm_err);
@@ -114,7 +128,7 @@ impl<'m> AutomationRegistryTransactionProcessor<'m> {
 
         let change_set = session.finish(change_set_configs)?;
 
-        let output = VMOutput::new(change_set, FeeStatement::zero(), txn_status, aux_data);
+        let output = VMOutput::new(change_set, fee_statement, txn_status, aux_data);
         Ok((vm_status, output))
     }
 }

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -2342,7 +2342,7 @@ Max storage fee per task.
 
 <a id="0x1_automation_registry_TASK_SUPPORT_FACTOR"></a>
 
-Task support factor in percentage.
+Task support factor in percentage. It should not exceed 100.
 
 
 <pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_TASK_SUPPORT_FACTOR">TASK_SUPPORT_FACTOR</a>: u64 = 80;
@@ -3190,7 +3190,7 @@ Returns the maximum number of the tasks that can be processed in scope of single
     <b>let</b> task_count = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_count_by_exec_gas, task_count_by_io_gas);
     task_count = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_count, task_count_by_storage_fee);
     task_count = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_count, task_count_by_write_op);
-    task_count * 100 / <a href="automation_registry.md#0x1_automation_registry_TASK_SUPPORT_FACTOR">TASK_SUPPORT_FACTOR</a>
+    task_count * <a href="automation_registry.md#0x1_automation_registry_TASK_SUPPORT_FACTOR">TASK_SUPPORT_FACTOR</a> / 100
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -74,6 +74,7 @@ This contract is part of the Supra Framework and is designed to manage automated
 -  [Function `is_registration_enabled`](#0x1_automation_registry_is_registration_enabled)
 -  [Function `get_cycle_duration`](#0x1_automation_registry_get_cycle_duration)
 -  [Function `get_cycle_info`](#0x1_automation_registry_get_cycle_info)
+-  [Function `get_record_max_task_count`](#0x1_automation_registry_get_record_max_task_count)
 -  [Function `withdraw_automation_task_fees`](#0x1_automation_registry_withdraw_automation_task_fees)
 -  [Function `update_config`](#0x1_automation_registry_update_config)
 -  [Function `update_config_v2`](#0x1_automation_registry_update_config_v2)
@@ -2307,6 +2308,58 @@ Registry resource creation seed
 
 
 
+<a id="0x1_automation_registry_TASK_EXECUTION_GAS"></a>
+
+Constants defining single task processing maximum limits
+Single task processing execution gas.
+max_execution_gas is defined 920_000_000, where scaling factor is 1_000_000.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_TASK_EXECUTION_GAS">TASK_EXECUTION_GAS</a>: u64 = 4000000;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_TASK_IO_GAS"></a>
+
+Single task processing IO gas.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_TASK_IO_GAS">TASK_IO_GAS</a>: u64 = 10000000;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_TASK_STORAGE_FEE"></a>
+
+Max storage fee per task.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_TASK_STORAGE_FEE">TASK_STORAGE_FEE</a>: u64 = 1000;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_TASK_SUPPORT_FACTOR"></a>
+
+Task support factor in percentage.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_TASK_SUPPORT_FACTOR">TASK_SUPPORT_FACTOR</a>: u64 = 80;
+</code></pre>
+
+
+
+<a id="0x1_automation_registry_TASK_WRITE_OPS"></a>
+
+Max write operation per task.
+
+
+<pre><code><b>const</b> <a href="automation_registry.md#0x1_automation_registry_TASK_WRITE_OPS">TASK_WRITE_OPS</a>: u64 = 10;
+</code></pre>
+
+
+
 <a id="0x1_automation_registry_TXN_HASH_LENGTH"></a>
 
 The length of the transaction hash.
@@ -3104,6 +3157,40 @@ Returns the current cycle info.
 <pre><code><b>public</b> <b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_cycle_info">get_cycle_info</a>(): <a href="automation_registry.md#0x1_automation_registry_AutomationCycleInfo">AutomationCycleInfo</a> <b>acquires</b> <a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a> {
     <b>let</b> details = <b>borrow_global</b>&lt;<a href="automation_registry.md#0x1_automation_registry_AutomationCycleDetails">AutomationCycleDetails</a>&gt;(@supra_framework);
     <a href="automation_registry.md#0x1_automation_registry_into_automation_cycle_info">into_automation_cycle_info</a>(details)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_automation_registry_get_record_max_task_count"></a>
+
+## Function `get_record_max_task_count`
+
+Returns the maximum number of the tasks that can be processed in scope of single bookkeeping transaction.
+
+
+<pre><code>#[view]
+<b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_record_max_task_count">get_record_max_task_count</a>(max_execution_gas: u64, max_io_gas: u64, max_storage_fee: u64, max_write_op: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_get_record_max_task_count">get_record_max_task_count</a>(max_execution_gas: u64, max_io_gas: u64, max_storage_fee: u64, max_write_op: u64): u64 {
+    <b>let</b> task_count_by_exec_gas = max_execution_gas / <a href="automation_registry.md#0x1_automation_registry_TASK_EXECUTION_GAS">TASK_EXECUTION_GAS</a>;
+    <b>let</b> task_count_by_io_gas = max_io_gas / <a href="automation_registry.md#0x1_automation_registry_TASK_IO_GAS">TASK_IO_GAS</a>;
+    <b>let</b> task_count_by_storage_fee = max_storage_fee / <a href="automation_registry.md#0x1_automation_registry_TASK_STORAGE_FEE">TASK_STORAGE_FEE</a>;
+    <b>let</b> task_count_by_write_op = max_write_op / <a href="automation_registry.md#0x1_automation_registry_TASK_WRITE_OPS">TASK_WRITE_OPS</a>;
+
+    <b>let</b> task_count = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_count_by_exec_gas, task_count_by_io_gas);
+    task_count = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_count, task_count_by_storage_fee);
+    task_count = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_min">math64::min</a>(task_count, task_count_by_write_op);
+    task_count * 100 / <a href="automation_registry.md#0x1_automation_registry_TASK_SUPPORT_FACTOR">TASK_SUPPORT_FACTOR</a>
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -792,7 +792,7 @@ module supra_framework::automation_registry {
         let task_count = math64::min(task_count_by_exec_gas, task_count_by_io_gas);
         task_count = math64::min(task_count, task_count_by_storage_fee);
         task_count = math64::min(task_count, task_count_by_write_op);
-        task_count * 100 / TASK_SUPPORT_FACTOR
+        task_count * TASK_SUPPORT_FACTOR / 100
     }
 
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -148,6 +148,19 @@ module supra_framework::automation_registry {
     /// Factor of `2` suggests that `1/2` of the deposit will be refunded.
     const REFUND_FACTOR: u64 = 2;
 
+    /// Constants defining single task processing maximum limits
+    /// Single task processing execution gas.
+    /// max_execution_gas is defined 920_000_000, where scaling factor is 1_000_000.
+    const TASK_EXECUTION_GAS: u64 = 4_000_000;
+    /// Single task processing IO gas.
+    const TASK_IO_GAS: u64 = 10_000_000;
+    /// Max storage fee per task.
+    const TASK_STORAGE_FEE: u64 = 1000;
+    /// Max write operation per task.
+    const TASK_WRITE_OPS: u64 = 10;
+    /// Task support factor in percentage.
+    const TASK_SUPPORT_FACTOR: u64 = 80;
+
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]
     struct ActiveAutomationRegistryConfig has key {
         main_config: AutomationRegistryConfig,
@@ -767,6 +780,21 @@ module supra_framework::automation_registry {
         let details = borrow_global<AutomationCycleDetails>(@supra_framework);
         into_automation_cycle_info(details)
     }
+
+    #[view]
+    /// Returns the maximum number of the tasks that can be processed in scope of single bookkeeping transaction.
+    fun get_record_max_task_count(max_execution_gas: u64, max_io_gas: u64, max_storage_fee: u64, max_write_op: u64): u64 {
+        let task_count_by_exec_gas = max_execution_gas / TASK_EXECUTION_GAS;
+        let task_count_by_io_gas = max_io_gas / TASK_IO_GAS;
+        let task_count_by_storage_fee = max_storage_fee / TASK_STORAGE_FEE;
+        let task_count_by_write_op = max_write_op / TASK_WRITE_OPS;
+
+        let task_count = math64::min(task_count_by_exec_gas, task_count_by_io_gas);
+        task_count = math64::min(task_count, task_count_by_storage_fee);
+        task_count = math64::min(task_count, task_count_by_write_op);
+        task_count * 100 / TASK_SUPPORT_FACTOR
+    }
+
 
     // Public entry functions
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -158,7 +158,7 @@ module supra_framework::automation_registry {
     const TASK_STORAGE_FEE: u64 = 1000;
     /// Max write operation per task.
     const TASK_WRITE_OPS: u64 = 10;
-    /// Task support factor in percentage.
+    /// Task support factor in percentage. It should not exceed 100.
     const TASK_SUPPORT_FACTOR: u64 = 80;
 
     #[resource_group_member(group = supra_framework::object::ObjectGroup)]


### PR DESCRIPTION

- Now to get maximum number of the tasks that can be included in the automation bookkeeping record can be done via view function `automation_registry::get_record_max_task_count` API by passing
 transaction maximum execution and IO gas, maximum storage fee and
 maximum write operations per transaction. With a simple profiling it
 was deduced that bookkeeping transaction uses 4 execution gas and 9 io
 gas which are rounded and stored in automation-registry to facilitate
 record task count calculation

- Also automation registry transaction processing is updated to use production gas-meter to have total used gas included in the execution output, although no fee is charged for them.