### PR TITLE
Updated gas-less automated transaction gas fee handling

### DIFF
--- a/aptos-move/aptos-vm/src/automation_registry_transaction_processor.rs
+++ b/aptos-move/aptos-vm/src/automation_registry_transaction_processor.rs
@@ -94,6 +94,7 @@ impl<'m> AutomationRegistryTransactionProcessor<'m> {
         SYSTEM_TRANSACTIONS_EXECUTED.inc();
 
         let fee_statement = AptosVM::fee_statement_from_gas_meter_for_gas(max_gas_amount.into(), &gas_meter, 0);
+
         match result {
             Ok(_) => {
                 let output = get_system_transaction_output(

--- a/aptos-move/aptos-vm/src/system_module_names.rs
+++ b/aptos-move/aptos-vm/src/system_module_names.rs
@@ -69,4 +69,4 @@ pub static TRANSACTION_FEE_MODULE: Lazy<ModuleId> = Lazy::new(|| {
 });
 
 pub const EMIT_FEE_STATEMENT: &IdentStr = ident_str!("emit_fee_statement");
-pub const EMIT_FEE_ASSESSMENT: &IdentStr = ident_str!("emit_fee_assessment");
+pub const EMIT_GAS_ASSESSMENT: &IdentStr = ident_str!("emit_gas_assessment");

--- a/aptos-move/aptos-vm/src/system_module_names.rs
+++ b/aptos-move/aptos-vm/src/system_module_names.rs
@@ -69,3 +69,4 @@ pub static TRANSACTION_FEE_MODULE: Lazy<ModuleId> = Lazy::new(|| {
 });
 
 pub const EMIT_FEE_STATEMENT: &IdentStr = ident_str!("emit_fee_statement");
+pub const EMIT_FEE_ASSESSMENT: &IdentStr = ident_str!("emit_fee_assessment");

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -31,6 +31,7 @@ use move_vm_runtime::{logging::expect_no_verification_errors, module_traversal::
 use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
 use aptos_types::transaction::automation::AutomationTaskType;
+use crate::system_module_names::EMIT_FEE_ASSESSMENT;
 
 pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
     Lazy::new(|| TransactionValidation {
@@ -383,7 +384,14 @@ fn run_automated_txn_epilogue(
 
     // Emit the FeeStatement event
     if features.is_emit_fee_statement_enabled() {
-        emit_fee_statement(session, fee_statement, traversal_context)?;
+        match task_type {
+            AutomationTaskType::User => {
+                emit_fee_statement(session, fee_statement, traversal_context)?;
+            }
+            AutomationTaskType::System => {
+                emit_as_fee_assessment(session, fee_statement, traversal_context)?;
+            }
+        }
     }
 
     maybe_raise_injected_error(InjectedError::EndOfRunEpilogue)?;
@@ -400,6 +408,23 @@ fn emit_fee_statement(
         .execute_function_bypass_visibility(
             &TRANSACTION_FEE_MODULE,
             EMIT_FEE_STATEMENT,
+            vec![],
+            vec![bcs::to_bytes(&fee_statement).expect("Failed to serialize fee statement")],
+            &mut UnmeteredGasMeter,
+            traversal_context,
+        )
+        .map(|_return_vals| ())
+}
+
+fn emit_as_fee_assessment(
+    session: &mut SessionExt,
+    fee_statement: FeeStatement,
+    traversal_context: &mut TraversalContext,
+) -> VMResult<()> {
+    session
+        .execute_function_bypass_visibility(
+            &TRANSACTION_FEE_MODULE,
+            EMIT_FEE_ASSESSMENT,
             vec![],
             vec![bcs::to_bytes(&fee_statement).expect("Failed to serialize fee statement")],
             &mut UnmeteredGasMeter,

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -31,7 +31,7 @@ use move_vm_runtime::{logging::expect_no_verification_errors, module_traversal::
 use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
 use aptos_types::transaction::automation::AutomationTaskType;
-use crate::system_module_names::EMIT_FEE_ASSESSMENT;
+use crate::system_module_names::EMIT_GAS_ASSESSMENT;
 
 pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
     Lazy::new(|| TransactionValidation {
@@ -389,7 +389,7 @@ fn run_automated_txn_epilogue(
                 emit_fee_statement(session, fee_statement, traversal_context)?;
             }
             AutomationTaskType::System => {
-                emit_as_fee_assessment(session, fee_statement, traversal_context)?;
+                emit_as_gas_assessment(session, fee_statement, traversal_context)?;
             }
         }
     }
@@ -416,7 +416,7 @@ fn emit_fee_statement(
         .map(|_return_vals| ())
 }
 
-fn emit_as_fee_assessment(
+fn emit_as_gas_assessment(
     session: &mut SessionExt,
     fee_statement: FeeStatement,
     traversal_context: &mut TraversalContext,
@@ -424,7 +424,7 @@ fn emit_as_fee_assessment(
     session
         .execute_function_bypass_visibility(
             &TRANSACTION_FEE_MODULE,
-            EMIT_FEE_ASSESSMENT,
+            EMIT_GAS_ASSESSMENT,
             vec![],
             vec![bcs::to_bytes(&fee_statement).expect("Failed to serialize fee statement")],
             &mut UnmeteredGasMeter,

--- a/aptos-move/framework/supra-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_fee.md
@@ -261,8 +261,9 @@ This is meant to emitted as a module event.
 
 ## Struct `GasAssessment`
 
-Breakdown of the assessed fee charges for the gas-less transactions.
-Holds the same information as FeeStatement for charged transactions.
+Breakdown of the gas consumed by gas-fee-less (i.e. gasless) transactions.
+The consumed amounts serve as a record of the workload of the transaction and
+are not charged to the gas payer's account.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]

--- a/aptos-move/framework/supra-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_fee.md
@@ -11,6 +11,7 @@ This module provides an interface to burn or collect and redistribute transactio
 -  [Resource `SupraCoinMintCapability`](#0x1_transaction_fee_SupraCoinMintCapability)
 -  [Resource `CollectedFeesPerBlock`](#0x1_transaction_fee_CollectedFeesPerBlock)
 -  [Struct `FeeStatement`](#0x1_transaction_fee_FeeStatement)
+-  [Struct `FeeAssessment`](#0x1_transaction_fee_FeeAssessment)
 -  [Constants](#@Constants_0)
 -  [Function `initialize_fee_collection_and_distribution`](#0x1_transaction_fee_initialize_fee_collection_and_distribution)
 -  [Function `is_fees_collection_enabled`](#0x1_transaction_fee_is_fees_collection_enabled)
@@ -26,6 +27,7 @@ This module provides an interface to burn or collect and redistribute transactio
 -  [Function `store_supra_coin_mint_cap`](#0x1_transaction_fee_store_supra_coin_mint_cap)
 -  [Function `initialize_storage_refund`](#0x1_transaction_fee_initialize_storage_refund)
 -  [Function `emit_fee_statement`](#0x1_transaction_fee_emit_fee_statement)
+-  [Function `emit_fee_assessment`](#0x1_transaction_fee_emit_fee_assessment)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -225,6 +227,60 @@ This is meant to emitted as a module event.
 </dt>
 <dd>
  Total gas charge.
+</dd>
+<dt>
+<code>execution_gas_units: u64</code>
+</dt>
+<dd>
+ Execution gas charge.
+</dd>
+<dt>
+<code>io_gas_units: u64</code>
+</dt>
+<dd>
+ IO gas charge.
+</dd>
+<dt>
+<code>storage_fee_quants: u64</code>
+</dt>
+<dd>
+ Storage fee charge.
+</dd>
+<dt>
+<code>storage_fee_refund_quants: u64</code>
+</dt>
+<dd>
+ Storage fee refund.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_transaction_fee_FeeAssessment"></a>
+
+## Struct `FeeAssessment`
+
+Breakdown of the assessed fee charges for the gas-less transactions.
+Holds the same information as FeeStatement for charged transactions.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="transaction_fee.md#0x1_transaction_fee_FeeAssessment">FeeAssessment</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>total_assessed_gas_units: u64</code>
+</dt>
+<dd>
+ Total gas assessed for transaction execution.
 </dd>
 <dt>
 <code>execution_gas_units: u64</code>
@@ -771,6 +827,46 @@ Only called during genesis.
 
 <pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_fee_statement">emit_fee_statement</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">FeeStatement</a>) {
     <a href="event.md#0x1_event_emit">event::emit</a>(fee_statement)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_transaction_fee_emit_fee_assessment"></a>
+
+## Function `emit_fee_assessment`
+
+
+
+<pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_fee_assessment">emit_fee_assessment</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">transaction_fee::FeeStatement</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_fee_assessment">emit_fee_assessment</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">FeeStatement</a>) {
+    <b>let</b> <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">FeeStatement</a> {
+        total_charge_gas_units,
+        execution_gas_units,
+        io_gas_units,
+        storage_fee_quants,
+        storage_fee_refund_quants,
+
+    } = fee_statement;
+    <b>let</b> fee_assesment = <a href="transaction_fee.md#0x1_transaction_fee_FeeAssessment">FeeAssessment</a> {
+        total_assessed_gas_units: total_charge_gas_units,
+        execution_gas_units,
+        io_gas_units,
+        storage_fee_quants,
+        storage_fee_refund_quants,
+
+    };
+    <a href="event.md#0x1_event_emit">event::emit</a>(fee_assesment)
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_fee.md
@@ -11,7 +11,7 @@ This module provides an interface to burn or collect and redistribute transactio
 -  [Resource `SupraCoinMintCapability`](#0x1_transaction_fee_SupraCoinMintCapability)
 -  [Resource `CollectedFeesPerBlock`](#0x1_transaction_fee_CollectedFeesPerBlock)
 -  [Struct `FeeStatement`](#0x1_transaction_fee_FeeStatement)
--  [Struct `FeeAssessment`](#0x1_transaction_fee_FeeAssessment)
+-  [Struct `GasAssessment`](#0x1_transaction_fee_GasAssessment)
 -  [Constants](#@Constants_0)
 -  [Function `initialize_fee_collection_and_distribution`](#0x1_transaction_fee_initialize_fee_collection_and_distribution)
 -  [Function `is_fees_collection_enabled`](#0x1_transaction_fee_is_fees_collection_enabled)
@@ -27,7 +27,7 @@ This module provides an interface to burn or collect and redistribute transactio
 -  [Function `store_supra_coin_mint_cap`](#0x1_transaction_fee_store_supra_coin_mint_cap)
 -  [Function `initialize_storage_refund`](#0x1_transaction_fee_initialize_storage_refund)
 -  [Function `emit_fee_statement`](#0x1_transaction_fee_emit_fee_statement)
--  [Function `emit_fee_assessment`](#0x1_transaction_fee_emit_fee_assessment)
+-  [Function `emit_gas_assessment`](#0x1_transaction_fee_emit_gas_assessment)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -257,16 +257,16 @@ This is meant to emitted as a module event.
 
 </details>
 
-<a id="0x1_transaction_fee_FeeAssessment"></a>
+<a id="0x1_transaction_fee_GasAssessment"></a>
 
-## Struct `FeeAssessment`
+## Struct `GasAssessment`
 
 Breakdown of the assessed fee charges for the gas-less transactions.
 Holds the same information as FeeStatement for charged transactions.
 
 
 <pre><code>#[<a href="event.md#0x1_event">event</a>]
-<b>struct</b> <a href="transaction_fee.md#0x1_transaction_fee_FeeAssessment">FeeAssessment</a> <b>has</b> drop, store
+<b>struct</b> <a href="transaction_fee.md#0x1_transaction_fee_GasAssessment">GasAssessment</a> <b>has</b> drop, store
 </code></pre>
 
 
@@ -834,13 +834,13 @@ Only called during genesis.
 
 </details>
 
-<a id="0x1_transaction_fee_emit_fee_assessment"></a>
+<a id="0x1_transaction_fee_emit_gas_assessment"></a>
 
-## Function `emit_fee_assessment`
+## Function `emit_gas_assessment`
 
 
 
-<pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_fee_assessment">emit_fee_assessment</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">transaction_fee::FeeStatement</a>)
+<pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_gas_assessment">emit_gas_assessment</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">transaction_fee::FeeStatement</a>)
 </code></pre>
 
 
@@ -849,7 +849,7 @@ Only called during genesis.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_fee_assessment">emit_fee_assessment</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">FeeStatement</a>) {
+<pre><code><b>fun</b> <a href="transaction_fee.md#0x1_transaction_fee_emit_gas_assessment">emit_gas_assessment</a>(fee_statement: <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">FeeStatement</a>) {
     <b>let</b> <a href="transaction_fee.md#0x1_transaction_fee_FeeStatement">FeeStatement</a> {
         total_charge_gas_units,
         execution_gas_units,
@@ -858,7 +858,7 @@ Only called during genesis.
         storage_fee_refund_quants,
 
     } = fee_statement;
-    <b>let</b> fee_assesment = <a href="transaction_fee.md#0x1_transaction_fee_FeeAssessment">FeeAssessment</a> {
+    <b>let</b> gas_assesment = <a href="transaction_fee.md#0x1_transaction_fee_GasAssessment">GasAssessment</a> {
         total_assessed_gas_units: total_charge_gas_units,
         execution_gas_units,
         io_gas_units,
@@ -866,7 +866,7 @@ Only called during genesis.
         storage_fee_refund_quants,
 
     };
-    <a href="event.md#0x1_event_emit">event::emit</a>(fee_assesment)
+    <a href="event.md#0x1_event_emit">event::emit</a>(gas_assesment)
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_validation.md
@@ -136,6 +136,25 @@ Transaction exceeded its allocated max gas
 
 
 
+<a id="0x1_transaction_validation_GST"></a>
+
+
+
+<pre><code><b>const</b> <a href="transaction_validation.md#0x1_transaction_validation_GST">GST</a>: u8 = 2;
+</code></pre>
+
+
+
+<a id="0x1_transaction_validation_UST"></a>
+
+Constants representing automation task type. Should match the values in scope of automation_registry module.
+
+
+<pre><code><b>const</b> <a href="transaction_validation.md#0x1_transaction_validation_UST">UST</a>: u8 = 1;
+</code></pre>
+
+
+
 <a id="0x1_transaction_validation_PROLOGUE_EACCOUNT_DOES_NOT_EXIST"></a>
 
 
@@ -444,8 +463,7 @@ V1 to V2 on active chains
     txn_expiration_time: u64,
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
 )  {
-    <b>let</b> ust:u8 = 1;
-    <a href="transaction_validation.md#0x1_transaction_validation_automated_transaction_prologue_v2">automated_transaction_prologue_v2</a>(sender, task_index, txn_gas_price, txn_max_gas_units, txn_expiration_time, <a href="chain_id.md#0x1_chain_id">chain_id</a>, ust);
+    <a href="transaction_validation.md#0x1_transaction_validation_automated_transaction_prologue_v2">automated_transaction_prologue_v2</a>(sender, task_index, txn_gas_price, txn_max_gas_units, txn_expiration_time, <a href="chain_id.md#0x1_chain_id">chain_id</a>, <a href="transaction_validation.md#0x1_transaction_validation_UST">UST</a>);
 }
 </code></pre>
 
@@ -486,9 +504,9 @@ V1 to V2 on active chains
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>),
     );
 
-    // Task is not gas-less/GST,
-    // gas-less automated transactions are not charged so no need <b>to</b> check eligability <b>to</b> pay the gas-fee
-    <b>if</b> (task_type != 2) {
+    // Task is not gas-less/<a href="transaction_validation.md#0x1_transaction_validation_GST">GST</a>,
+    // gas-less automated transactions are not charged so no need <b>to</b> check eligability <b>to</b> pay the gas-fee.
+    <b>if</b> (task_type != <a href="transaction_validation.md#0x1_transaction_validation_GST">GST</a>) {
         <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 
         <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {

--- a/aptos-move/framework/supra-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_validation.md
@@ -486,18 +486,22 @@ V1 to V2 on active chains
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>),
     );
 
-    <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
+    // Task is not gas-less/GST,
+    // gas-less automated transactions are not charged so no need <b>to</b> check eligability <b>to</b> pay the gas-fee
+    <b>if</b> (task_type != 2) {
+        <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
 
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {
-        <b>assert</b>!(
-            <a href="supra_account.md#0x1_supra_account_is_fungible_balance_at_least">supra_account::is_fungible_balance_at_least</a>(gas_payer, max_transaction_fee),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
-        );
-    } <b>else</b> {
-        <b>assert</b>!(
-            <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;SupraCoin&gt;(gas_payer, max_transaction_fee),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
-        );
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {
+            <b>assert</b>!(
+                <a href="supra_account.md#0x1_supra_account_is_fungible_balance_at_least">supra_account::is_fungible_balance_at_least</a>(gas_payer, max_transaction_fee),
+                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
+            );
+        } <b>else</b> {
+            <b>assert</b>!(
+                <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;SupraCoin&gt;(gas_payer, max_transaction_fee),
+                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
+            );
+        };
     };
     <b>assert</b>!(<a href="automation_registry.md#0x1_automation_registry_has_sender_active_task_with_id_and_type">automation_registry::has_sender_active_task_with_id_and_type</a>(address_of(&sender), task_index, task_type),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK">PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK</a>))

--- a/aptos-move/framework/supra-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_fee.move
@@ -86,8 +86,9 @@ module supra_framework::transaction_fee {
     }
 
     #[event]
-    /// Breakdown of the assessed fee charges for the gas-less transactions.
-    ///  Holds the same information as FeeStatement for charged transactions.
+    /// Breakdown of the gas consumed by gas-fee-less (i.e. gasless) transactions.
+    /// The consumed amounts serve as a record of the workload of the transaction and
+    /// are not charged to the gas payer's account.
     struct GasAssessment has drop, store {
         /// Total gas assessed for transaction execution.
         total_assessed_gas_units: u64,

--- a/aptos-move/framework/supra-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_fee.move
@@ -85,6 +85,22 @@ module supra_framework::transaction_fee {
         storage_fee_refund_quants: u64,
     }
 
+    #[event]
+    /// Breakdown of the assessed fee charges for the gas-less transactions.
+    ///  Holds the same information as FeeStatement for charged transactions.
+    struct FeeAssessment has drop, store {
+        /// Total gas assessed for transaction execution.
+        total_assessed_gas_units: u64,
+        /// Execution gas charge.
+        execution_gas_units: u64,
+        /// IO gas charge.
+        io_gas_units: u64,
+        /// Storage fee charge.
+        storage_fee_quants: u64,
+        /// Storage fee refund.
+        storage_fee_refund_quants: u64,
+    }
+
     /// Initializes the resource storing information about gas fees collection and
     /// distribution. Should be called by on-chain governance.
     public fun initialize_fee_collection_and_distribution(supra_framework: &signer, burn_percentage: u8) {
@@ -282,6 +298,27 @@ module supra_framework::transaction_fee {
     // Called by the VM after epilogue.
     fun emit_fee_statement(fee_statement: FeeStatement) {
         event::emit(fee_statement)
+    }
+
+    // Called by the VM after epilogue for gas-less transactions to report fee assessment
+    fun emit_fee_assessment(fee_statement: FeeStatement) {
+        let FeeStatement {
+            total_charge_gas_units,
+            execution_gas_units,
+            io_gas_units,
+            storage_fee_quants,
+            storage_fee_refund_quants,
+
+        } = fee_statement;
+        let fee_assesment = FeeAssessment {
+            total_assessed_gas_units: total_charge_gas_units,
+            execution_gas_units,
+            io_gas_units,
+            storage_fee_quants,
+            storage_fee_refund_quants,
+
+        };
+        event::emit(fee_assesment)
     }
 
     #[test_only]

--- a/aptos-move/framework/supra-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_fee.move
@@ -88,7 +88,7 @@ module supra_framework::transaction_fee {
     #[event]
     /// Breakdown of the assessed fee charges for the gas-less transactions.
     ///  Holds the same information as FeeStatement for charged transactions.
-    struct FeeAssessment has drop, store {
+    struct GasAssessment has drop, store {
         /// Total gas assessed for transaction execution.
         total_assessed_gas_units: u64,
         /// Execution gas charge.
@@ -301,7 +301,7 @@ module supra_framework::transaction_fee {
     }
 
     // Called by the VM after epilogue for gas-less transactions to report fee assessment
-    fun emit_fee_assessment(fee_statement: FeeStatement) {
+    fun emit_gas_assessment(fee_statement: FeeStatement) {
         let FeeStatement {
             total_charge_gas_units,
             execution_gas_units,
@@ -310,7 +310,7 @@ module supra_framework::transaction_fee {
             storage_fee_refund_quants,
 
         } = fee_statement;
-        let fee_assesment = FeeAssessment {
+        let gas_assesment = GasAssessment {
             total_assessed_gas_units: total_charge_gas_units,
             execution_gas_units,
             io_gas_units,
@@ -318,7 +318,7 @@ module supra_framework::transaction_fee {
             storage_fee_refund_quants,
 
         };
-        event::emit(fee_assesment)
+        event::emit(gas_assesment)
     }
 
     #[test_only]

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.move
@@ -205,18 +205,22 @@ module supra_framework::transaction_validation {
             error::invalid_argument(PROLOGUE_ETRANSACTION_EXPIRED),
         );
 
-        let max_transaction_fee = txn_gas_price * txn_max_gas_units;
+        // Task is not gas-less/GST,
+        // gas-less automated transactions are not charged so no need to check eligability to pay the gas-fee
+        if (task_type != 2) {
+            let max_transaction_fee = txn_gas_price * txn_max_gas_units;
 
-        if (features::operations_default_to_fa_supra_store_enabled()) {
-            assert!(
-                supra_account::is_fungible_balance_at_least(gas_payer, max_transaction_fee),
-                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
-            );
-        } else {
-            assert!(
-                coin::is_balance_at_least<SupraCoin>(gas_payer, max_transaction_fee),
-                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
-            );
+            if (features::operations_default_to_fa_supra_store_enabled()) {
+                assert!(
+                    supra_account::is_fungible_balance_at_least(gas_payer, max_transaction_fee),
+                    error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+                );
+            } else {
+                assert!(
+                    coin::is_balance_at_least<SupraCoin>(gas_payer, max_transaction_fee),
+                    error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+                );
+            };
         };
         assert!(automation_registry::has_sender_active_task_with_id_and_type(address_of(&sender), task_index, task_type),
             error::invalid_state(PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK))

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.move
@@ -36,6 +36,10 @@ module supra_framework::transaction_validation {
     /// Transaction exceeded its allocated max gas
     const EOUT_OF_GAS: u64 = 6;
 
+    /// Constants representing automation task type. Should match the values in scope of automation_registry module.
+    const UST:u8 = 1;
+    const GST:u8 = 2;
+
     /// Prologue errors. These are separated out from the other errors in this
     /// module since they are mapped separately to major VM statuses, and are
     /// important to the semantics of the system.
@@ -183,8 +187,7 @@ module supra_framework::transaction_validation {
         txn_expiration_time: u64,
         chain_id: u8,
     )  {
-        let ust:u8 = 1;
-        automated_transaction_prologue_v2(sender, task_index, txn_gas_price, txn_max_gas_units, txn_expiration_time, chain_id, ust);
+        automated_transaction_prologue_v2(sender, task_index, txn_gas_price, txn_max_gas_units, txn_expiration_time, chain_id, UST);
     }
 
     fun automated_transaction_prologue_v2(
@@ -206,8 +209,8 @@ module supra_framework::transaction_validation {
         );
 
         // Task is not gas-less/GST,
-        // gas-less automated transactions are not charged so no need to check eligability to pay the gas-fee
-        if (task_type != 2) {
+        // gas-less automated transactions are not charged so no need to check eligability to pay the gas-fee.
+        if (task_type != GST) {
             let max_transaction_fee = txn_gas_price * txn_max_gas_units;
 
             if (features::operations_default_to_fa_supra_store_enabled()) {


### PR DESCRIPTION
- Now instead of FeeStatement event FeeAssessment event is emitted for gas-less automated transactions,  and the fee-statement in scope of execution output will be zero leading to 0 gas-used

- Updated automated transaction prologue to avoid balance check for gas-fee for gas-less transactions