### PR TITLE
Issue 2291

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
  "coset",
  "criterion",
  "derivative",
+ "derive-getters",
  "fixed",
  "fxhash",
  "hashbrown 0.14.3",
@@ -6917,6 +6918,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,6 +545,7 @@ debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
 derivation-path = "0.2.0"
 derive_builder = "0.20.0"
+derive-getters = "0.5.0"
 determinator = "0.12.0"
 derive_more = "0.99.11"
 diesel = "2.1"

--- a/third_party/move/move-core/types/src/move_resource.rs
+++ b/third_party/move/move-core/types/src/move_resource.rs
@@ -2,8 +2,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::OnceLock;
-
 use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -35,11 +33,6 @@ pub trait MoveStructType {
             module: Self::module_identifier(),
             type_args: Self::type_args(),
         }
-    }
-
-    fn cached_type_tag() -> &'static TypeTag {
-        static TAG: OnceLock<TypeTag> = OnceLock::new();
-        TAG.get_or_init(|| TypeTag::Struct(Box::new(Self::struct_tag())))
     }
 }
 

--- a/third_party/move/move-core/types/src/move_resource.rs
+++ b/third_party/move/move-core/types/src/move_resource.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::OnceLock;
+
 use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -33,6 +35,11 @@ pub trait MoveStructType {
             module: Self::module_identifier(),
             type_args: Self::type_args(),
         }
+    }
+
+    fn cached_type_tag() -> &'static TypeTag {
+        static TAG: OnceLock<TypeTag> = OnceLock::new();
+        TAG.get_or_init(|| TypeTag::Struct(Box::new(Self::struct_tag())))
     }
 }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -28,6 +28,7 @@ arr_macro = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+derive-getters = { workspace = true }
 fixed = { workspace = true }
 fxhash = { workspace = true }
 hashbrown = { workspace = true }

--- a/types/src/account_config/events/coin.rs
+++ b/types/src/account_config/events/coin.rs
@@ -1,0 +1,82 @@
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType, parser::parse_type_tag
+};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+pub static COIN_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(CoinWithdraw::struct_tag())));
+pub static COIN_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(CoinDeposit::struct_tag())));
+
+pub static COIN_LEGACY_DEPOSIT_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
+    parse_type_tag("0x1::coin::DepositEvent")
+        .expect("parse type tag for 0x1::coin::DepositEvent should succeed")
+});
+pub static COIN_LEGACY_WITHDRAW_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
+    parse_type_tag("0x1::coin::WithdrawEvent")
+        .expect("parse type tag for 0x1::coin::WithdrawEvent should succeed")
+});
+
+/// Module event emitted when some amount of a coin is deposited into an account.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CoinDeposit {
+    coin_type: String,
+    account: AccountAddress,
+    amount: u64,
+}
+
+/// Module event emitted when some amount of a coin is withdrawn from an account.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CoinWithdraw {
+    coin_type: String,
+    account: AccountAddress,
+    amount: u64,
+}
+
+pub trait MoveEventAccountAddr {
+    fn account_address(&self) -> AccountAddress;
+}
+
+impl CoinDeposit {
+    pub fn coin_type(&self) -> &str {
+        &self.coin_type
+    }
+
+    /// Get the amount sent or received
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+}
+
+impl CoinWithdraw {
+    pub fn coin_type(&self) -> &str {
+        &self.coin_type
+    }
+
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+}
+
+impl MoveEventAccountAddr for CoinDeposit {
+    fn account_address(&self) -> AccountAddress {
+        self.account
+    }
+}
+
+impl MoveEventAccountAddr for CoinWithdraw {
+    fn account_address(&self) -> AccountAddress {
+        self.account
+    }
+}
+
+impl MoveStructType for CoinWithdraw {
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CoinWithdraw");
+}
+
+impl MoveStructType for CoinDeposit {
+    const MODULE_NAME: &'static IdentStr = ident_str!("coin");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("CoinDeposit");
+}

--- a/types/src/account_config/events/coin.rs
+++ b/types/src/account_config/events/coin.rs
@@ -3,7 +3,7 @@ use move_core_types::{
 };
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-
+use derive_getters::Getters;
 pub static COIN_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
     Lazy::new(|| TypeTag::Struct(Box::new(CoinWithdraw::struct_tag())));
 pub static COIN_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
@@ -19,7 +19,7 @@ pub static COIN_LEGACY_WITHDRAW_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
 });
 
 /// Module event emitted when some amount of a coin is deposited into an account.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Getters)]
 pub struct CoinDeposit {
     coin_type: String,
     account: AccountAddress,
@@ -27,48 +27,11 @@ pub struct CoinDeposit {
 }
 
 /// Module event emitted when some amount of a coin is withdrawn from an account.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Getters)]
 pub struct CoinWithdraw {
     coin_type: String,
     account: AccountAddress,
     amount: u64,
-}
-
-pub trait MoveEventAccountAddr {
-    fn account_address(&self) -> AccountAddress;
-}
-
-impl CoinDeposit {
-    pub fn coin_type(&self) -> &str {
-        &self.coin_type
-    }
-
-    /// Get the amount sent or received
-    pub fn amount(&self) -> u64 {
-        self.amount
-    }
-}
-
-impl CoinWithdraw {
-    pub fn coin_type(&self) -> &str {
-        &self.coin_type
-    }
-
-    pub fn amount(&self) -> u64 {
-        self.amount
-    }
-}
-
-impl MoveEventAccountAddr for CoinDeposit {
-    fn account_address(&self) -> AccountAddress {
-        self.account
-    }
-}
-
-impl MoveEventAccountAddr for CoinWithdraw {
-    fn account_address(&self) -> AccountAddress {
-        self.account
-    }
 }
 
 impl MoveStructType for CoinWithdraw {

--- a/types/src/account_config/events/coin.rs
+++ b/types/src/account_config/events/coin.rs
@@ -1,22 +1,9 @@
-use move_core_types::{
-    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType, parser::parse_type_tag
-};
-use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 use derive_getters::Getters;
-pub static COIN_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
-    Lazy::new(|| TypeTag::Struct(Box::new(CoinWithdraw::struct_tag())));
-pub static COIN_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
-    Lazy::new(|| TypeTag::Struct(Box::new(CoinDeposit::struct_tag())));
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, move_resource::MoveStructType
+};
+use serde::{Deserialize, Serialize};
 
-pub static COIN_LEGACY_DEPOSIT_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
-    parse_type_tag("0x1::coin::DepositEvent")
-        .expect("parse type tag for 0x1::coin::DepositEvent should succeed")
-});
-pub static COIN_LEGACY_WITHDRAW_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
-    parse_type_tag("0x1::coin::WithdrawEvent")
-        .expect("parse type tag for 0x1::coin::WithdrawEvent should succeed")
-});
 
 /// Module event emitted when some amount of a coin is deposited into an account.
 #[derive(Debug, Serialize, Deserialize, Getters)]

--- a/types/src/account_config/events/coin.rs
+++ b/types/src/account_config/events/coin.rs
@@ -1,9 +1,22 @@
-use derive_getters::Getters;
 use move_core_types::{
-    account_address::AccountAddress, ident_str, identifier::IdentStr, move_resource::MoveStructType
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType, parser::parse_type_tag
 };
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use derive_getters::Getters;
+pub static COIN_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(CoinWithdraw::struct_tag())));
+pub static COIN_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(CoinDeposit::struct_tag())));
 
+pub static COIN_LEGACY_DEPOSIT_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
+    parse_type_tag("0x1::coin::DepositEvent")
+        .expect("parse type tag for 0x1::coin::DepositEvent should succeed")
+});
+pub static COIN_LEGACY_WITHDRAW_EVENT_V1: Lazy<TypeTag> = Lazy::new(|| {
+    parse_type_tag("0x1::coin::WithdrawEvent")
+        .expect("parse type tag for 0x1::coin::WithdrawEvent should succeed")
+});
 
 /// Module event emitted when some amount of a coin is deposited into an account.
 #[derive(Debug, Serialize, Deserialize, Getters)]

--- a/types/src/account_config/events/fa.rs
+++ b/types/src/account_config/events/fa.rs
@@ -1,0 +1,60 @@
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+use crate::account_config::MoveEventAccountAddr;
+
+pub static FA_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(FaWithdraw::struct_tag())));
+pub static FA_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(FaDeposit::struct_tag())));
+
+/// Represents a Deposit event for a Fungible Asset.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FaDeposit {
+    store: AccountAddress,
+    amount: u64,
+}
+
+/// Represents a Withdraw event for a Fungible Asset.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FaWithdraw {
+    store: AccountAddress,
+    amount: u64,
+}
+
+impl FaDeposit {
+    /// Get the deposited amount.
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+}
+
+impl MoveStructType for FaDeposit {
+    const MODULE_NAME: &'static IdentStr = ident_str!("fungible_asset");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Deposit");
+}
+
+impl MoveEventAccountAddr for FaDeposit {
+    fn account_address(&self) -> AccountAddress {
+        self.store
+    }
+}
+
+impl FaWithdraw {
+    /// Get the withdrawn amount.
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+}
+
+impl MoveStructType for FaWithdraw {
+    const MODULE_NAME: &'static IdentStr = ident_str!("fungible_asset");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Withdraw");
+}
+
+impl MoveEventAccountAddr for FaWithdraw {
+    fn account_address(&self) -> AccountAddress {
+        self.store
+    }
+}

--- a/types/src/account_config/events/fa.rs
+++ b/types/src/account_config/events/fa.rs
@@ -1,12 +1,6 @@
 use derive_getters::Getters;
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType};
-use once_cell::sync::Lazy;
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr, move_resource::MoveStructType};
 use serde::{Deserialize, Serialize};
-
-pub static FA_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
-    Lazy::new(|| TypeTag::Struct(Box::new(FaWithdraw::struct_tag())));
-pub static FA_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
-    Lazy::new(|| TypeTag::Struct(Box::new(FaDeposit::struct_tag())));
 
 /// Represents a Deposit event for a Fungible Asset.
 #[derive(Debug, Serialize, Deserialize, Getters)]

--- a/types/src/account_config/events/fa.rs
+++ b/types/src/account_config/events/fa.rs
@@ -1,6 +1,12 @@
 use derive_getters::Getters;
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr, move_resource::MoveStructType};
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+
+pub static FA_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(FaWithdraw::struct_tag())));
+pub static FA_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(FaDeposit::struct_tag())));
 
 /// Represents a Deposit event for a Fungible Asset.
 #[derive(Debug, Serialize, Deserialize, Getters)]

--- a/types/src/account_config/events/fa.rs
+++ b/types/src/account_config/events/fa.rs
@@ -1,8 +1,7 @@
+use derive_getters::Getters;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag, move_resource::MoveStructType};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-
-use crate::account_config::MoveEventAccountAddr;
 
 pub static FA_WITHDRAW_EVENT_TYPE_TAG: Lazy<TypeTag> =
     Lazy::new(|| TypeTag::Struct(Box::new(FaWithdraw::struct_tag())));
@@ -10,24 +9,17 @@ pub static FA_DEPOSIT_EVENT_TYPE_TAG: Lazy<TypeTag> =
     Lazy::new(|| TypeTag::Struct(Box::new(FaDeposit::struct_tag())));
 
 /// Represents a Deposit event for a Fungible Asset.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Getters)]
 pub struct FaDeposit {
     store: AccountAddress,
     amount: u64,
 }
 
 /// Represents a Withdraw event for a Fungible Asset.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Getters)]
 pub struct FaWithdraw {
     store: AccountAddress,
     amount: u64,
-}
-
-impl FaDeposit {
-    /// Get the deposited amount.
-    pub fn amount(&self) -> u64 {
-        self.amount
-    }
 }
 
 impl MoveStructType for FaDeposit {
@@ -35,26 +27,7 @@ impl MoveStructType for FaDeposit {
     const STRUCT_NAME: &'static IdentStr = ident_str!("Deposit");
 }
 
-impl MoveEventAccountAddr for FaDeposit {
-    fn account_address(&self) -> AccountAddress {
-        self.store
-    }
-}
-
-impl FaWithdraw {
-    /// Get the withdrawn amount.
-    pub fn amount(&self) -> u64 {
-        self.amount
-    }
-}
-
 impl MoveStructType for FaWithdraw {
     const MODULE_NAME: &'static IdentStr = ident_str!("fungible_asset");
     const STRUCT_NAME: &'static IdentStr = ident_str!("Withdraw");
-}
-
-impl MoveEventAccountAddr for FaWithdraw {
-    fn account_address(&self) -> AccountAddress {
-        self.store
-    }
 }

--- a/types/src/account_config/events/mod.rs
+++ b/types/src/account_config/events/mod.rs
@@ -6,8 +6,12 @@ pub mod deposit;
 pub mod new_block;
 pub mod new_epoch;
 pub mod withdraw;
+pub mod coin;
+pub mod fa;
 
 pub use deposit::*;
 pub use new_block::*;
 pub use new_epoch::*;
 pub use withdraw::*;
+pub use coin::*;
+pub use fa::*;


### PR DESCRIPTION
Based on the issue [here](https://github.com/Entropy-Foundation/smr-moonshot/issues/2291), it's required to move Coin and FA event types to Aptos Core repo.