### PR TITLE
Updated minimum GAS_UNIT_PRICE from 100 to 100_000

### DIFF
--- a/config/global-constants/src/lib.rs
+++ b/config/global-constants/src/lib.rs
@@ -23,8 +23,10 @@ pub const GENESIS_WAYPOINT: &str = "genesis-waypoint";
 
 #[cfg(any(test, feature = "testing"))]
 pub const GAS_UNIT_PRICE: u64 = 0;
+
+/// Increased from 100 to 100_000 in accordance with the outcome of https://vote.supra.com/proposal/3.
 #[cfg(not(any(test, feature = "testing")))]
-pub const GAS_UNIT_PRICE: u64 = 100;
+pub const GAS_UNIT_PRICE: u64 = 100_000;
 
 #[cfg(any(test, feature = "testing"))]
 pub const MAX_GAS_AMOUNT: u64 = 100_000_000;


### PR DESCRIPTION
Updated minimum GAS_UNIT_PRICE from `100` to `100_000` in accordance with the outcome of https://vote.supra.com/proposal/3. Part of https://github.com/Entropy-Foundation/smr-moonshot/pull/2686.