### PR TITLE
Enabled skipping the gas payment validation check in the transaction prologue during simulation

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1379,8 +1379,10 @@ impl TransactionsApi {
 
         // Simulate transaction
         let state_view = self.context.latest_state_view_poem(&ledger_info)?;
+        // Supra does not use this function, so we retain its original behavior.
+        let skip_prologue_gas_fee_check = false;
         let (vm_status, output) =
-            AptosSimulationVM::create_vm_and_simulate_signed_transaction(&txn, &state_view);
+            AptosSimulationVM::create_vm_and_simulate_signed_transaction(&txn, &state_view, skip_prologue_gas_fee_check);
         let version = ledger_info.version();
 
         // Ensure that all known statuses return their values in the output (even if they aren't supposed to)

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1080,8 +1080,7 @@ impl TransactionsApi {
                                         ledger_info,
                                         params.automated_function(),
                                     )?;
-
-                                }
+                                },
                             }
                         }
                     },
@@ -1382,7 +1381,7 @@ impl TransactionsApi {
         // Supra does not use this function, so we retain its original behavior.
         let skip_prologue_gas_fee_check = false;
         let (vm_status, output) =
-            AptosSimulationVM::create_vm_and_simulate_signed_transaction(&txn, &state_view, skip_prologue_gas_fee_check);
+            AptosSimulationVM::create_vm_and_simulate_signed_transaction(&txn, &state_view);
         let version = ledger_info.version();
 
         // Ensure that all known statuses return their values in the output (even if they aren't supposed to)
@@ -1420,7 +1419,7 @@ impl TransactionsApi {
                                 auto_payload.module_id(),
                                 &auto_payload.function().into(),
                             )
-                        }
+                        },
                     }
                 } else {
                     "Multisig::unknown".to_string()

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2882,8 +2882,11 @@ impl VMValidator for AptosVM {
                 return VMValidatorResult::error(StatusCode::INVALID_SIGNATURE);
             },
         };
-        let txn_data = TransactionMetadata::new(&txn);
 
+        // The prologue gas fee check should only be skipped during simulation. 
+        // Transactions that make it to execution should have gas parameters that have been chosen deliberately.
+        let skip_prologue_gas_fee_check = false;
+        let txn_data = TransactionMetadata::new(&txn, skip_prologue_gas_fee_check);
         let resolver = self.as_move_resolver(&state_view);
         let is_approved_gov_script = is_approved_gov_script(&resolver, &txn, &txn_data);
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2009,18 +2009,22 @@ impl AptosVM {
 
     /// Main entrypoint for executing a user transaction that also allows the customization of the
     /// gas meter to be used.
+    /// 
+    /// `skip_prologue_gas_fee_check` should only be set to true when simulating a transaction with
+    /// the default max-gas value.
     pub fn execute_user_transaction_with_custom_gas_meter<G, F>(
         &self,
         resolver: &impl AptosMoveResolver,
         txn: &SignedTransaction,
         log_context: &AdapterLogSchema,
         make_gas_meter: F,
+        skip_prologue_gas_fee_check: bool,
     ) -> Result<(VMStatus, VMOutput, G), VMStatus>
     where
         G: AptosGasMeter,
         F: FnOnce(u64, VMGasParameters, StorageGasParameters, bool, Gas) -> G,
     {
-        let txn_metadata = TransactionMetadata::new(txn);
+        let txn_metadata = TransactionMetadata::new(txn, skip_prologue_gas_fee_check);
 
         let is_approved_gov_script = is_approved_gov_script(resolver, txn, &txn_metadata);
 
@@ -2079,21 +2083,28 @@ impl AptosVM {
                     meter_balance,
                 ))
             },
+            // We do not currently use this function to simulate transactions.
+            false,
         )
     }
 
     /// Executes a user transaction using the production gas meter.
+    /// 
+    /// `skip_prologue_gas_fee_check` should only be set to true when simulating a transaction with
+    /// the default max-gas value.
     pub fn execute_user_transaction(
         &self,
         resolver: &impl AptosMoveResolver,
         txn: &SignedTransaction,
         log_context: &AdapterLogSchema,
+        skip_prologue_gas_fee_check: bool,
     ) -> (VMStatus, VMOutput) {
         match self.execute_user_transaction_with_custom_gas_meter(
             resolver,
             txn,
             log_context,
             make_prod_gas_meter,
+            skip_prologue_gas_fee_check,
         ) {
             Ok((vm_status, vm_output, _gas_meter)) => (vm_status, vm_output),
             Err(vm_status) => {
@@ -2607,7 +2618,10 @@ impl AptosVM {
             Transaction::UserTransaction(txn) => {
                 fail_point!("aptos_vm::execution::user_transaction");
                 let _timer = TXN_TOTAL_SECONDS.start_timer();
-                let (vm_status, output) = self.execute_user_transaction(resolver, txn, log_context);
+                // The prologue gas fee check should only be skipped during simulation. Transactions
+                // that make it to execution should have gas parameters that have been chosen deliberately.
+                let skip_prologue_gas_fee_check = false;
+                let (vm_status, output) = self.execute_user_transaction(resolver, txn, log_context, skip_prologue_gas_fee_check);
 
                 if let StatusType::InvariantViolation = vm_status.status_type() {
                     match vm_status.status_code() {
@@ -2921,7 +2935,16 @@ impl AptosSimulationVM {
 
     /// Simulates a signed transaction (i.e., executes it without performing
     /// signature verification) on a newly created VM instance.
+    /// 
     /// *Precondition:* the transaction must **not** have a valid signature.
+    /// 
+    /// Transactions that have a `max_gas_amount` equal to `u64::MAX` will skip the prologue gas fee check.
+    /// This value will never be deliberately selected by a user for a real transaction as it will always
+    /// result in a failure during execution (since their account will never have enough balance to cover
+    /// the implied gas fee). Consequently, it is a safe value to use as a flag to indicate that the prologue
+    /// gas fee check should be skipped during simulation. This allows clients to use simulation to precisely
+    /// set the `max_gas_amount` parameter of a transaction without having to predict an approximate value
+    /// to use during simulation, which would inevitably be imprecise.
     pub fn create_vm_and_simulate_signed_transaction(
         transaction: &SignedTransaction,
         state_view: &impl StateView,
@@ -2935,8 +2958,9 @@ impl AptosSimulationVM {
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let resolver = state_view.as_move_resolver();
+        let skip_prologue_gas_fee_check = transaction.max_gas_amount() == u64::MAX;
         let (vm_status, vm_output) =
-            vm.0.execute_user_transaction(&resolver, transaction, &log_context);
+            vm.0.execute_user_transaction(&resolver, transaction, &log_context, skip_prologue_gas_fee_check);
         let txn_output = vm_output
             .try_materialize_into_transaction_output(&resolver)
             .expect("Materializing aggregator V1 deltas should never fail");

--- a/aptos-move/aptos-vm/src/testing.rs
+++ b/aptos-move/aptos-vm/src/testing.rs
@@ -74,7 +74,7 @@ impl AptosVM {
         use crate::gas::make_prod_gas_meter;
         use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
 
-        let txn_data = TransactionMetadata::new(txn);
+        let txn_data = TransactionMetadata::new(txn, false);
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let vm_gas_params = self

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -35,10 +35,11 @@ pub struct TransactionMetadata {
     pub is_keyless: bool,
     pub payload_type_reference: PayloadTypeReferenceMeta,
     pub txn_app_hash: Vec<u8>,
+    pub skip_prologue_gas_fee_check: bool,
 }
 
 impl TransactionMetadata {
-    pub fn new(txn: &SignedTransaction) -> Self {
+    pub fn new(txn: &SignedTransaction, skip_prologue_gas_fee_check: bool) -> Self {
         let payload_type_reference = match txn.payload() {
             TransactionPayload::Script(_) |
             TransactionPayload::ModuleBundle(_) => PayloadTypeReferenceMeta::Other,
@@ -89,6 +90,7 @@ impl TransactionMetadata {
                 &bcs::to_bytes(&txn).expect("Unable to serialize SignedTransaction"),
             )
             .to_vec(),
+            skip_prologue_gas_fee_check,
         }
     }
 
@@ -197,6 +199,7 @@ impl From<&AutomatedTransaction> for TransactionMetadata {
             is_keyless: false,
             payload_type_reference: PayloadTypeReferenceMeta::UserEntryFunction(txn.payload().clone().into_entry_function()),
             txn_app_hash: txn.hash().to_vec(),
+            skip_prologue_gas_fee_check: false,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -111,6 +111,7 @@ pub(crate) fn run_script_prologue(
             MoveValue::U64(txn_max_gas_units.into()),
             MoveValue::U64(txn_expiration_timestamp_secs),
             MoveValue::U8(chain_id.id()),
+            MoveValue::Bool(txn_data.skip_prologue_gas_fee_check),
         ];
         (&APTOS_TRANSACTION_VALIDATION.fee_payer_prologue_name, args)
     } else if txn_data.is_multi_agent() {
@@ -124,6 +125,7 @@ pub(crate) fn run_script_prologue(
             MoveValue::U64(txn_max_gas_units.into()),
             MoveValue::U64(txn_expiration_timestamp_secs),
             MoveValue::U8(chain_id.id()),
+            MoveValue::Bool(txn_data.skip_prologue_gas_fee_check),
         ];
         (
             &APTOS_TRANSACTION_VALIDATION.multi_agent_prologue_name,
@@ -139,6 +141,7 @@ pub(crate) fn run_script_prologue(
             MoveValue::U64(txn_expiration_timestamp_secs),
             MoveValue::U8(chain_id.id()),
             MoveValue::vector_u8(txn_data.script_hash.clone()),
+            MoveValue::Bool(txn_data.skip_prologue_gas_fee_check),
         ];
         (&APTOS_TRANSACTION_VALIDATION.script_prologue_name, args)
     };
@@ -237,6 +240,7 @@ pub(crate) fn run_automated_transaction_prologue(
         .map_err(expect_no_verification_errors)
         .or_else(|err| convert_prologue_error(err, log_context))
 }
+
 /// Run the prologue for automated transactions where
 /// 1. sender is checked to have enough funds for transaction execution
 /// 2. automated task expiry time is checked.

--- a/aptos-move/framework/supra-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/supra-framework/doc/transaction_validation.md
@@ -8,6 +8,7 @@
 -  [Resource `TransactionValidation`](#0x1_transaction_validation_TransactionValidation)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_transaction_validation_initialize)
+-  [Function `verify_gas_payment`](#0x1_transaction_validation_verify_gas_payment)
 -  [Function `prologue_common`](#0x1_transaction_validation_prologue_common)
 -  [Function `script_prologue`](#0x1_transaction_validation_script_prologue)
 -  [Function `automated_transaction_prologue`](#0x1_transaction_validation_automated_transaction_prologue)
@@ -279,19 +280,62 @@ Only called during genesis to initialize system resources for this module.
     // module_prologue_name is deprecated and not used.
     module_prologue_name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     multi_agent_prologue_name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    user_epilogue_name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    user_epilogue_name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
 
-    <b>move_to</b>(supra_framework, <a href="transaction_validation.md#0x1_transaction_validation_TransactionValidation">TransactionValidation</a> {
-        module_addr: @supra_framework,
-        module_name: b"<a href="transaction_validation.md#0x1_transaction_validation">transaction_validation</a>",
-        script_prologue_name,
-        // module_prologue_name is deprecated and not used.
-        module_prologue_name,
-        multi_agent_prologue_name,
-        user_epilogue_name,
-    });
+    <b>move_to</b>(
+        supra_framework,
+        <a href="transaction_validation.md#0x1_transaction_validation_TransactionValidation">TransactionValidation</a> {
+            module_addr: @supra_framework,
+            module_name: b"<a href="transaction_validation.md#0x1_transaction_validation">transaction_validation</a>",
+            script_prologue_name,
+            // module_prologue_name is deprecated and not used.
+            module_prologue_name,
+            multi_agent_prologue_name,
+            user_epilogue_name
+        }
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_transaction_validation_verify_gas_payment"></a>
+
+## Function `verify_gas_payment`
+
+
+
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_verify_gas_payment">verify_gas_payment</a>(gas_payer: <b>address</b>, txn_gas_price: u64, txn_gas_units: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_verify_gas_payment">verify_gas_payment</a>(
+    gas_payer: <b>address</b>, txn_gas_price: u64, txn_gas_units: u64
+): u64 {
+    <b>let</b> <a href="transaction_fee.md#0x1_transaction_fee">transaction_fee</a> = txn_gas_price * txn_gas_units;
+
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {
+        <b>assert</b>!(
+            <a href="supra_account.md#0x1_supra_account_is_fungible_balance_at_least">supra_account::is_fungible_balance_at_least</a>(gas_payer, <a href="transaction_fee.md#0x1_transaction_fee">transaction_fee</a>),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
+        );
+    } <b>else</b> {
+        <b>assert</b>!(
+            <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;SupraCoin&gt;(gas_payer, <a href="transaction_fee.md#0x1_transaction_fee">transaction_fee</a>),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
+        );
+    };
+
+    <a href="transaction_fee.md#0x1_transaction_fee">transaction_fee</a>
 }
 </code></pre>
 
@@ -305,7 +349,7 @@ Only called during genesis to initialize system resources for this module.
 
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, txn_sequence_number: u64, txn_authentication_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, txn_sequence_number: u64, txn_authentication_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -323,28 +367,35 @@ Only called during genesis to initialize system resources for this module.
     txn_max_gas_units: u64,
     txn_expiration_time: u64,
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
+    verify_gas_payment: bool
 ) {
     <b>assert</b>!(
         <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &lt; txn_expiration_time,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>)
     );
-    <b>assert</b>!(<a href="chain_id.md#0x1_chain_id_get">chain_id::get</a>() == <a href="chain_id.md#0x1_chain_id">chain_id</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EBAD_CHAIN_ID">PROLOGUE_EBAD_CHAIN_ID</a>));
+    <b>assert</b>!(
+        <a href="chain_id.md#0x1_chain_id_get">chain_id::get</a>() == <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EBAD_CHAIN_ID">PROLOGUE_EBAD_CHAIN_ID</a>)
+    );
 
     <b>let</b> transaction_sender = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&sender);
 
-    <b>if</b> (
-        transaction_sender == gas_payer
-            || <a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender)
-            || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_sponsored_automatic_account_creation_enabled">features::sponsored_automatic_account_creation_enabled</a>()
-            || txn_sequence_number != 0
-    ) {
-        <b>assert</b>!(<a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EACCOUNT_DOES_NOT_EXIST">PROLOGUE_EACCOUNT_DOES_NOT_EXIST</a>));
+    <b>if</b> (transaction_sender == gas_payer
+        || <a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender)
+        || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_sponsored_automatic_account_creation_enabled">features::sponsored_automatic_account_creation_enabled</a>()
+        || txn_sequence_number != 0) {
         <b>assert</b>!(
-            txn_authentication_key == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(transaction_sender),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+            <a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EACCOUNT_DOES_NOT_EXIST">PROLOGUE_EACCOUNT_DOES_NOT_EXIST</a>)
+        );
+        <b>assert</b>!(
+            txn_authentication_key
+                == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(transaction_sender),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
         );
 
-        <b>let</b> account_sequence_number = <a href="account.md#0x1_account_get_sequence_number">account::get_sequence_number</a>(transaction_sender);
+        <b>let</b> account_sequence_number =
+            <a href="account.md#0x1_account_get_sequence_number">account::get_sequence_number</a>(transaction_sender);
         <b>assert</b>!(
             txn_sequence_number &lt; (1u64 &lt;&lt; 63),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ESEQUENCE_NUMBER_TOO_BIG">PROLOGUE_ESEQUENCE_NUMBER_TOO_BIG</a>)
@@ -369,22 +420,17 @@ Only called during genesis to initialize system resources for this module.
 
         <b>assert</b>!(
             txn_authentication_key == <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&transaction_sender),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
         );
     };
 
-    <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
-
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {
-        <b>assert</b>!(
-            <a href="supra_account.md#0x1_supra_account_is_fungible_balance_at_least">supra_account::is_fungible_balance_at_least</a>(gas_payer, max_transaction_fee),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
-        );
-    } <b>else</b> {
-        <b>assert</b>!(
-            <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;SupraCoin&gt;(gas_payer, max_transaction_fee),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
-        );
+    // Should only be <b>false</b> when simulating a transaction <b>with</b> the default max-gas value.
+    // Clients that do not manually specify their own max-gas value should generally be using
+    // simulation <b>to</b> estimate the value of this parameter for their actual transaction.
+    // The transaction will fail during the epilogue <b>with</b> the same <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> <a href="code.md#0x1_code">code</a> <b>if</b> the <a href="account.md#0x1_account">account</a> does not
+    // have enough balance <b>to</b> cover the actual gas payment.
+    <b>if</b> (verify_gas_payment) {
+        <a href="transaction_validation.md#0x1_transaction_validation_verify_gas_payment">verify_gas_payment</a>(gas_payer, txn_gas_price, txn_max_gas_units);
     }
 }
 </code></pre>
@@ -399,7 +445,7 @@ Only called during genesis to initialize system resources for this module.
 
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -416,7 +462,7 @@ Only called during genesis to initialize system resources for this module.
     txn_max_gas_units: u64,
     txn_expiration_time: u64,
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
-    _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    verify_gas_payment: bool
 ) {
     <b>let</b> gas_payer = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&sender);
     <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(
@@ -427,7 +473,8 @@ Only called during genesis to initialize system resources for this module.
         txn_gas_price,
         txn_max_gas_units,
         txn_expiration_time,
-        <a href="chain_id.md#0x1_chain_id">chain_id</a>
+        <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        verify_gas_payment
     )
 }
 </code></pre>
@@ -461,9 +508,17 @@ V1 to V2 on active chains
     txn_gas_price: u64,
     txn_max_gas_units: u64,
     txn_expiration_time: u64,
-    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
-)  {
-    <a href="transaction_validation.md#0x1_transaction_validation_automated_transaction_prologue_v2">automated_transaction_prologue_v2</a>(sender, task_index, txn_gas_price, txn_max_gas_units, txn_expiration_time, <a href="chain_id.md#0x1_chain_id">chain_id</a>, <a href="transaction_validation.md#0x1_transaction_validation_UST">UST</a>);
+    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8
+) {
+    <a href="transaction_validation.md#0x1_transaction_validation_automated_transaction_prologue_v2">automated_transaction_prologue_v2</a>(
+        sender,
+        task_index,
+        txn_gas_price,
+        txn_max_gas_units,
+        txn_expiration_time,
+        <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        <a href="transaction_validation.md#0x1_transaction_validation_UST">UST</a>
+    );
 }
 </code></pre>
 
@@ -493,36 +548,32 @@ V1 to V2 on active chains
     txn_max_gas_units: u64,
     txn_expiration_time: u64,
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
-    task_type: u8,
-)  {
+    task_type: u8
+) {
     <b>let</b> gas_payer = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&sender);
 
-    <b>assert</b>!(<a href="chain_id.md#0x1_chain_id_get">chain_id::get</a>() == <a href="chain_id.md#0x1_chain_id">chain_id</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EBAD_CHAIN_ID">PROLOGUE_EBAD_CHAIN_ID</a>));
+    <b>assert</b>!(
+        <a href="chain_id.md#0x1_chain_id_get">chain_id::get</a>() == <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EBAD_CHAIN_ID">PROLOGUE_EBAD_CHAIN_ID</a>)
+    );
 
     <b>assert</b>!(
         <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &lt; txn_expiration_time,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ETRANSACTION_EXPIRED">PROLOGUE_ETRANSACTION_EXPIRED</a>)
     );
 
     // Task is not gas-less/<a href="transaction_validation.md#0x1_transaction_validation_GST">GST</a>,
     // gas-less automated transactions are not charged so no need <b>to</b> check eligability <b>to</b> pay the gas-fee.
     <b>if</b> (task_type != <a href="transaction_validation.md#0x1_transaction_validation_GST">GST</a>) {
-        <b>let</b> max_transaction_fee = txn_gas_price * txn_max_gas_units;
-
-        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {
-            <b>assert</b>!(
-                <a href="supra_account.md#0x1_supra_account_is_fungible_balance_at_least">supra_account::is_fungible_balance_at_least</a>(gas_payer, max_transaction_fee),
-                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
-            );
-        } <b>else</b> {
-            <b>assert</b>!(
-                <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;SupraCoin&gt;(gas_payer, max_transaction_fee),
-                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>)
-            );
-        };
+        <a href="transaction_validation.md#0x1_transaction_validation_verify_gas_payment">verify_gas_payment</a>(gas_payer, txn_gas_price, txn_max_gas_units);
     };
-    <b>assert</b>!(<a href="automation_registry.md#0x1_automation_registry_has_sender_active_task_with_id_and_type">automation_registry::has_sender_active_task_with_id_and_type</a>(address_of(&sender), task_index, task_type),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK">PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK</a>))
+
+    <b>assert</b>!(
+        <a href="automation_registry.md#0x1_automation_registry_has_sender_active_task_with_id_and_type">automation_registry::has_sender_active_task_with_id_and_type</a>(
+            address_of(&sender), task_index, task_type
+        ),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK">PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK</a>)
+    )
 }
 </code></pre>
 
@@ -536,7 +587,7 @@ V1 to V2 on active chains
 
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -555,6 +606,7 @@ V1 to V2 on active chains
     txn_max_gas_units: u64,
     txn_expiration_time: u64,
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
+    verify_gas_payment: bool
 ) {
     <b>let</b> sender_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&sender);
     <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(
@@ -566,8 +618,11 @@ V1 to V2 on active chains
         txn_max_gas_units,
         txn_expiration_time,
         <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        verify_gas_payment
     );
-    <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(secondary_signer_addresses, secondary_signer_public_key_hashes);
+    <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(
+        secondary_signer_addresses, secondary_signer_public_key_hashes
+    );
 }
 </code></pre>
 
@@ -592,12 +647,13 @@ V1 to V2 on active chains
 
 <pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(
     secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
-    secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
+    secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
 ) {
     <b>let</b> num_secondary_signers = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&secondary_signer_addresses);
     <b>assert</b>!(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&secondary_signer_public_key_hashes) == num_secondary_signers,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH">PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH</a>),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&secondary_signer_public_key_hashes)
+            == num_secondary_signers,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH">PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH</a>)
     );
 
     <b>let</b> i = 0;
@@ -607,17 +663,24 @@ V1 to V2 on active chains
             <b>invariant</b> <b>forall</b> j in 0..i:
                 <a href="account.md#0x1_account_exists_at">account::exists_at</a>(secondary_signer_addresses[j])
                     && secondary_signer_public_key_hashes[j]
-                    == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_signer_addresses[j]);
+                        == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(
+                            secondary_signer_addresses[j]
+                        );
         };
         (i &lt; num_secondary_signers)
     }) {
         <b>let</b> secondary_address = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&secondary_signer_addresses, i);
-        <b>assert</b>!(<a href="account.md#0x1_account_exists_at">account::exists_at</a>(secondary_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EACCOUNT_DOES_NOT_EXIST">PROLOGUE_EACCOUNT_DOES_NOT_EXIST</a>));
-
-        <b>let</b> signer_public_key_hash = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&secondary_signer_public_key_hashes, i);
         <b>assert</b>!(
-            signer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_address),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+            <a href="account.md#0x1_account_exists_at">account::exists_at</a>(secondary_address),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EACCOUNT_DOES_NOT_EXIST">PROLOGUE_EACCOUNT_DOES_NOT_EXIST</a>)
+        );
+
+        <b>let</b> signer_public_key_hash =
+            *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&secondary_signer_public_key_hashes, i);
+        <b>assert</b>!(
+            signer_public_key_hash
+                == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_address),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
         );
         i = i + 1;
     }
@@ -634,7 +697,7 @@ V1 to V2 on active chains
 
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, fee_payer_address: <b>address</b>, fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, fee_payer_address: <b>address</b>, fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -655,8 +718,12 @@ V1 to V2 on active chains
     txn_max_gas_units: u64,
     txn_expiration_time: u64,
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
+    verify_gas_payment: bool
 ) {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_fee_payer_enabled">features::fee_payer_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EFEE_PAYER_NOT_ENABLED">PROLOGUE_EFEE_PAYER_NOT_ENABLED</a>));
+    <b>assert</b>!(
+        <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_fee_payer_enabled">features::fee_payer_enabled</a>(),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EFEE_PAYER_NOT_ENABLED">PROLOGUE_EFEE_PAYER_NOT_ENABLED</a>)
+    );
     <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(
         sender,
         fee_payer_address,
@@ -666,11 +733,15 @@ V1 to V2 on active chains
         txn_max_gas_units,
         txn_expiration_time,
         <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        verify_gas_payment
     );
-    <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(secondary_signer_addresses, secondary_signer_public_key_hashes);
+    <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(
+        secondary_signer_addresses, secondary_signer_public_key_hashes
+    );
     <b>assert</b>!(
-        fee_payer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(fee_payer_address),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+        fee_payer_public_key_hash
+            == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(fee_payer_address),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
     );
 }
 </code></pre>
@@ -704,7 +775,14 @@ Called by the Adapter
     gas_units_remaining: u64
 ) {
     <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
-    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(<a href="account.md#0x1_account">account</a>, addr, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(
+        <a href="account.md#0x1_account">account</a>,
+        addr,
+        storage_fee_refunded,
+        txn_gas_price,
+        txn_max_gas_units,
+        gas_units_remaining
+    );
 }
 </code></pre>
 
@@ -737,7 +815,13 @@ Called by the Adapter
     gas_units_remaining: u64
 ) {
     <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
-    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_only">epilogue_gas_payer_only</a>(addr, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_only">epilogue_gas_payer_only</a>(
+        addr,
+        storage_fee_refunded,
+        txn_gas_price,
+        txn_max_gas_units,
+        gas_units_remaining
+    );
 }
 </code></pre>
 
@@ -770,43 +854,37 @@ Only burns spent gas does not increment sequcence number of the sender account.
     txn_max_gas_units: u64,
     gas_units_remaining: u64
 ) {
-    <b>assert</b>!(txn_max_gas_units &gt;= gas_units_remaining, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_EOUT_OF_GAS">EOUT_OF_GAS</a>));
+    <b>assert</b>!(
+        txn_max_gas_units &gt;= gas_units_remaining,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_EOUT_OF_GAS">EOUT_OF_GAS</a>)
+    );
     <b>let</b> gas_used = txn_max_gas_units - gas_units_remaining;
 
     <b>assert</b>!(
         (txn_gas_price <b>as</b> u128) * (gas_used <b>as</b> u128) &lt;= <a href="transaction_validation.md#0x1_transaction_validation_MAX_U64">MAX_U64</a>,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_EOUT_OF_GAS">EOUT_OF_GAS</a>)
     );
-    <b>let</b> transaction_fee_amount = txn_gas_price * gas_used;
 
     // it's important <b>to</b> maintain the <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> <a href="code.md#0x1_code">code</a> consistent <b>with</b> vm
     // <b>to</b> do failed transaction cleanup.
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_supra_store_enabled">features::operations_default_to_fa_supra_store_enabled</a>()) {
-        <b>assert</b>!(
-            <a href="supra_account.md#0x1_supra_account_is_fungible_balance_at_least">supra_account::is_fungible_balance_at_least</a>(gas_payer, transaction_fee_amount),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
-        );
-    } <b>else</b> {
-        <b>assert</b>!(
-            <a href="coin.md#0x1_coin_is_balance_at_least">coin::is_balance_at_least</a>&lt;SupraCoin&gt;(gas_payer, transaction_fee_amount),
-            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_ECANT_PAY_GAS_DEPOSIT">PROLOGUE_ECANT_PAY_GAS_DEPOSIT</a>),
-        );
-    };
+    <b>let</b> transaction_fee_amount =
+        <a href="transaction_validation.md#0x1_transaction_validation_verify_gas_payment">verify_gas_payment</a>(gas_payer, txn_gas_price, txn_max_gas_units);
 
-    <b>let</b> amount_to_burn = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_collect_and_distribute_gas_fees">features::collect_and_distribute_gas_fees</a>()) {
-        // TODO(gas): We might want <b>to</b> distinguish the refundable part of the charge and burn it or track
-        // it separately, so that we don't increase the total supply by refunding.
+    <b>let</b> amount_to_burn =
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_collect_and_distribute_gas_fees">features::collect_and_distribute_gas_fees</a>()) {
+            // TODO(gas): We might want <b>to</b> distinguish the refundable part of the charge and burn it or track
+            // it separately, so that we don't increase the total supply by refunding.
 
-        // If transaction fees are redistributed <b>to</b> validators, collect them here for
-        // later redistribution.
-        <a href="transaction_fee.md#0x1_transaction_fee_collect_fee">transaction_fee::collect_fee</a>(gas_payer, transaction_fee_amount);
-        0
-    } <b>else</b> {
-        // Otherwise, just burn the fee.
-        // TODO: this branch should be removed completely when transaction fee collection
-        // is tested and is fully proven <b>to</b> work well.
-        transaction_fee_amount
-    };
+            // If transaction fees are redistributed <b>to</b> validators, collect them here for
+            // later redistribution.
+            <a href="transaction_fee.md#0x1_transaction_fee_collect_fee">transaction_fee::collect_fee</a>(gas_payer, transaction_fee_amount);
+            0
+        } <b>else</b> {
+            // Otherwise, just burn the fee.
+            // TODO: this branch should be removed completely when transaction fee collection
+            // is tested and is fully proven <b>to</b> work well.
+            transaction_fee_amount
+        };
 
     <b>if</b> (amount_to_burn &gt; storage_fee_refunded) {
         <b>let</b> burn_amount = amount_to_burn - storage_fee_refunded;
@@ -848,7 +926,13 @@ Called by the Adapter
     txn_max_gas_units: u64,
     gas_units_remaining: u64
 ) {
-    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_only">epilogue_gas_payer_only</a>(gas_payer, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+    <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_only">epilogue_gas_payer_only</a>(
+        gas_payer,
+        storage_fee_refunded,
+        txn_gas_price,
+        txn_max_gas_units,
+        gas_units_remaining
+    );
 
     // Increment sequence number
     <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
@@ -952,6 +1036,7 @@ Give some constraints that may abort according to the conditions.
     txn_max_gas_units: u64;
     txn_expiration_time: u64;
     <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8;
+    verify_gas_payment: bool;
     <b>aborts_if</b> !<b>exists</b>&lt;CurrentTimeMicroseconds&gt;(@supra_framework);
     <b>aborts_if</b> !(<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &lt; txn_expiration_time);
     <b>aborts_if</b> !<b>exists</b>&lt;ChainId&gt;(@supra_framework);
@@ -962,13 +1047,25 @@ Give some constraints that may abort according to the conditions.
             || <a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender)
             || transaction_sender == gas_payer
             || txn_sequence_number &gt; 0
-    ) && (
-        !(txn_sequence_number &gt;= <b>global</b>&lt;Account&gt;(transaction_sender).sequence_number)
-            || !(txn_authentication_key == <b>global</b>&lt;Account&gt;(transaction_sender).authentication_key)
-            || !<a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender)
-            || !(txn_sequence_number == <b>global</b>&lt;Account&gt;(transaction_sender).sequence_number)
-    );
-    <b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a>)
+    )
+        && (
+            !(
+                txn_sequence_number
+                    &gt;= <b>global</b>&lt;Account&gt;(transaction_sender).sequence_number
+            )
+                || !(
+                    txn_authentication_key
+                        == <b>global</b>&lt;Account&gt;(transaction_sender).authentication_key
+                )
+                || !<a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender)
+                || !(
+                    txn_sequence_number
+                        == <b>global</b>&lt;Account&gt;(transaction_sender).sequence_number
+                )
+        );
+    <b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(
+        <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a>
+    )
         && transaction_sender != gas_payer
         && txn_sequence_number == 0
         && !<a href="account.md#0x1_account_exists_at">account::exists_at</a>(transaction_sender)
@@ -978,7 +1075,11 @@ Give some constraints that may abort according to the conditions.
     <b>aborts_if</b> max_transaction_fee &gt; <a href="transaction_validation.md#0x1_transaction_validation_MAX_U64">MAX_U64</a>;
     <b>aborts_if</b> !<b>exists</b>&lt;CoinStore&lt;SupraCoin&gt;&gt;(gas_payer);
     // This enforces <a id="high-level-req-1" href="#high-level-req">high-level requirement 1</a>:
-    <b>aborts_if</b> !(<b>global</b>&lt;CoinStore&lt;SupraCoin&gt;&gt;(gas_payer).<a href="coin.md#0x1_coin">coin</a>.value &gt;= max_transaction_fee);
+    <b>aborts_if</b> !(
+        !verify_gas_payment
+            || <b>global</b>&lt;CoinStore&lt;SupraCoin&gt;&gt;(gas_payer).<a href="coin.md#0x1_coin">coin</a>.value
+                &gt;= max_transaction_fee
+    );
 }
 </code></pre>
 
@@ -989,7 +1090,7 @@ Give some constraints that may abort according to the conditions.
 ### Function `prologue_common`
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, txn_sequence_number: u64, txn_authentication_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_prologue_common">prologue_common</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_payer: <b>address</b>, txn_sequence_number: u64, txn_authentication_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -1006,7 +1107,7 @@ Give some constraints that may abort according to the conditions.
 ### Function `script_prologue`
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, _script_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_script_prologue">script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -1033,12 +1134,12 @@ Give some constraints that may abort according to the conditions.
     // This enforces <a id="high-level-req-2" href="#high-level-req">high-level requirement 2</a>:
     <b>aborts_if</b> <b>exists</b> i in 0..num_secondary_signers:
         !<a href="account.md#0x1_account_exists_at">account::exists_at</a>(secondary_signer_addresses[i])
-            || secondary_signer_public_key_hashes[i] !=
-            <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_signer_addresses[i]);
+            || secondary_signer_public_key_hashes[i]
+                != <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_signer_addresses[i]);
     <b>ensures</b> <b>forall</b> i in 0..num_secondary_signers:
         <a href="account.md#0x1_account_exists_at">account::exists_at</a>(secondary_signer_addresses[i])
-            && secondary_signer_public_key_hashes[i] ==
-            <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_signer_addresses[i]);
+            && secondary_signer_public_key_hashes[i]
+                == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(secondary_signer_addresses[i]);
 }
 </code></pre>
 
@@ -1065,7 +1166,7 @@ Give some constraints that may abort according to the conditions.
 ### Function `multi_agent_script_prologue`
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_script_prologue">multi_agent_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -1079,11 +1180,11 @@ not equal the number of singers.
 <b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a> {
     gas_payer,
     txn_sequence_number,
-    txn_authentication_key: txn_sender_public_key,
+    txn_authentication_key: txn_sender_public_key
 };
 <b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_MultiAgentPrologueCommonAbortsIf">MultiAgentPrologueCommonAbortsIf</a> {
     secondary_signer_addresses,
-    secondary_signer_public_key_hashes,
+    secondary_signer_public_key_hashes
 };
 </code></pre>
 
@@ -1102,7 +1203,7 @@ not equal the number of singers.
 
 <pre><code><b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_MultiAgentPrologueCommonAbortsIf">MultiAgentPrologueCommonAbortsIf</a> {
     secondary_signer_addresses,
-    secondary_signer_public_key_hashes,
+    secondary_signer_public_key_hashes
 };
 </code></pre>
 
@@ -1113,7 +1214,7 @@ not equal the number of singers.
 ### Function `fee_payer_script_prologue`
 
 
-<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, fee_payer_address: <b>address</b>, fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8)
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_fee_payer_script_prologue">fee_payer_script_prologue</a>(sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, txn_sequence_number: u64, txn_sender_public_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, secondary_signer_public_key_hashes: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, fee_payer_address: <b>address</b>, fee_payer_public_key_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, txn_gas_price: u64, txn_max_gas_units: u64, txn_expiration_time: u64, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, verify_gas_payment: bool)
 </code></pre>
 
 
@@ -1125,14 +1226,16 @@ not equal the number of singers.
 <b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a> {
     gas_payer,
     txn_sequence_number,
-    txn_authentication_key: txn_sender_public_key,
+    txn_authentication_key: txn_sender_public_key
 };
 <b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_MultiAgentPrologueCommonAbortsIf">MultiAgentPrologueCommonAbortsIf</a> {
     secondary_signer_addresses,
-    secondary_signer_public_key_hashes,
+    secondary_signer_public_key_hashes
 };
 <b>aborts_if</b> !<a href="account.md#0x1_account_exists_at">account::exists_at</a>(gas_payer);
-<b>aborts_if</b> !(fee_payer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(gas_payer));
+<b>aborts_if</b> !(
+    fee_payer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(gas_payer)
+);
 <b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_fee_payer_enabled">features::spec_fee_payer_enabled</a>();
 </code></pre>
 
@@ -1232,17 +1335,21 @@ Skip transaction_fee::burn_fee verification.
     <b>aborts_if</b> !<b>exists</b>&lt;Account&gt;(addr);
     <b>aborts_if</b> !(<b>global</b>&lt;Account&gt;(addr).sequence_number &lt; <a href="transaction_validation.md#0x1_transaction_validation_MAX_U64">MAX_U64</a>);
     <b>ensures</b> <a href="account.md#0x1_account">account</a>.sequence_number == pre_account.sequence_number + 1;
-    <b>let</b> collect_fee_enabled = <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES">features::COLLECT_AND_DISTRIBUTE_GAS_FEES</a>);
+    <b>let</b> collect_fee_enabled = <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(
+        <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES">features::COLLECT_AND_DISTRIBUTE_GAS_FEES</a>
+    );
     <b>let</b> collected_fees = <b>global</b>&lt;CollectedFeesPerBlock&gt;(@supra_framework).amount;
     <b>let</b> aggr = collected_fees.value;
     <b>let</b> aggr_val = <a href="aggregator.md#0x1_aggregator_spec_aggregator_get_val">aggregator::spec_aggregator_get_val</a>(aggr);
     <b>let</b> aggr_lim = <a href="aggregator.md#0x1_aggregator_spec_get_limit">aggregator::spec_get_limit</a>(aggr);
     // This enforces <a id="high-level-req-3" href="#high-level-req">high-level requirement 3</a>:
-    <b>aborts_if</b> collect_fee_enabled && !<b>exists</b>&lt;CollectedFeesPerBlock&gt;(@supra_framework);
-    <b>aborts_if</b> collect_fee_enabled && transaction_fee_amount &gt; 0 && aggr_val + transaction_fee_amount &gt; aggr_lim;
-    <b>let</b> amount_to_burn = <b>if</b> (collect_fee_enabled) {
-        0
-    } <b>else</b> {
+    <b>aborts_if</b> collect_fee_enabled
+        && !<b>exists</b>&lt;CollectedFeesPerBlock&gt;(@supra_framework);
+    <b>aborts_if</b> collect_fee_enabled
+        && transaction_fee_amount &gt; 0
+        && aggr_val + transaction_fee_amount &gt; aggr_lim;
+    <b>let</b> amount_to_burn = <b>if</b> (collect_fee_enabled) { 0 }
+    <b>else</b> {
         transaction_fee_amount - storage_fee_refunded
     };
     <b>let</b> apt_addr = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_of">type_info::type_of</a>&lt;SupraCoin&gt;().account_address;
@@ -1252,11 +1359,17 @@ Skip transaction_fee::burn_fee verification.
     <b>let</b> apt_supply_value = <a href="optional_aggregator.md#0x1_optional_aggregator_optional_aggregator_value">optional_aggregator::optional_aggregator_value</a>(apt_supply);
     <b>let</b> <b>post</b> post_maybe_apt_supply = <b>global</b>&lt;CoinInfo&lt;SupraCoin&gt;&gt;(apt_addr).supply;
     <b>let</b> <b>post</b> post_apt_supply = <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(post_maybe_apt_supply);
-    <b>let</b> <b>post</b> post_apt_supply_value = <a href="optional_aggregator.md#0x1_optional_aggregator_optional_aggregator_value">optional_aggregator::optional_aggregator_value</a>(post_apt_supply);
-    <b>aborts_if</b> amount_to_burn &gt; 0 && !<b>exists</b>&lt;SupraCoinCapabilities&gt;(@supra_framework);
+    <b>let</b> <b>post</b> post_apt_supply_value = <a href="optional_aggregator.md#0x1_optional_aggregator_optional_aggregator_value">optional_aggregator::optional_aggregator_value</a>(
+        post_apt_supply
+    );
+    <b>aborts_if</b> amount_to_burn &gt; 0
+        && !<b>exists</b>&lt;SupraCoinCapabilities&gt;(@supra_framework);
     <b>aborts_if</b> amount_to_burn &gt; 0 && !<b>exists</b>&lt;CoinInfo&lt;SupraCoin&gt;&gt;(apt_addr);
-    <b>aborts_if</b> amount_to_burn &gt; 0 && total_supply_enabled && apt_supply_value &lt; amount_to_burn;
-    <b>ensures</b> total_supply_enabled ==&gt; apt_supply_value - amount_to_burn == post_apt_supply_value;
+    <b>aborts_if</b> amount_to_burn &gt; 0
+        && total_supply_enabled
+        && apt_supply_value &lt; amount_to_burn;
+    <b>ensures</b> total_supply_enabled ==&gt;
+        apt_supply_value - amount_to_burn == post_apt_supply_value;
     <b>let</b> amount_to_mint = <b>if</b> (collect_fee_enabled) {
         storage_fee_refunded
     } <b>else</b> {
@@ -1265,11 +1378,14 @@ Skip transaction_fee::burn_fee verification.
     <b>let</b> total_supply = <a href="coin.md#0x1_coin_supply">coin::supply</a>&lt;SupraCoin&gt;;
     <b>let</b> <b>post</b> post_total_supply = <a href="coin.md#0x1_coin_supply">coin::supply</a>&lt;SupraCoin&gt;;
     <b>aborts_if</b> amount_to_mint &gt; 0 && !<b>exists</b>&lt;CoinStore&lt;SupraCoin&gt;&gt;(addr);
-    <b>aborts_if</b> amount_to_mint &gt; 0 && !<b>exists</b>&lt;SupraCoinMintCapability&gt;(@supra_framework);
+    <b>aborts_if</b> amount_to_mint &gt; 0
+        && !<b>exists</b>&lt;SupraCoinMintCapability&gt;(@supra_framework);
     <b>aborts_if</b> amount_to_mint &gt; 0 && total_supply + amount_to_mint &gt; MAX_U128;
-    <b>ensures</b> amount_to_mint &gt; 0 ==&gt; post_total_supply == total_supply + amount_to_mint;
+    <b>ensures</b> amount_to_mint &gt; 0 ==&gt;
+        post_total_supply == total_supply + amount_to_mint;
     <b>let</b> aptos_addr = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_of">type_info::type_of</a>&lt;SupraCoin&gt;().account_address;
-    <b>aborts_if</b> (amount_to_mint != 0) && !<b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">coin::CoinInfo</a>&lt;SupraCoin&gt;&gt;(aptos_addr);
+    <b>aborts_if</b> (amount_to_mint != 0)
+        && !<b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">coin::CoinInfo</a>&lt;SupraCoin&gt;&gt;(aptos_addr);
     <b>include</b> <a href="coin.md#0x1_coin_CoinAddAbortsIf">coin::CoinAddAbortsIf</a>&lt;SupraCoin&gt; { amount: amount_to_mint };
 }
 </code></pre>

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.move
@@ -107,7 +107,8 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         assert!(
             timestamp::now_seconds() < txn_expiration_time,
@@ -164,7 +165,14 @@ module supra_framework::transaction_validation {
             );
         };
 
-        verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
+        // Should only be false when simulating a transaction with the default max-gas value.
+        // Clients that do not manually specify their own max-gas value should generally be using
+        // simulation to estimate the value of this parameter for their actual transaction.
+        // The transaction will fail during the epilogue with the same error code if the account does not
+        // have enough balance to cover the actual gas payment.
+        if (verify_gas_payment) {
+            verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
+        }
     }
 
     fun script_prologue(
@@ -175,7 +183,7 @@ module supra_framework::transaction_validation {
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
         chain_id: u8,
-        _script_hash: vector<u8>
+        verify_gas_payment: bool
     ) {
         let gas_payer = signer::address_of(&sender);
         prologue_common(
@@ -186,7 +194,8 @@ module supra_framework::transaction_validation {
             txn_gas_price,
             txn_max_gas_units,
             txn_expiration_time,
-            chain_id
+            chain_id,
+            verify_gas_payment
         )
     }
 
@@ -257,7 +266,8 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         let sender_addr = signer::address_of(&sender);
         prologue_common(
@@ -268,7 +278,8 @@ module supra_framework::transaction_validation {
             txn_gas_price,
             txn_max_gas_units,
             txn_expiration_time,
-            chain_id
+            chain_id,
+            verify_gas_payment
         );
         multi_agent_common_prologue(
             secondary_signer_addresses, secondary_signer_public_key_hashes
@@ -327,7 +338,8 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         assert!(
             features::fee_payer_enabled(),
@@ -341,7 +353,8 @@ module supra_framework::transaction_validation {
             txn_gas_price,
             txn_max_gas_units,
             txn_expiration_time,
-            chain_id
+            chain_id,
+            verify_gas_payment
         );
         multi_agent_common_prologue(
             secondary_signer_addresses, secondary_signer_public_key_hashes

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.move
@@ -83,7 +83,7 @@ module supra_framework::transaction_validation {
 
     fun verify_gas_payment(
         gas_payer: address, txn_gas_price: u64, txn_gas_units: u64
-    ) {
+    ): u64 {
         let transaction_fee = txn_gas_price * txn_gas_units;
 
         if (features::operations_default_to_fa_supra_store_enabled()) {
@@ -96,7 +96,9 @@ module supra_framework::transaction_validation {
                 coin::is_balance_at_least<SupraCoin>(gas_payer, transaction_fee),
                 error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
             );
-        }
+        };
+
+        transaction_fee
     }
 
     fun prologue_common(
@@ -428,7 +430,8 @@ module supra_framework::transaction_validation {
 
         // it's important to maintain the error code consistent with vm
         // to do failed transaction cleanup.
-        verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
+        let transaction_fee_amount =
+            verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
 
         let amount_to_burn =
             if (features::collect_and_distribute_gas_fees()) {

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.move
@@ -27,7 +27,7 @@ module supra_framework::transaction_validation {
         // module_prologue_name is deprecated and not used.
         module_prologue_name: vector<u8>,
         multi_agent_prologue_name: vector<u8>,
-        user_epilogue_name: vector<u8>,
+        user_epilogue_name: vector<u8>
     }
 
     /// MSB is used to indicate a gas payer tx
@@ -37,8 +37,8 @@ module supra_framework::transaction_validation {
     const EOUT_OF_GAS: u64 = 6;
 
     /// Constants representing automation task type. Should match the values in scope of automation_registry module.
-    const UST:u8 = 1;
-    const GST:u8 = 2;
+    const UST: u8 = 1;
+    const GST: u8 = 2;
 
     /// Prologue errors. These are separated out from the other errors in this
     /// module since they are mapped separately to major VM statuses, and are
@@ -63,19 +63,40 @@ module supra_framework::transaction_validation {
         // module_prologue_name is deprecated and not used.
         module_prologue_name: vector<u8>,
         multi_agent_prologue_name: vector<u8>,
-        user_epilogue_name: vector<u8>,
+        user_epilogue_name: vector<u8>
     ) {
         system_addresses::assert_supra_framework(supra_framework);
 
-        move_to(supra_framework, TransactionValidation {
-            module_addr: @supra_framework,
-            module_name: b"transaction_validation",
-            script_prologue_name,
-            // module_prologue_name is deprecated and not used.
-            module_prologue_name,
-            multi_agent_prologue_name,
-            user_epilogue_name,
-        });
+        move_to(
+            supra_framework,
+            TransactionValidation {
+                module_addr: @supra_framework,
+                module_name: b"transaction_validation",
+                script_prologue_name,
+                // module_prologue_name is deprecated and not used.
+                module_prologue_name,
+                multi_agent_prologue_name,
+                user_epilogue_name
+            }
+        );
+    }
+
+    fun verify_gas_payment(
+        gas_payer: address, txn_gas_price: u64, txn_gas_units: u64
+    ) {
+        let transaction_fee = txn_gas_price * txn_gas_units;
+
+        if (features::operations_default_to_fa_supra_store_enabled()) {
+            assert!(
+                supra_account::is_fungible_balance_at_least(gas_payer, transaction_fee),
+                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+            );
+        } else {
+            assert!(
+                coin::is_balance_at_least<SupraCoin>(gas_payer, transaction_fee),
+                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+            );
+        }
     }
 
     fun prologue_common(
@@ -86,29 +107,35 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8,
+        chain_id: u8
     ) {
         assert!(
             timestamp::now_seconds() < txn_expiration_time,
-            error::invalid_argument(PROLOGUE_ETRANSACTION_EXPIRED),
+            error::invalid_argument(PROLOGUE_ETRANSACTION_EXPIRED)
         );
-        assert!(chain_id::get() == chain_id, error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID));
+        assert!(
+            chain_id::get() == chain_id,
+            error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID)
+        );
 
         let transaction_sender = signer::address_of(&sender);
 
-        if (
-            transaction_sender == gas_payer
-                || account::exists_at(transaction_sender)
-                || !features::sponsored_automatic_account_creation_enabled()
-                || txn_sequence_number != 0
-        ) {
-            assert!(account::exists_at(transaction_sender), error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST));
+        if (transaction_sender == gas_payer
+            || account::exists_at(transaction_sender)
+            || !features::sponsored_automatic_account_creation_enabled()
+            || txn_sequence_number != 0) {
             assert!(
-                txn_authentication_key == account::get_authentication_key(transaction_sender),
-                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+                account::exists_at(transaction_sender),
+                error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST)
+            );
+            assert!(
+                txn_authentication_key
+                    == account::get_authentication_key(transaction_sender),
+                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
             );
 
-            let account_sequence_number = account::get_sequence_number(transaction_sender);
+            let account_sequence_number =
+                account::get_sequence_number(transaction_sender);
             assert!(
                 txn_sequence_number < (1u64 << 63),
                 error::out_of_range(PROLOGUE_ESEQUENCE_NUMBER_TOO_BIG)
@@ -133,31 +160,11 @@ module supra_framework::transaction_validation {
 
             assert!(
                 txn_authentication_key == bcs::to_bytes(&transaction_sender),
-                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
             );
         };
 
         verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
-    }
-
-    fun verify_gas_payment(
-        gas_payer: address,
-        txn_gas_price: u64,
-        txn_gas_units: u64,
-    ) {
-        let transaction_fee = txn_gas_price * txn_gas_units;
-
-        if (features::operations_default_to_fa_supra_store_enabled()) {
-            assert!(
-                supra_account::is_fungible_balance_at_least(gas_payer, transaction_fee),
-                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
-            );
-        } else {
-            assert!(
-                coin::is_balance_at_least<SupraCoin>(gas_payer, transaction_fee),
-                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
-            );
-        }
     }
 
     fun script_prologue(
@@ -168,7 +175,7 @@ module supra_framework::transaction_validation {
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
         chain_id: u8,
-        _script_hash: vector<u8>,
+        _script_hash: vector<u8>
     ) {
         let gas_payer = signer::address_of(&sender);
         prologue_common(
@@ -193,9 +200,17 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8,
-    )  {
-        automated_transaction_prologue_v2(sender, task_index, txn_gas_price, txn_max_gas_units, txn_expiration_time, chain_id, UST);
+        chain_id: u8
+    ) {
+        automated_transaction_prologue_v2(
+            sender,
+            task_index,
+            txn_gas_price,
+            txn_max_gas_units,
+            txn_expiration_time,
+            chain_id,
+            UST
+        );
     }
 
     fun automated_transaction_prologue_v2(
@@ -205,15 +220,18 @@ module supra_framework::transaction_validation {
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
         chain_id: u8,
-        task_type: u8,
-    )  {
+        task_type: u8
+    ) {
         let gas_payer = signer::address_of(&sender);
 
-        assert!(chain_id::get() == chain_id, error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID));
+        assert!(
+            chain_id::get() == chain_id,
+            error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID)
+        );
 
         assert!(
             timestamp::now_seconds() < txn_expiration_time,
-            error::invalid_argument(PROLOGUE_ETRANSACTION_EXPIRED),
+            error::invalid_argument(PROLOGUE_ETRANSACTION_EXPIRED)
         );
 
         // Task is not gas-less/GST,
@@ -222,8 +240,12 @@ module supra_framework::transaction_validation {
             verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
         };
 
-        assert!(automation_registry::has_sender_active_task_with_id_and_type(address_of(&sender), task_index, task_type),
-            error::invalid_state(PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK))
+        assert!(
+            automation_registry::has_sender_active_task_with_id_and_type(
+                address_of(&sender), task_index, task_type
+            ),
+            error::invalid_state(PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK)
+        )
     }
 
     fun multi_agent_script_prologue(
@@ -235,7 +257,7 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8,
+        chain_id: u8
     ) {
         let sender_addr = signer::address_of(&sender);
         prologue_common(
@@ -246,19 +268,22 @@ module supra_framework::transaction_validation {
             txn_gas_price,
             txn_max_gas_units,
             txn_expiration_time,
-            chain_id,
+            chain_id
         );
-        multi_agent_common_prologue(secondary_signer_addresses, secondary_signer_public_key_hashes);
+        multi_agent_common_prologue(
+            secondary_signer_addresses, secondary_signer_public_key_hashes
+        );
     }
 
     fun multi_agent_common_prologue(
         secondary_signer_addresses: vector<address>,
-        secondary_signer_public_key_hashes: vector<vector<u8>>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>
     ) {
         let num_secondary_signers = vector::length(&secondary_signer_addresses);
         assert!(
-            vector::length(&secondary_signer_public_key_hashes) == num_secondary_signers,
-            error::invalid_argument(PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH),
+            vector::length(&secondary_signer_public_key_hashes)
+                == num_secondary_signers,
+            error::invalid_argument(PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH)
         );
 
         let i = 0;
@@ -268,17 +293,24 @@ module supra_framework::transaction_validation {
                 invariant forall j in 0..i:
                     account::exists_at(secondary_signer_addresses[j])
                         && secondary_signer_public_key_hashes[j]
-                        == account::get_authentication_key(secondary_signer_addresses[j]);
+                            == account::get_authentication_key(
+                                secondary_signer_addresses[j]
+                            );
             };
             (i < num_secondary_signers)
         }) {
             let secondary_address = *vector::borrow(&secondary_signer_addresses, i);
-            assert!(account::exists_at(secondary_address), error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST));
-
-            let signer_public_key_hash = *vector::borrow(&secondary_signer_public_key_hashes, i);
             assert!(
-                signer_public_key_hash == account::get_authentication_key(secondary_address),
-                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+                account::exists_at(secondary_address),
+                error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST)
+            );
+
+            let signer_public_key_hash =
+                *vector::borrow(&secondary_signer_public_key_hashes, i);
+            assert!(
+                signer_public_key_hash
+                    == account::get_authentication_key(secondary_address),
+                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
             );
             i = i + 1;
         }
@@ -295,9 +327,12 @@ module supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8,
+        chain_id: u8
     ) {
-        assert!(features::fee_payer_enabled(), error::invalid_state(PROLOGUE_EFEE_PAYER_NOT_ENABLED));
+        assert!(
+            features::fee_payer_enabled(),
+            error::invalid_state(PROLOGUE_EFEE_PAYER_NOT_ENABLED)
+        );
         prologue_common(
             sender,
             fee_payer_address,
@@ -306,12 +341,15 @@ module supra_framework::transaction_validation {
             txn_gas_price,
             txn_max_gas_units,
             txn_expiration_time,
-            chain_id,
+            chain_id
         );
-        multi_agent_common_prologue(secondary_signer_addresses, secondary_signer_public_key_hashes);
+        multi_agent_common_prologue(
+            secondary_signer_addresses, secondary_signer_public_key_hashes
+        );
         assert!(
-            fee_payer_public_key_hash == account::get_authentication_key(fee_payer_address),
-            error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+            fee_payer_public_key_hash
+                == account::get_authentication_key(fee_payer_address),
+            error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
         );
     }
 
@@ -325,7 +363,14 @@ module supra_framework::transaction_validation {
         gas_units_remaining: u64
     ) {
         let addr = signer::address_of(&account);
-        epilogue_gas_payer(account, addr, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+        epilogue_gas_payer(
+            account,
+            addr,
+            storage_fee_refunded,
+            txn_gas_price,
+            txn_max_gas_units,
+            gas_units_remaining
+        );
     }
 
     /// Epilogue function is run after a automated transaction is successfully executed.
@@ -338,7 +383,13 @@ module supra_framework::transaction_validation {
         gas_units_remaining: u64
     ) {
         let addr = signer::address_of(&account);
-        epilogue_gas_payer_only(addr, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+        epilogue_gas_payer_only(
+            addr,
+            storage_fee_refunded,
+            txn_gas_price,
+            txn_max_gas_units,
+            gas_units_remaining
+        );
     }
 
     /// Epilogue function with explicit gas payer specified, is run after a transaction is successfully executed.
@@ -351,7 +402,10 @@ module supra_framework::transaction_validation {
         txn_max_gas_units: u64,
         gas_units_remaining: u64
     ) {
-        assert!(txn_max_gas_units >= gas_units_remaining, error::invalid_argument(EOUT_OF_GAS));
+        assert!(
+            txn_max_gas_units >= gas_units_remaining,
+            error::invalid_argument(EOUT_OF_GAS)
+        );
         let gas_used = txn_max_gas_units - gas_units_remaining;
 
         assert!(
@@ -363,20 +417,21 @@ module supra_framework::transaction_validation {
         // to do failed transaction cleanup.
         verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
 
-        let amount_to_burn = if (features::collect_and_distribute_gas_fees()) {
-            // TODO(gas): We might want to distinguish the refundable part of the charge and burn it or track
-            // it separately, so that we don't increase the total supply by refunding.
+        let amount_to_burn =
+            if (features::collect_and_distribute_gas_fees()) {
+                // TODO(gas): We might want to distinguish the refundable part of the charge and burn it or track
+                // it separately, so that we don't increase the total supply by refunding.
 
-            // If transaction fees are redistributed to validators, collect them here for
-            // later redistribution.
-            transaction_fee::collect_fee(gas_payer, transaction_fee_amount);
-            0
-        } else {
-            // Otherwise, just burn the fee.
-            // TODO: this branch should be removed completely when transaction fee collection
-            // is tested and is fully proven to work well.
-            transaction_fee_amount
-        };
+                // If transaction fees are redistributed to validators, collect them here for
+                // later redistribution.
+                transaction_fee::collect_fee(gas_payer, transaction_fee_amount);
+                0
+            } else {
+                // Otherwise, just burn the fee.
+                // TODO: this branch should be removed completely when transaction fee collection
+                // is tested and is fully proven to work well.
+                transaction_fee_amount
+            };
 
         if (amount_to_burn > storage_fee_refunded) {
             let burn_amount = amount_to_burn - storage_fee_refunded;
@@ -398,11 +453,16 @@ module supra_framework::transaction_validation {
         txn_max_gas_units: u64,
         gas_units_remaining: u64
     ) {
-        epilogue_gas_payer_only(gas_payer, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+        epilogue_gas_payer_only(
+            gas_payer,
+            storage_fee_refunded,
+            txn_gas_price,
+            txn_max_gas_units,
+            gas_units_remaining
+        );
 
         // Increment sequence number
         let addr = signer::address_of(&account);
         account::increment_sequence_number(addr);
     }
 }
-

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.move
@@ -137,16 +137,24 @@ module supra_framework::transaction_validation {
             );
         };
 
-        let max_transaction_fee = txn_gas_price * txn_max_gas_units;
+        verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
+    }
+
+    fun verify_gas_payment(
+        gas_payer: address,
+        txn_gas_price: u64,
+        txn_gas_units: u64,
+    ) {
+        let transaction_fee = txn_gas_price * txn_gas_units;
 
         if (features::operations_default_to_fa_supra_store_enabled()) {
             assert!(
-                supra_account::is_fungible_balance_at_least(gas_payer, max_transaction_fee),
+                supra_account::is_fungible_balance_at_least(gas_payer, transaction_fee),
                 error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
             );
         } else {
             assert!(
-                coin::is_balance_at_least<SupraCoin>(gas_payer, max_transaction_fee),
+                coin::is_balance_at_least<SupraCoin>(gas_payer, transaction_fee),
                 error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
             );
         }
@@ -211,20 +219,9 @@ module supra_framework::transaction_validation {
         // Task is not gas-less/GST,
         // gas-less automated transactions are not charged so no need to check eligability to pay the gas-fee.
         if (task_type != GST) {
-            let max_transaction_fee = txn_gas_price * txn_max_gas_units;
-
-            if (features::operations_default_to_fa_supra_store_enabled()) {
-                assert!(
-                    supra_account::is_fungible_balance_at_least(gas_payer, max_transaction_fee),
-                    error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
-                );
-            } else {
-                assert!(
-                    coin::is_balance_at_least<SupraCoin>(gas_payer, max_transaction_fee),
-                    error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
-                );
-            };
+            verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
         };
+
         assert!(automation_registry::has_sender_active_task_with_id_and_type(address_of(&sender), task_index, task_type),
             error::invalid_state(PROLOGUE_ENO_ACTIVE_AUTOMATED_TASK))
     }
@@ -361,21 +358,10 @@ module supra_framework::transaction_validation {
             (txn_gas_price as u128) * (gas_used as u128) <= MAX_U64,
             error::out_of_range(EOUT_OF_GAS)
         );
-        let transaction_fee_amount = txn_gas_price * gas_used;
 
         // it's important to maintain the error code consistent with vm
         // to do failed transaction cleanup.
-        if (features::operations_default_to_fa_supra_store_enabled()) {
-            assert!(
-                supra_account::is_fungible_balance_at_least(gas_payer, transaction_fee_amount),
-                error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
-            );
-        } else {
-            assert!(
-                coin::is_balance_at_least<SupraCoin>(gas_payer, transaction_fee_amount),
-                error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
-            );
-        };
+        verify_gas_payment(gas_payer, txn_gas_price, txn_max_gas_units);
 
         let amount_to_burn = if (features::collect_and_distribute_gas_fees()) {
             // TODO(gas): We might want to distinguish the refundable part of the charge and burn it or track
@@ -419,3 +405,4 @@ module supra_framework::transaction_validation {
         account::increment_sequence_number(addr);
     }
 }
+

--- a/aptos-move/framework/supra-framework/sources/transaction_validation.spec.move
+++ b/aptos-move/framework/supra-framework/sources/transaction_validation.spec.move
@@ -31,11 +31,11 @@ spec supra_framework::transaction_validation {
     /// Ensure caller is `supra_framework`.
     /// Aborts if TransactionValidation already exists.
     spec initialize(
-    supra_framework: &signer,
-    script_prologue_name: vector<u8>,
-    module_prologue_name: vector<u8>,
-    multi_agent_prologue_name: vector<u8>,
-    user_epilogue_name: vector<u8>,
+        supra_framework: &signer,
+        script_prologue_name: vector<u8>,
+        module_prologue_name: vector<u8>,
+        multi_agent_prologue_name: vector<u8>,
+        user_epilogue_name: vector<u8>
     ) {
         use std::signer;
         let addr = signer::address_of(supra_framework);
@@ -61,6 +61,7 @@ spec supra_framework::transaction_validation {
         txn_max_gas_units: u64;
         txn_expiration_time: u64;
         chain_id: u8;
+        verify_gas_payment: bool;
 
         aborts_if !exists<CurrentTimeMicroseconds>(@supra_framework);
         aborts_if !(timestamp::now_seconds() < txn_expiration_time);
@@ -74,14 +75,26 @@ spec supra_framework::transaction_validation {
                 || account::exists_at(transaction_sender)
                 || transaction_sender == gas_payer
                 || txn_sequence_number > 0
-        ) && (
-            !(txn_sequence_number >= global<Account>(transaction_sender).sequence_number)
-                || !(txn_authentication_key == global<Account>(transaction_sender).authentication_key)
-                || !account::exists_at(transaction_sender)
-                || !(txn_sequence_number == global<Account>(transaction_sender).sequence_number)
-        );
+        )
+            && (
+                !(
+                    txn_sequence_number
+                        >= global<Account>(transaction_sender).sequence_number
+                )
+                    || !(
+                        txn_authentication_key
+                            == global<Account>(transaction_sender).authentication_key
+                    )
+                    || !account::exists_at(transaction_sender)
+                    || !(
+                        txn_sequence_number
+                            == global<Account>(transaction_sender).sequence_number
+                    )
+            );
 
-        aborts_if features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+        aborts_if features::spec_is_enabled(
+            features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
+        )
             && transaction_sender != gas_payer
             && txn_sequence_number == 0
             && !account::exists_at(transaction_sender)
@@ -94,18 +107,23 @@ spec supra_framework::transaction_validation {
         aborts_if !exists<CoinStore<SupraCoin>>(gas_payer);
         // property 1: The sender of a transaction should have sufficient coin balance to pay the transaction fee.
         /// [high-level-req-1]
-        aborts_if !(global<CoinStore<SupraCoin>>(gas_payer).coin.value >= max_transaction_fee);
+        aborts_if !(
+            !verify_gas_payment
+                || global<CoinStore<SupraCoin>>(gas_payer).coin.value
+                    >= max_transaction_fee
+        );
     }
 
     spec prologue_common(
-    sender: signer,
-    gas_payer: address,
-    txn_sequence_number: u64,
-    txn_authentication_key: vector<u8>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
+        sender: signer,
+        gas_payer: address,
+        txn_sequence_number: u64,
+        txn_authentication_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -113,14 +131,14 @@ spec supra_framework::transaction_validation {
     }
 
     spec script_prologue(
-    sender: signer,
-    txn_sequence_number: u64,
-    txn_public_key: vector<u8>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
-    _script_hash: vector<u8>,
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_public_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -143,23 +161,23 @@ spec supra_framework::transaction_validation {
         /// [high-level-req-2]
         aborts_if exists i in 0..num_secondary_signers:
             !account::exists_at(secondary_signer_addresses[i])
-                || secondary_signer_public_key_hashes[i] !=
-                account::get_authentication_key(secondary_signer_addresses[i]);
+                || secondary_signer_public_key_hashes[i]
+                    != account::get_authentication_key(secondary_signer_addresses[i]);
 
         // By the end, all secondary signers account should exist and public key hash should match.
         ensures forall i in 0..num_secondary_signers:
             account::exists_at(secondary_signer_addresses[i])
-                && secondary_signer_public_key_hashes[i] ==
-                account::get_authentication_key(secondary_signer_addresses[i]);
+                && secondary_signer_public_key_hashes[i]
+                    == account::get_authentication_key(secondary_signer_addresses[i]);
     }
 
     spec multi_agent_common_prologue(
-    secondary_signer_addresses: vector<address>,
-    secondary_signer_public_key_hashes: vector<vector<u8>>,
+        secondary_signer_addresses: vector<address>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>
     ) {
         include MultiAgentPrologueCommonAbortsIf {
             secondary_signer_addresses,
-            secondary_signer_public_key_hashes,
+            secondary_signer_public_key_hashes
         };
     }
 
@@ -169,23 +187,24 @@ spec supra_framework::transaction_validation {
         txn_gas_price: u64,
         txn_max_gas_units: u64,
         txn_expiration_time: u64,
-        chain_id: u8,
+        chain_id: u8
     ) {
         pragma verify = false;
     }
 
     /// Aborts if length of public key hashed vector
     /// not equal the number of singers.
-    spec multi_agent_script_prologue (
-    sender: signer,
-    txn_sequence_number: u64,
-    txn_sender_public_key: vector<u8>,
-    secondary_signer_addresses: vector<address>,
-    secondary_signer_public_key_hashes: vector<vector<u8>>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
+    spec multi_agent_script_prologue(
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_sender_public_key: vector<u8>,
+        secondary_signer_addresses: vector<address>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         pragma verify_duration_estimate = 120;
         let gas_payer = signer::address_of(sender);
@@ -194,26 +213,27 @@ spec supra_framework::transaction_validation {
         include PrologueCommonAbortsIf {
             gas_payer,
             txn_sequence_number,
-            txn_authentication_key: txn_sender_public_key,
+            txn_authentication_key: txn_sender_public_key
         };
         include MultiAgentPrologueCommonAbortsIf {
             secondary_signer_addresses,
-            secondary_signer_public_key_hashes,
+            secondary_signer_public_key_hashes
         };
     }
 
     spec fee_payer_script_prologue(
-    sender: signer,
-    txn_sequence_number: u64,
-    txn_sender_public_key: vector<u8>,
-    secondary_signer_addresses: vector<address>,
-    secondary_signer_public_key_hashes: vector<vector<u8>>,
-    fee_payer_address: address,
-    fee_payer_public_key_hash: vector<u8>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_sender_public_key: vector<u8>,
+        secondary_signer_addresses: vector<address>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>,
+        fee_payer_address: address,
+        fee_payer_public_key_hash: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+        verify_gas_payment: bool
     ) {
         pragma verify_duration_estimate = 120;
 
@@ -222,15 +242,17 @@ spec supra_framework::transaction_validation {
         include PrologueCommonAbortsIf {
             gas_payer,
             txn_sequence_number,
-            txn_authentication_key: txn_sender_public_key,
+            txn_authentication_key: txn_sender_public_key
         };
         include MultiAgentPrologueCommonAbortsIf {
             secondary_signer_addresses,
-            secondary_signer_public_key_hashes,
+            secondary_signer_public_key_hashes
         };
 
         aborts_if !account::exists_at(gas_payer);
-        aborts_if !(fee_payer_public_key_hash == account::get_authentication_key(gas_payer));
+        aborts_if !(
+            fee_payer_public_key_hash == account::get_authentication_key(gas_payer)
+        );
         aborts_if !features::spec_fee_payer_enabled();
     }
 
@@ -238,11 +260,11 @@ spec supra_framework::transaction_validation {
     /// `SupraCoinCapabilities` and `CoinInfo` should exists.
     /// Skip transaction_fee::burn_fee verification.
     spec epilogue(
-    account: signer,
-    storage_fee_refunded: u64,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    gas_units_remaining: u64
+        account: signer,
+        storage_fee_refunded: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -273,12 +295,12 @@ spec supra_framework::transaction_validation {
     /// `SupraCoinCapabilities` and `CoinInfo` should exist.
     /// Skip transaction_fee::burn_fee verification.
     spec epilogue_gas_payer(
-    account: signer,
-    gas_payer: address,
-    storage_fee_refunded: u64,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    gas_units_remaining: u64
+        account: signer,
+        gas_payer: address,
+        storage_fee_refunded: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -294,7 +316,11 @@ spec supra_framework::transaction_validation {
         use supra_framework::coin;
         use supra_framework::coin::{CoinStore, CoinInfo};
         use supra_framework::optional_aggregator;
-        use supra_framework::transaction_fee::{SupraCoinCapabilities, SupraCoinMintCapability, CollectedFeesPerBlock};
+        use supra_framework::transaction_fee::{
+            SupraCoinCapabilities,
+            SupraCoinMintCapability,
+            CollectedFeesPerBlock
+        };
 
         account: signer;
         gas_payer: address;
@@ -324,23 +350,26 @@ spec supra_framework::transaction_validation {
         // ensures balance == pre_balance - transaction_fee_amount + storage_fee_refunded;
         ensures account.sequence_number == pre_account.sequence_number + 1;
 
-
         // Check fee collection.
-        let collect_fee_enabled = features::spec_is_enabled(features::COLLECT_AND_DISTRIBUTE_GAS_FEES);
+        let collect_fee_enabled = features::spec_is_enabled(
+            features::COLLECT_AND_DISTRIBUTE_GAS_FEES
+        );
         let collected_fees = global<CollectedFeesPerBlock>(@supra_framework).amount;
         let aggr = collected_fees.value;
         let aggr_val = aggregator::spec_aggregator_get_val(aggr);
         let aggr_lim = aggregator::spec_get_limit(aggr);
 
         /// [high-level-req-3]
-        aborts_if collect_fee_enabled && !exists<CollectedFeesPerBlock>(@supra_framework);
-        aborts_if collect_fee_enabled && transaction_fee_amount > 0 && aggr_val + transaction_fee_amount > aggr_lim;
+        aborts_if collect_fee_enabled
+            && !exists<CollectedFeesPerBlock>(@supra_framework);
+        aborts_if collect_fee_enabled
+            && transaction_fee_amount > 0
+            && aggr_val + transaction_fee_amount > aggr_lim;
 
         // Check burning.
         //   (Check the total supply aggregator when enabled.)
-        let amount_to_burn = if (collect_fee_enabled) {
-            0
-        } else {
+        let amount_to_burn = if (collect_fee_enabled) { 0 }
+        else {
             transaction_fee_amount - storage_fee_refunded
         };
         let apt_addr = type_info::type_of<SupraCoin>().account_address;
@@ -350,12 +379,18 @@ spec supra_framework::transaction_validation {
         let apt_supply_value = optional_aggregator::optional_aggregator_value(apt_supply);
         let post post_maybe_apt_supply = global<CoinInfo<SupraCoin>>(apt_addr).supply;
         let post post_apt_supply = option::spec_borrow(post_maybe_apt_supply);
-        let post post_apt_supply_value = optional_aggregator::optional_aggregator_value(post_apt_supply);
+        let post post_apt_supply_value = optional_aggregator::optional_aggregator_value(
+            post_apt_supply
+        );
 
-        aborts_if amount_to_burn > 0 && !exists<SupraCoinCapabilities>(@supra_framework);
+        aborts_if amount_to_burn > 0
+            && !exists<SupraCoinCapabilities>(@supra_framework);
         aborts_if amount_to_burn > 0 && !exists<CoinInfo<SupraCoin>>(apt_addr);
-        aborts_if amount_to_burn > 0 && total_supply_enabled && apt_supply_value < amount_to_burn;
-        ensures total_supply_enabled ==> apt_supply_value - amount_to_burn == post_apt_supply_value;
+        aborts_if amount_to_burn > 0
+            && total_supply_enabled
+            && apt_supply_value < amount_to_burn;
+        ensures total_supply_enabled ==>
+            apt_supply_value - amount_to_burn == post_apt_supply_value;
 
         // Check minting.
         let amount_to_mint = if (collect_fee_enabled) {
@@ -367,12 +402,15 @@ spec supra_framework::transaction_validation {
         let post post_total_supply = coin::supply<SupraCoin>;
 
         aborts_if amount_to_mint > 0 && !exists<CoinStore<SupraCoin>>(addr);
-        aborts_if amount_to_mint > 0 && !exists<SupraCoinMintCapability>(@supra_framework);
+        aborts_if amount_to_mint > 0
+            && !exists<SupraCoinMintCapability>(@supra_framework);
         aborts_if amount_to_mint > 0 && total_supply + amount_to_mint > MAX_U128;
-        ensures amount_to_mint > 0 ==> post_total_supply == total_supply + amount_to_mint;
+        ensures amount_to_mint > 0 ==>
+            post_total_supply == total_supply + amount_to_mint;
 
         let aptos_addr = type_info::type_of<SupraCoin>().account_address;
-        aborts_if (amount_to_mint != 0) && !exists<coin::CoinInfo<SupraCoin>>(aptos_addr);
+        aborts_if (amount_to_mint != 0)
+            && !exists<coin::CoinInfo<SupraCoin>>(aptos_addr);
         include coin::CoinAddAbortsIf<SupraCoin> { amount: amount_to_mint };
     }
 }

--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -23,7 +23,7 @@ pub fn run_transaction_using_debugger(
     let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
     let resolver = state_view.as_move_resolver();
-    let (vm_status, vm_output) = vm.execute_user_transaction(&resolver, &transaction, &log_context);
+    let (vm_status, vm_output) = vm.execute_user_transaction(&resolver, &transaction, &log_context, false);
 
     Ok((vm_status, vm_output))
 }
@@ -39,7 +39,7 @@ pub fn benchmark_transaction_using_debugger(
     let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
     let resolver = state_view.as_move_resolver();
-    let (vm_status, vm_output) = vm.execute_user_transaction(&resolver, &transaction, &log_context);
+    let (vm_status, vm_output) = vm.execute_user_transaction(&resolver, &transaction, &log_context, false);
 
     let time_cold = {
         let n = 15;
@@ -56,6 +56,7 @@ pub fn benchmark_transaction_using_debugger(
                 &resolver,
                 &transaction,
                 &log_context,
+                false,
             ));
             let t2 = Instant::now();
 
@@ -78,6 +79,7 @@ pub fn benchmark_transaction_using_debugger(
                 &resolver,
                 &transaction,
                 &log_context,
+                false,
             ));
             let t2 = Instant::now();
 


### PR DESCRIPTION
Part of https://github.com/Entropy-Foundation/smr-moonshot/issues/2684. See https://github.com/Entropy-Foundation/smr-moonshot/issues/2684#issuecomment-4030053804.