### PR TITLE
[smr-moonshot 2248] Only Supra Framework missing native functions emit new status

### DIFF
--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -96,7 +96,12 @@ move-unit-test = { workspace = true }
 [features]
 default = []
 fuzzing = ["aptos-types/fuzzing"]
-testing = ["aptos-move-stdlib/testing", "aptos-crypto/fuzzing"]
+testing = [
+    "aptos-move-stdlib/testing",
+    "aptos-crypto/fuzzing",
+    "build_test_framework",
+]
+build_test_framework = []
 
 [lib]
 doctest = false

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -29,6 +29,7 @@ aptos-framework = { workspace = true }
 [features]
 default = []
 fuzzing = ["proptest", "proptest-derive"]
+test_framework = ["aptos-framework/build_test_framework"]
 
 [package.metadata.cargo-machete]
 ignored = ["proptest"]

--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -73,6 +73,9 @@ impl ReleaseTarget {
                 "aptos-token-objects",
                 Some("cached-packages/src/aptos_token_objects_sdk_builder.rs"),
             ),
+            // This is only included when the `build_test_framework` feature is enabled.
+            // It contains Move code for testing purposes only and is not meant to be
+            // included in production releases.
             #[cfg(feature = "build_test_framework")]
             ("test-framework", None),
         ];
@@ -101,8 +104,6 @@ impl ReleaseTarget {
                 (crate_dir.join(path), binding_path.unwrap_or("").to_owned())
             })
             .collect::<Vec<_>>();
-
-        // INSERT HERE
 
         ReleaseOptions {
             build_options: BuildOptions {

--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -73,6 +73,8 @@ impl ReleaseTarget {
                 "aptos-token-objects",
                 Some("cached-packages/src/aptos_token_objects_sdk_builder.rs"),
             ),
+            #[cfg(feature = "build_test_framework")]
+            ("test-framework", None),
         ];
         // Currently we don't have experimental packages only included in particular targets.
         result
@@ -99,6 +101,9 @@ impl ReleaseTarget {
                 (crate_dir.join(path), binding_path.unwrap_or("").to_owned())
             })
             .collect::<Vec<_>>();
+
+        // INSERT HERE
+
         ReleaseOptions {
             build_options: BuildOptions {
                 dev: false,

--- a/aptos-move/framework/test-framework/Move.toml
+++ b/aptos-move/framework/test-framework/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "TestFramework"
+version = "0.1.0"
+
+[addresses]
+supra_framework = "0x1"
+
+[dependencies]

--- a/aptos-move/framework/test-framework/doc/missing_natives.md
+++ b/aptos-move/framework/test-framework/doc/missing_natives.md
@@ -1,0 +1,92 @@
+
+<a id="0x1_test_missing_native"></a>
+
+# Module `0x1::test_missing_native`
+
+Test framework module for testing missing native function error handling.
+This module should never be included in production builds.
+
+
+-  [Function `missing_native`](#0x1_test_missing_native_missing_native)
+-  [Function `public_missing_native`](#0x1_test_missing_native_public_missing_native)
+-  [Function `missing_native_function`](#0x1_test_missing_native_missing_native_function)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="0x1_test_missing_native_missing_native"></a>
+
+## Function `missing_native`
+
+Native function declaration without implementation - FOR TESTING ONLY
+
+
+<pre><code><b>fun</b> <a href="missing_natives.md#0x1_test_missing_native_missing_native">missing_native</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="missing_natives.md#0x1_test_missing_native_missing_native">missing_native</a>();
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_test_missing_native_public_missing_native"></a>
+
+## Function `public_missing_native`
+
+Public native function declaration without implementation - FOR TESTING ONLY
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="missing_natives.md#0x1_test_missing_native_public_missing_native">public_missing_native</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="missing_natives.md#0x1_test_missing_native_public_missing_native">public_missing_native</a>();
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_test_missing_native_missing_native_function"></a>
+
+## Function `missing_native_function`
+
+Public wrapper function that calls the missing native
+This function is used to trigger the missing native function error during tests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="missing_natives.md#0x1_test_missing_native_missing_native_function">missing_native_function</a>(framework: &signer)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="missing_natives.md#0x1_test_missing_native_missing_native_function">missing_native_function</a>(framework: &signer) {
+    <a href="missing_natives.md#0x1_test_missing_native_missing_native">missing_native</a>();
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/test-framework/doc/overview.md
+++ b/aptos-move/framework/test-framework/doc/overview.md
@@ -1,0 +1,18 @@
+
+<a id="@Supra_Framework_0"></a>
+
+# Supra Framework
+
+
+This is the reference documentation of the Test Supra framework. This should never be included in the production framework.
+
+
+<a id="@Index_1"></a>
+
+## Index
+
+
+-  [`0x1::test_missing_native`](missing_natives.md#0x1_test_missing_native)
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/test-framework/doc/overview.md
+++ b/aptos-move/framework/test-framework/doc/overview.md
@@ -1,10 +1,11 @@
 
-<a id="@Supra_Framework_0"></a>
+<a id="@Test_Supra_Framework_0"></a>
 
-# Supra Framework
+# Test Supra Framework
 
 
-This is the reference documentation of the Test Supra framework. This should never be included in the production framework.
+This is the reference documentation of the Test Supra framework.
+This defines modules used for testing. It should never be deployed to production.
 
 
 <a id="@Index_1"></a>

--- a/aptos-move/framework/test-framework/doc_template/overview.md
+++ b/aptos-move/framework/test-framework/doc_template/overview.md
@@ -1,0 +1,8 @@
+# Test Supra Framework
+
+This is the reference documentation of the Test Supra framework.
+This defines modules used for testing. It should never be deployed to production.
+
+## Index
+
+> {{move-index}}

--- a/aptos-move/framework/test-framework/doc_template/references.md
+++ b/aptos-move/framework/test-framework/doc_template/references.md
@@ -1,0 +1,1 @@
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/test-framework/sources/missing_natives.move
+++ b/aptos-move/framework/test-framework/sources/missing_natives.move
@@ -1,5 +1,13 @@
+/// Test framework module for testing missing native function error handling.
+/// This module should never be included in production builds.
 module supra_framework::test_missing_native {
+    /// Native function declaration without implementation - FOR TESTING ONLY
     native fun missing_native();
+    /// Public native function declaration without implementation - FOR TESTING ONLY
+    public native fun public_missing_native();
+
+    /// Public wrapper function that calls the missing native
+    /// This function is used to trigger the missing native function error during tests.
     public fun missing_native_function(framework: &signer) {
         missing_native();
     }

--- a/aptos-move/framework/test-framework/sources/missing_natives.move
+++ b/aptos-move/framework/test-framework/sources/missing_natives.move
@@ -1,0 +1,6 @@
+module supra_framework::test_missing_native {
+    native fun missing_native();
+    public fun missing_native_function(framework: &signer) {
+        missing_native();
+    }
+}

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -15,7 +15,11 @@ use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{AbilitySet, Bytecode, CompiledModule, FunctionDefinitionIndex, Visibility},
 };
-use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{ModuleId, CORE_CODE_ADDRESS},
+    vm_status::StatusCode,
+};
 use move_vm_types::loaded_data::{
     runtime_access_specifier::AccessSpecifier,
     runtime_types::{StructIdentifier, Type},
@@ -260,8 +264,17 @@ impl Function {
 
     pub(crate) fn get_native(&self) -> PartialVMResult<&UnboxedNativeFunction> {
         self.native.as_deref().ok_or_else(|| {
-            PartialVMError::new(StatusCode::MISSING_NATIVE_FUNCTION)
-                .with_message(format!("Missing Native Function `{}`", self.name))
+            let status_code = match &self.scope {
+                Scope::Module(module_id) if module_id.address() == &CORE_CODE_ADDRESS => {
+                    StatusCode::MISSING_NATIVE_FUNCTION
+                },
+                _ => StatusCode::MISSING_DEPENDENCY,
+            };
+
+            PartialVMError::new(status_code).with_message(format!(
+                "Missing Native Function `{}` at {:?}",
+                self.name, self.scope
+            ))
         })
     }
 }

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -265,9 +265,14 @@ impl Function {
     pub(crate) fn get_native(&self) -> PartialVMResult<&UnboxedNativeFunction> {
         self.native.as_deref().ok_or_else(|| {
             let status_code = match &self.scope {
-                Scope::Module(module_id) if module_id.address() == &CORE_CODE_ADDRESS => {
+                Scope::Module(module_id) if module_id.address() == &CORE_CODE_ADDRESS =>
+                // This status code should only be returned for natives in the `0x1` address.
+                // Validator should be terminated if this happens.
+                {
                     StatusCode::MISSING_NATIVE_FUNCTION
                 },
+                // At the moment non-framework packages can define native functions.
+                // If those functions don't exist the transaction will fail, but validator will continue to run.
                 _ => StatusCode::MISSING_DEPENDENCY,
             };
 


### PR DESCRIPTION
Solves [#2248](https://github.com/Entropy-Foundation/smr-moonshot/issues/2248).

A missing native function now emits the related new status code only if it was defined by the  "0x1" address.

I added a separate `test_missing_native` module to be able to test this, only included if a Rust feature flag is present.
