### PR TITLE
[AN-Issue-2480-2486] Updated system task handling on cancellation and cycle suspension

### DIFF
--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -4888,6 +4888,7 @@ Committed gas-limit is updated by reducing it with the max-gas-amount of the can
     <b>assert</b>!(automation_task_metadata.state != <a href="automation_registry.md#0x1_automation_registry_CANCELLED">CANCELLED</a>, <a href="automation_registry.md#0x1_automation_registry_EALREADY_CANCELLED">EALREADY_CANCELLED</a>);
     <b>if</b> (automation_task_metadata.state == <a href="automation_registry.md#0x1_automation_registry_PENDING">PENDING</a>) {
         <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.main.tasks, task_index);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_remove_value">vector::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.system_tasks_state.task_ids, &task_index);
     } <b>else</b> { // it is safe not <b>to</b> check the state <b>as</b> above, the cancelled tasks are already rejected.
         <b>let</b> automation_task_metadata_mut = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_get_value_mut">enumerable_map::get_value_mut</a>(
             &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.main.tasks,
@@ -5654,6 +5655,7 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(task_indexes, |task_index| {
         <b>if</b> (<a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_contains">enumerable_map::contains</a>(&<a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.main.tasks, task_index)) {
             <b>let</b> task = <a href="../../supra-stdlib/doc/enumerable_map.md#0x1_enumerable_map_remove_value">enumerable_map::remove_value</a>(&<b>mut</b> <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>.main.tasks, task_index);
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> removed_tasks, task_index);
             <a href="automation_registry.md#0x1_automation_registry_mark_task_processed">mark_task_processed</a>(transition_state, task_index);
             // Nothing <b>to</b> refund for <a href="automation_registry.md#0x1_automation_registry_GST">GST</a> tasks
             <b>if</b> (<a href="automation_registry.md#0x1_automation_registry_is_of_type">is_of_type</a>(&task, <a href="automation_registry.md#0x1_automation_registry_UST">UST</a>)) {
@@ -5666,9 +5668,8 @@ In case if end is identified the registry state is update to CYCLE_READY and cor
                     &resource_signer,
                     epoch_locked_fees,
                     current_time,
-                    &<b>mut</b> removed_tasks
                 )
-            };
+            }
         }
     });
 
@@ -5902,7 +5903,7 @@ Removes system task from registry state.
 Refunds the deposit fee and any autoamtion fees of the task.
 
 
-<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_task_fees">refund_task_fees</a>(task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfigV2">automation_registry::ActiveAutomationRegistryConfigV2</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_locked_fees: u64, current_time: u64, removed_tasks: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;): u64
+<pre><code><b>fun</b> <a href="automation_registry.md#0x1_automation_registry_refund_task_fees">refund_task_fees</a>(task: <a href="automation_registry.md#0x1_automation_registry_AutomationTaskMetaData">automation_registry::AutomationTaskMetaData</a>, <a href="automation_registry.md#0x1_automation_registry">automation_registry</a>: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRegistry">automation_registry::AutomationRegistry</a>, refund_bookkeeping: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_AutomationRefundBookkeeping">automation_registry::AutomationRefundBookkeeping</a>, arc: &<a href="automation_registry.md#0x1_automation_registry_ActiveAutomationRegistryConfigV2">automation_registry::ActiveAutomationRegistryConfigV2</a>, transition_state: &<b>mut</b> <a href="automation_registry.md#0x1_automation_registry_TransitionState">automation_registry::TransitionState</a>, resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch_locked_fees: u64, current_time: u64): u64
 </code></pre>
 
 
@@ -5920,7 +5921,6 @@ Refunds the deposit fee and any autoamtion fees of the task.
     resource_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     epoch_locked_fees: u64,
     current_time: u64,
-    removed_tasks: &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u64&gt;
 
 ) : u64 {
     <b>assert</b>!(<a href="automation_registry.md#0x1_automation_registry_is_of_type">is_of_type</a>(&task, <a href="automation_registry.md#0x1_automation_registry_UST">UST</a>), <a href="automation_registry.md#0x1_automation_registry_EREGISTERED_TASK_INVALID_TYPE">EREGISTERED_TASK_INVALID_TYPE</a>);
@@ -5950,7 +5950,6 @@ Refunds the deposit fee and any autoamtion fees of the task.
         task.owner,
         task.locked_fee_for_next_epoch,
         task.locked_fee_for_next_epoch);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(removed_tasks, task.task_index);
     epoch_locked_fees
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1471,6 +1471,7 @@ module supra_framework::automation_registry {
         assert!(automation_task_metadata.state != CANCELLED, EALREADY_CANCELLED);
         if (automation_task_metadata.state == PENDING) {
             enumerable_map::remove_value(&mut automation_registry.main.tasks, task_index);
+            vector::remove_value(&mut automation_registry.system_tasks_state.task_ids, &task_index);
         } else { // it is safe not to check the state as above, the cancelled tasks are already rejected.
             let automation_task_metadata_mut = enumerable_map::get_value_mut(
                 &mut automation_registry.main.tasks,
@@ -2047,6 +2048,7 @@ module supra_framework::automation_registry {
         vector::for_each(task_indexes, |task_index| {
             if (enumerable_map::contains(&automation_registry.main.tasks, task_index)) {
                 let task = enumerable_map::remove_value(&mut automation_registry.main.tasks, task_index);
+                vector::push_back(&mut removed_tasks, task_index);
                 mark_task_processed(transition_state, task_index);
                 // Nothing to refund for GST tasks
                 if (is_of_type(&task, UST)) {
@@ -2059,9 +2061,8 @@ module supra_framework::automation_registry {
                         &resource_signer,
                         epoch_locked_fees,
                         current_time,
-                        &mut removed_tasks
                     )
-                };
+                }
             }
         });
 
@@ -2213,7 +2214,6 @@ module supra_framework::automation_registry {
         resource_signer: &signer,
         epoch_locked_fees: u64,
         current_time: u64,
-        removed_tasks: &mut vector<u64>
 
     ) : u64 {
         assert!(is_of_type(&task, UST), EREGISTERED_TASK_INVALID_TYPE);
@@ -2243,7 +2243,6 @@ module supra_framework::automation_registry {
             task.owner,
             task.locked_fee_for_next_epoch,
             task.locked_fee_for_next_epoch);
-        vector::push_back(removed_tasks, task.task_index);
         epoch_locked_fees
     }
 

--- a/aptos-move/framework/supra-framework/tests/automation_registry_tests.move
+++ b/aptos-move/framework/supra-framework/tests/automation_registry_tests.move
@@ -4048,58 +4048,78 @@ module std::automation_registry_tests {
         initialize_registry_test(framework, user);
         let (multisig_address, multisig_signer) = setup_multisig_account(framework, user);
         automation_registry::grant_authorization(framework, multisig_address);
+        let max_gas_amount = 10;
 
         let _ = automation_registry::register_system_task_with_state(
             &multisig_signer,
-            10,
+            max_gas_amount,
             86400,
             ACTIVE
         );
         let _ = automation_registry::register_system_task_with_state(
             &multisig_signer,
-            10,
+            max_gas_amount,
             86400,
             ACTIVE
         );
-        // check account balances after registration
+        // check account balances after registration, no charges are expected
         let registry_fee_address = automation_registry::get_registry_fee_address();
         let user_address = address_of(user);
         check_account_balance(user_address, ACCOUNT_BALANCE);
         check_account_balance(multisig_address, ACCOUNT_BALANCE);
         check_account_balance(registry_fee_address, REGISTRY_DEFAULT_BALANCE);
 
-        assert!(20 == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
+        assert!((2 * max_gas_amount) == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
         let active_task_ids = automation_registry::get_active_task_ids();
         let expected_ids = vector<u64>[0, 1];
         vector::for_each(expected_ids, |task_index| {
             assert!(vector::contains(&active_task_ids, &task_index), 1);
         });
 
-        // Cancel task 2. The committed gas for the next epoch will be updated,
+        let system_task_ids = automation_registry::get_system_task_indexes();
+        vector::for_each(expected_ids, |task_index| {
+            assert!(vector::contains(&system_task_ids, &task_index), 1);
+        });
+        // Cancel second registered task . The committed gas for the next cycle by system tasks will be updated,
         // but when requested active task it will be still available in the list
         automation_registry::cancel_system_task(&multisig_signer, 1);
         // Task will be still available in the registry but with cancelled state
         automation_registry::check_task_state(1, true, CANCELLED);
 
-        assert!(10 == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
+        assert!(max_gas_amount == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
         let active_task_ids = automation_registry::get_active_task_ids();
         vector::for_each(expected_ids, |task_index| {
             assert!(vector::contains(&active_task_ids, &task_index), 1);
+       });
+        let system_task_ids = automation_registry::get_system_task_indexes();
+        vector::for_each(expected_ids, |task_index| {
+            assert!(vector::contains(&system_task_ids, &task_index), 1);
         });
 
-        // Add and cancel the task in the same epoch. Task index will be 4
+        // Add and cancel the task in the same cycle. Task index will be 2
         assert!(automation_registry::get_next_task_index() == 2, 1);
         automation_registry::register_system_task_with_state(&multisig_signer,
             10,
             86400,
             PENDING,
         );
+        let expected_system_ids = vector<u64>[0, 1, 2];
+        let system_task_ids = automation_registry::get_system_task_indexes();
+        vector::for_each(expected_ids, |task_index| {
+            assert!(vector::contains(&system_task_ids, &task_index), 1);
+        });
         automation_registry::cancel_system_task(&multisig_signer, 2);
-        assert!(10 == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
+        assert!(max_gas_amount == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
         let active_task_ids = automation_registry::get_active_task_ids();
         vector::for_each(expected_ids, |task_index| {
             assert!(vector::contains(&active_task_ids, &task_index), 1);
         });
+        let expected_system_ids = vector<u64>[0, 1];
+        let system_task_ids = automation_registry::get_system_task_indexes();
+        vector::for_each(expected_ids, |task_index| {
+            assert!(vector::contains(&system_task_ids, &task_index), 1);
+        });
+
         // there is no task with index 2 and the next task index will be 3.
         assert!(!automation_registry::has_task_with_id(2), 1);
         assert!(automation_registry::get_next_task_index() == 3, 1);
@@ -4202,7 +4222,7 @@ module std::automation_registry_tests {
     }
 
     #[test(framework = @supra_framework, user = @0x1caff)]
-    fun check_system_task_successful_stopped(
+    fun check_system_task_successfully_stopped(
         framework: &signer,
         user: &signer
     ) {
@@ -4259,7 +4279,12 @@ module std::automation_registry_tests {
             assert!(vector::contains(&active_task_ids, &task_index), 2);
         });
 
-        // 0.002 (*4) - automation_epoch_fee_per_second, 7200 epoch duration
+        let system_task_ids = automation_registry::get_system_task_indexes();
+        vector::for_each(expected_ids, |task_index| {
+            assert!(vector::contains(&active_task_ids, &task_index), 2);
+        });
+
+        // No fees are charged
         check_account_balance( multisig_address, ACCOUNT_BALANCE );
         check_account_balance(user_account, ACCOUNT_BALANCE );
         check_account_balance( registry_fee_address, REGISTRY_DEFAULT_BALANCE );
@@ -4311,7 +4336,7 @@ module std::automation_registry_tests {
         assert!(automation_registry::get_next_task_index() == 5, 1);
         assert!(3 * max_gas_amount == automation_registry::get_system_gas_committed_for_next_cycle(), 1);
 
-        // Check balances after test execution
+        // Check balances after test execution, no fees are charged or refunded.
         check_account_balance(multisig_address, ACCOUNT_BALANCE);
         check_account_balance(user_account, ACCOUNT_BALANCE);
         check_account_balance(registry_fee_address, REGISTRY_DEFAULT_BALANCE);


### PR DESCRIPTION

- If pending system task is cancelled, the task index is removed from the cached list of system tasks
   - Fixes https://github.com/Entropy-Foundation/smr-moonshot/issues/2486

- When cycle suspended then system tasks are also included in the removed tasks list of the reported error.
   - Fixes https://github.com/Entropy-Foundation/smr-moonshot/issues/2480
