### PR TITLE
 [smr-moonshot Issue 2268] Identity to delegation pool address 

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -334,6 +334,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::SupraCountFailedProposals => {
                 AptosFeatureFlag::SUPRA_COUNT_FAILED_PROPOSALS
             },
+            FeatureFlag::SupraRLPEncode => AptosFeatureFlag::SUPRA_RLP_ENCODE,
             FeatureFlag::SupraDelegationPoolIdentity => {
                 AptosFeatureFlag::SUPRA_DELEGATION_POOL_IDENTITY
             },

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -128,6 +128,7 @@ pub enum FeatureFlag {
     SupraAutomationTaskSync,
     SupraCountFailedProposals,
     SupraRLPEncode,
+    SupraDelegationPoolIdentity,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -333,7 +334,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::SupraCountFailedProposals => {
                 AptosFeatureFlag::SUPRA_COUNT_FAILED_PROPOSALS
             },
-            FeatureFlag::SupraRLPEncode => AptosFeatureFlag::SUPRA_RLP_ENCODE,
+            FeatureFlag::SupraDelegationPoolIdentity => {
+                AptosFeatureFlag::SUPRA_DELEGATION_POOL_IDENTITY
+            },
         }
     }
 }
@@ -469,6 +472,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::SupraCountFailedProposals
             },
             AptosFeatureFlag::SUPRA_RLP_ENCODE => FeatureFlag::SupraRLPEncode,
+            AptosFeatureFlag::SUPRA_DELEGATION_POOL_IDENTITY => {
+                FeatureFlag::SupraDelegationPoolIdentity
+            },
         }
     }
 }

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -750,7 +750,20 @@ module std::features {
     public fun supra_rlp_enabled(): bool acquires Features {
         is_enabled(SUPRA_RLP_ENCODE)
     }
-    
+
+    /// Whether using delegation pool as node identity feature is enabled.
+    ///
+    /// Lifetime: transient
+    const SUPRA_DELEGATION_POOL_IDENTITY: u64 = 95;
+
+    public fun get_supra_delegation_pool_identity_feature(): u64 {
+        SUPRA_DELEGATION_POOL_IDENTITY
+    }
+
+    public fun supra_delegation_pool_identity_enabled(): bool acquires Features {
+        is_enabled(SUPRA_DELEGATION_POOL_IDENTITY)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -753,7 +753,7 @@ module std::features {
 
     /// Whether using delegation pool as node identity feature is enabled.
     ///
-    /// Lifetime: transient
+    /// Lifetime: permanent
     const SUPRA_DELEGATION_POOL_IDENTITY: u64 = 95;
 
     public fun get_supra_delegation_pool_identity_feature(): u64 {
@@ -762,6 +762,7 @@ module std::features {
 
     public fun supra_delegation_pool_identity_enabled(): bool acquires Features {
         is_enabled(SUPRA_DELEGATION_POOL_IDENTITY)
+        // We could update supra_delegation_pool_identity_enabled to always return true after the feature has been rolled out.
     }
 
     // ============================================================================================

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -95,6 +95,7 @@ pub enum FeatureFlag {
     SUPRA_AUTOMATION_TASK_SYNC = 92,
     SUPRA_COUNT_FAILED_PROPOSALS = 93,
     SUPRA_RLP_ENCODE = 94,
+    SUPRA_DELEGATION_POOL_IDENTITY = 95,
 }
 
 impl FeatureFlag {
@@ -165,6 +166,7 @@ impl FeatureFlag {
             FeatureFlag::PRIVATE_POLL,
             FeatureFlag::SUPRA_AUTOMATION_TASK_SYNC,
             FeatureFlag::SUPRA_COUNT_FAILED_PROPOSALS,
+            FeatureFlag::SUPRA_DELEGATION_POOL_IDENTITY,
         ]
     }
 }


### PR DESCRIPTION
This PR adds a feature gate for using the delegation pool as node identity. 