### PR TITLE
[AN-Issue-2236] Introduced AutomationRegistryConfigV2 to enable backward-compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,6 +4080,8 @@ dependencies = [
  "coset",
  "criterion",
  "derivative",
+ "derive-getters",
+ "derive_more 2.0.1",
  "fixed",
  "fxhash",
  "hashbrown 0.14.3",
@@ -4212,7 +4214,7 @@ dependencies = [
  "bytes",
  "claims",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 2.0.1",
  "fail",
  "futures",
  "hex",
@@ -6248,6 +6250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6919,6 +6930,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6966,11 +6988,33 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -12394,7 +12438,7 @@ checksum = "e69c569eb0671cc85e65cfb6bd960d0168d24732ff58825227b4d2a10167ba91"
 dependencies = [
  "base64 0.13.1",
  "bytes",
- "derive_more",
+ "derive_more 0.99.17",
  "futures-util",
  "mime",
  "num-traits",
@@ -13865,7 +13909,7 @@ checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
 dependencies = [
  "bitvec 0.20.4",
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.17",
  "parity-scale-codec 2.3.1",
  "scale-info-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,8 +545,9 @@ debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
 derivation-path = "0.2.0"
 derive_builder = "0.20.0"
+derive-getters = "0.5.0"
 determinator = "0.12.0"
-derive_more = "0.99.11"
+derive_more = { version = "2.0.1",features = ["full"] }
 diesel = "2.1"
 # Use the crate version once this feature gets released on crates.io:
 # https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -63,6 +63,8 @@ serde_yaml = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
+derive-getters = { workspace = true }
+derive_more = { workspace = true }
 
 [dev-dependencies]
 ahash = { workspace = true }

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -119,9 +119,9 @@ impl AutomationRegistryConfigV1 {
 /// Extended version of configuration parameters for Supra native automation feature supporting cycle-duration.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
 pub struct AutomationRegistryConfigV2 {
-    #[serde(flatten)]
-    v1: AutomationRegistryConfigV1,
-    /// Cycle duration in seconds
+    /// Main user task registration related parameters.
+    main: AutomationRegistryConfigV1,
+    /// Cycle duration in seconds.
     cycle_duration_secs: u64,
 }
 
@@ -129,7 +129,7 @@ pub struct AutomationRegistryConfigV2 {
 impl Default for AutomationRegistryConfigV2 {
     fn default() -> Self {
         Self {
-            v1: Default::default(),
+            main: Default::default(),
             cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
         }
     }
@@ -163,7 +163,7 @@ impl AutomationRegistryConfigV2 {
             task_capacity,
         );
         Self {
-            v1,
+            main: v1,
             cycle_duration_secs,
         }
     }
@@ -173,14 +173,14 @@ impl Deref for AutomationRegistryConfigV2 {
     type Target = AutomationRegistryConfigV1;
 
     fn deref(&self) -> &Self::Target {
-        &self.v1
+        &self.main
     }
 }
 
 impl From<AutomationRegistryConfigV1> for AutomationRegistryConfigV2 {
     fn from(v1: AutomationRegistryConfigV1) -> Self {
         Self {
-            v1,
+            main: v1,
             cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
         }
     }

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2025 Supra.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
+use crate::on_chain_config::OnChainConfig;
+use derive_getters::Getters;
+use derive_more::Constructor;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::value::{serialize_values, MoveValue};
-use serde::{Deserialize, Serialize};
-use crate::on_chain_config::OnChainConfig;
 use move_core_types::{ident_str, identifier::IdentStr, move_resource::MoveStructType};
+use serde::{Deserialize, Serialize};
 
 const ONE_MONTH_IN_SECS: u64 = 2_626_560;
 const DEFAULT_REGISTRY_MAX_GAS_CAP: u64 = 100_000_000;
@@ -19,7 +20,7 @@ const DEFAULT_TASK_CAPACITY: u16 = 500;
 const DEFAULT_CYCLE_DURATION_SECS: u64 = 1200;
 
 /// Initial version of configuration parameters for Supra native automation feature
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq, Getters, Constructor)]
 pub struct AutomationRegistryConfigV1 {
     /// Maximum allowable duration (in seconds) from the registration time that an automation task can run.
     /// If the expiration time exceeds this duration, the task registration will fail.
@@ -41,7 +42,6 @@ pub struct AutomationRegistryConfigV1 {
     congestion_exponent: u8,
     /// Maximum number of tasks that registry can hold.
     task_capacity: u16,
-
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -59,133 +59,74 @@ impl Default for AutomationRegistryConfigV1 {
     }
 }
 
-impl AutomationRegistryConfigV1 {
-
-    pub fn new(
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
-
-    ) -> Self {
-        Self {
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            automation_base_fee_in_quants_per_sec,
-            flat_registration_fee_in_quants,
-            congestion_threshold_percentage,
-            congestion_base_fee_in_quants_per_sec,
-            congestion_exponent,
-            task_capacity,
-        }
-    }
-
-    pub fn task_duration_cap_in_secs(&self) -> u64 {
-        self.task_duration_cap_in_secs
-    }
-
-    pub fn registry_max_gas_cap(&self) -> u64 {
-        self.registry_max_gas_cap
-    }
-
-    pub fn automation_base_fee_in_quants_per_sec(&self) -> u64 {
-        self.automation_base_fee_in_quants_per_sec
-    }
-    pub fn flat_registration_fee_in_quants(&self) -> u64 {
-        self.flat_registration_fee_in_quants
-    }
-
-    pub fn congestion_threshold_percentage(&self) -> u8 {
-        self.congestion_threshold_percentage
-    }
-    pub fn congestion_base_fee_in_quants_per_sec(&self) -> u64 {
-        self.congestion_base_fee_in_quants_per_sec
-    }
-
-    pub fn congestion_exponent(&self) -> u8 {
-        self.congestion_exponent
-    }
-
-    pub fn task_capacity(&self) -> u16 {
-        self.task_capacity
-    }
-
-}
-
 /// Extended version of configuration parameters for Supra native automation feature supporting cycle-duration.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq, Getters, Constructor)]
 pub struct AutomationRegistryConfigV2 {
-    /// Main user task registration related parameters.
-    main: AutomationRegistryConfigV1,
+    /// Maximum allowable duration (in seconds) from the registration time that an automation task can run.
+    /// If the expiration time exceeds this duration, the task registration will fail.
+    task_duration_cap_in_secs: u64,
+    /// Maximum gas allocation for automation tasks per epoch
+    /// Exceeding this limit during task registration will cause failure and is used in fee calculation.
+    registry_max_gas_cap: u64,
+    /// Base fee per second for the full capacity of the automation registry, measured in quants/sec.
+    /// The capacity is considered full if the total committed gas of all registered tasks equals registry_max_gas_cap.
+    automation_base_fee_in_quants_per_sec: u64,
+    /// Flat registration fee charged by default for each task.
+    flat_registration_fee_in_quants: u64,
+    /// Ratio (in the range [0;100]) representing the acceptable upper limit of committed gas amount
+    /// relative to registry_max_gas_cap. Beyond this threshold, congestion fees apply.
+    congestion_threshold_percentage: u8,
+    /// Base fee per second for the full capacity of the automation registry when the congestion threshold is exceeded.
+    congestion_base_fee_in_quants_per_sec: u64,
+    /// The congestion fee increases exponentially based on this value, ensuring higher fees as the registry approaches full capacity.
+    congestion_exponent: u8,
+    /// Maximum number of tasks that registry can hold.
+    task_capacity: u16,
     /// Cycle duration in seconds.
     cycle_duration_secs: u64,
 }
 
-
 impl Default for AutomationRegistryConfigV2 {
     fn default() -> Self {
         Self {
-            main: Default::default(),
+            task_duration_cap_in_secs: ONE_MONTH_IN_SECS,
+            registry_max_gas_cap: DEFAULT_REGISTRY_MAX_GAS_CAP,
+            automation_base_fee_in_quants_per_sec: DEFAULT_AUTOMATION_BASE_FEE_IN_QUANTS_PER_SEC,
+            flat_registration_fee_in_quants: ONE_SUPRA_IN_QUANTS,
+            congestion_threshold_percentage: DEFAULT_CONGESTION_THRESHOLD_PERCENTAGE,
+            congestion_base_fee_in_quants_per_sec: DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC,
+            congestion_exponent: DEFAULT_CONGESTION_EXPONENT,
+            task_capacity: DEFAULT_TASK_CAPACITY,
             cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
         }
-    }
-}
-
-impl AutomationRegistryConfigV2 {
-    pub fn cycle_duration_secs(&self) -> u64 {
-        self.cycle_duration_secs
-    }
-
-    pub fn new(
-        task_duration_cap_in_secs: u64,
-        registry_max_gas_cap: u64,
-        automation_base_fee_in_quants_per_sec: u64,
-        flat_registration_fee_in_quants: u64,
-        congestion_threshold_percentage: u8,
-        congestion_base_fee_in_quants_per_sec: u64,
-        congestion_exponent: u8,
-        task_capacity: u16,
-        cycle_duration_secs: u64,
-
-    ) -> Self {
-        let v1= AutomationRegistryConfigV1::new(
-            task_duration_cap_in_secs,
-            registry_max_gas_cap,
-            automation_base_fee_in_quants_per_sec,
-            flat_registration_fee_in_quants,
-            congestion_threshold_percentage,
-            congestion_base_fee_in_quants_per_sec,
-            congestion_exponent,
-            task_capacity,
-        );
-        Self {
-            main: v1,
-            cycle_duration_secs,
-        }
-    }
-}
-
-impl Deref for AutomationRegistryConfigV2 {
-    type Target = AutomationRegistryConfigV1;
-
-    fn deref(&self) -> &Self::Target {
-        &self.main
     }
 }
 
 impl From<AutomationRegistryConfigV1> for AutomationRegistryConfigV2 {
     fn from(v1: AutomationRegistryConfigV1) -> Self {
+        let AutomationRegistryConfigV1 {
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+        } = v1;
         Self {
-            main: v1,
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
             cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
         }
     }
 }
-
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
 pub enum AutomationRegistryConfig {
@@ -208,31 +149,31 @@ impl AutomationRegistryConfig {
             AutomationRegistryConfig::V1(config) => {
                 vec![
                     MoveValue::Signer(signer_address),
-                    MoveValue::U64(config.task_duration_cap_in_secs()),
-                    MoveValue::U64(config.registry_max_gas_cap()),
-                    MoveValue::U64(config.automation_base_fee_in_quants_per_sec()),
-                    MoveValue::U64(config.flat_registration_fee_in_quants()),
-                    MoveValue::U8(config.congestion_threshold_percentage()),
-                    MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
-                    MoveValue::U8(config.congestion_exponent()),
-                    MoveValue::U16(config.task_capacity()),
+                    MoveValue::U64(*config.task_duration_cap_in_secs()),
+                    MoveValue::U64(*config.registry_max_gas_cap()),
+                    MoveValue::U64(*config.automation_base_fee_in_quants_per_sec()),
+                    MoveValue::U64(*config.flat_registration_fee_in_quants()),
+                    MoveValue::U8(*config.congestion_threshold_percentage()),
+                    MoveValue::U64(*config.congestion_base_fee_in_quants_per_sec()),
+                    MoveValue::U8(*config.congestion_exponent()),
+                    MoveValue::U16(*config.task_capacity()),
                     MoveValue::U64(DEFAULT_CYCLE_DURATION_SECS),
                 ]
-            }
+            },
             AutomationRegistryConfig::V2(config) => {
                 vec![
                     MoveValue::Signer(signer_address),
-                    MoveValue::U64(config.task_duration_cap_in_secs()),
-                    MoveValue::U64(config.registry_max_gas_cap()),
-                    MoveValue::U64(config.automation_base_fee_in_quants_per_sec()),
-                    MoveValue::U64(config.flat_registration_fee_in_quants()),
-                    MoveValue::U8(config.congestion_threshold_percentage()),
-                    MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
-                    MoveValue::U8(config.congestion_exponent()),
-                    MoveValue::U16(config.task_capacity()),
-                    MoveValue::U64(config.cycle_duration_secs()),
+                    MoveValue::U64(*config.task_duration_cap_in_secs()),
+                    MoveValue::U64(*config.registry_max_gas_cap()),
+                    MoveValue::U64(*config.automation_base_fee_in_quants_per_sec()),
+                    MoveValue::U64(*config.flat_registration_fee_in_quants()),
+                    MoveValue::U8(*config.congestion_threshold_percentage()),
+                    MoveValue::U64(*config.congestion_base_fee_in_quants_per_sec()),
+                    MoveValue::U8(*config.congestion_exponent()),
+                    MoveValue::U16(*config.task_capacity()),
+                    MoveValue::U64(*config.cycle_duration_secs()),
                 ]
-            }
+            },
         };
         serialize_values(&arguments)
     }
@@ -257,7 +198,7 @@ pub enum AutomationCycleState {
     READY = 0,
     STARTED,
     FINISHED,
-    SUSPENDED
+    SUSPENDED,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -306,7 +247,7 @@ pub struct AutomationCycleTransitionState {
     pub expected_tasks_to_be_processed: Vec<u64>,
     /// Position of the task index in the expected_tasks_to_be_processed to be processed next.
     /// It is incremented when an expected task is successfully processed.
-    pub next_task_index_position: u64
+    pub next_task_index_position: u64,
 }
 
 /// On-chain Automation Cycle Details.
@@ -339,4 +280,3 @@ impl OnChainConfig for AutomationCycleDetails {
     const MODULE_IDENTIFIER: &'static str = "automation_registry";
     const TYPE_IDENTIFIER: &'static str = "AutomationCycleDetails";
 }
-

--- a/types/src/on_chain_config/automation_registry.rs
+++ b/types/src/on_chain_config/automation_registry.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Supra.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::value::{serialize_values, MoveValue};
 use serde::{Deserialize, Serialize};
@@ -40,8 +41,7 @@ pub struct AutomationRegistryConfigV1 {
     congestion_exponent: u8,
     /// Maximum number of tasks that registry can hold.
     task_capacity: u16,
-    /// Cycle duration in seconds
-    cycle_duration_secs: u64,
+
 }
 
 impl Default for AutomationRegistryConfigV1 {
@@ -55,12 +55,35 @@ impl Default for AutomationRegistryConfigV1 {
             congestion_base_fee_in_quants_per_sec: DEFAULT_CONGESTION_BASE_FEE_IN_QUANTS_PER_SEC,
             congestion_exponent: DEFAULT_CONGESTION_EXPONENT,
             task_capacity: DEFAULT_TASK_CAPACITY,
-            cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
         }
     }
 }
 
 impl AutomationRegistryConfigV1 {
+
+    pub fn new(
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+
+    ) -> Self {
+        Self {
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+        }
+    }
+
     pub fn task_duration_cap_in_secs(&self) -> u64 {
         self.task_duration_cap_in_secs
     }
@@ -91,14 +114,83 @@ impl AutomationRegistryConfigV1 {
         self.task_capacity
     }
 
+}
+
+/// Extended version of configuration parameters for Supra native automation feature supporting cycle-duration.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
+pub struct AutomationRegistryConfigV2 {
+    #[serde(flatten)]
+    v1: AutomationRegistryConfigV1,
+    /// Cycle duration in seconds
+    cycle_duration_secs: u64,
+}
+
+
+impl Default for AutomationRegistryConfigV2 {
+    fn default() -> Self {
+        Self {
+            v1: Default::default(),
+            cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
+        }
+    }
+}
+
+impl AutomationRegistryConfigV2 {
     pub fn cycle_duration_secs(&self) -> u64 {
         self.cycle_duration_secs
     }
+
+    pub fn new(
+        task_duration_cap_in_secs: u64,
+        registry_max_gas_cap: u64,
+        automation_base_fee_in_quants_per_sec: u64,
+        flat_registration_fee_in_quants: u64,
+        congestion_threshold_percentage: u8,
+        congestion_base_fee_in_quants_per_sec: u64,
+        congestion_exponent: u8,
+        task_capacity: u16,
+        cycle_duration_secs: u64,
+
+    ) -> Self {
+        let v1= AutomationRegistryConfigV1::new(
+            task_duration_cap_in_secs,
+            registry_max_gas_cap,
+            automation_base_fee_in_quants_per_sec,
+            flat_registration_fee_in_quants,
+            congestion_threshold_percentage,
+            congestion_base_fee_in_quants_per_sec,
+            congestion_exponent,
+            task_capacity,
+        );
+        Self {
+            v1,
+            cycle_duration_secs,
+        }
+    }
 }
+
+impl Deref for AutomationRegistryConfigV2 {
+    type Target = AutomationRegistryConfigV1;
+
+    fn deref(&self) -> &Self::Target {
+        &self.v1
+    }
+}
+
+impl From<AutomationRegistryConfigV1> for AutomationRegistryConfigV2 {
+    fn from(v1: AutomationRegistryConfigV1) -> Self {
+        Self {
+            v1,
+            cycle_duration_secs: DEFAULT_CYCLE_DURATION_SECS,
+        }
+    }
+}
+
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Eq)]
 pub enum AutomationRegistryConfig {
     V1(AutomationRegistryConfigV1),
+    V2(AutomationRegistryConfigV2),
 }
 
 impl Default for AutomationRegistryConfig {
@@ -112,19 +204,36 @@ impl AutomationRegistryConfig {
         &self,
         signer_address: AccountAddress,
     ) -> Vec<Vec<u8>> {
-        let AutomationRegistryConfig::V1(config) = self;
-        let arguments = vec![
-            MoveValue::Signer(signer_address),
-            MoveValue::U64(config.task_duration_cap_in_secs()),
-            MoveValue::U64(config.registry_max_gas_cap()),
-            MoveValue::U64(config.automation_base_fee_in_quants_per_sec()),
-            MoveValue::U64(config.flat_registration_fee_in_quants()),
-            MoveValue::U8(config.congestion_threshold_percentage()),
-            MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
-            MoveValue::U8(config.congestion_exponent()),
-            MoveValue::U16(config.task_capacity()),
-            MoveValue::U64(config.cycle_duration_secs()),
-        ];
+        let arguments = match self {
+            AutomationRegistryConfig::V1(config) => {
+                vec![
+                    MoveValue::Signer(signer_address),
+                    MoveValue::U64(config.task_duration_cap_in_secs()),
+                    MoveValue::U64(config.registry_max_gas_cap()),
+                    MoveValue::U64(config.automation_base_fee_in_quants_per_sec()),
+                    MoveValue::U64(config.flat_registration_fee_in_quants()),
+                    MoveValue::U8(config.congestion_threshold_percentage()),
+                    MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
+                    MoveValue::U8(config.congestion_exponent()),
+                    MoveValue::U16(config.task_capacity()),
+                    MoveValue::U64(DEFAULT_CYCLE_DURATION_SECS),
+                ]
+            }
+            AutomationRegistryConfig::V2(config) => {
+                vec![
+                    MoveValue::Signer(signer_address),
+                    MoveValue::U64(config.task_duration_cap_in_secs()),
+                    MoveValue::U64(config.registry_max_gas_cap()),
+                    MoveValue::U64(config.automation_base_fee_in_quants_per_sec()),
+                    MoveValue::U64(config.flat_registration_fee_in_quants()),
+                    MoveValue::U8(config.congestion_threshold_percentage()),
+                    MoveValue::U64(config.congestion_base_fee_in_quants_per_sec()),
+                    MoveValue::U8(config.congestion_exponent()),
+                    MoveValue::U16(config.task_capacity()),
+                    MoveValue::U64(config.cycle_duration_secs()),
+                ]
+            }
+        };
         serialize_values(&arguments)
     }
 }
@@ -135,6 +244,11 @@ impl From<AutomationRegistryConfigV1> for AutomationRegistryConfig {
     }
 }
 
+impl From<AutomationRegistryConfigV2> for AutomationRegistryConfig {
+    fn from(config: AutomationRegistryConfigV2) -> Self {
+        Self::V2(config)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[repr(u8)]

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -46,7 +46,7 @@ pub use self::{
     },
     automation_registry::{
         AutomationCycleDetails, AutomationCycleEvent, AutomationCycleInfo, AutomationCycleState,
-        AutomationRegistryConfig, AutomationRegistryConfigV1, AutomationCycleTransitionState
+        AutomationRegistryConfig, AutomationRegistryConfigV1, AutomationRegistryConfigV2, AutomationCycleTransitionState
     },
     commit_history::CommitHistoryResource,
     consensus_config::{


### PR DESCRIPTION
Relates to https://github.com/Entropy-Foundation/smr-moonshot/issues/2236