### PR TITLE
Ensured that validators that do not migrate to the new key format before the related feature flag is activated are evicted from the validator set when the flag is activated

### DIFF
--- a/aptos-move/framework/supra-framework/doc/stake.md
+++ b/aptos-move/framework/supra-framework/doc/stake.md
@@ -88,6 +88,8 @@ or if their stake drops below the min required, they would get removed at the en
 -  [Function `initialize_validator_genesis`](#0x1_stake_initialize_validator_genesis)
 -  [Function `initialize_validator_internal`](#0x1_stake_initialize_validator_internal)
 -  [Function `validate_consensus_public_key`](#0x1_stake_validate_consensus_public_key)
+-  [Function `is_unrotated_legacy_key`](#0x1_stake_is_unrotated_legacy_key)
+-  [Function `is_eligible_active_validator`](#0x1_stake_is_eligible_active_validator)
 -  [Function `assert_consensus_pubkey_unique_in_next_validator_set`](#0x1_stake_assert_consensus_pubkey_unique_in_next_validator_set)
 -  [Function `assert_consensus_pubkey_unique_in_validator_list`](#0x1_stake_assert_consensus_pubkey_unique_in_validator_list)
 -  [Function `assert_network_addresses_unique_in_next_validator_set`](#0x1_stake_assert_network_addresses_unique_in_next_validator_set)
@@ -2887,6 +2889,70 @@ proof-of-possession (mirrors <code>rotate_consensus_key</code> / <code>rotate_co
 
 </details>
 
+<a id="0x1_stake_is_unrotated_legacy_key"></a>
+
+## Function `is_unrotated_legacy_key`
+
+Returns true iff the v2 validator-identity format is enforced and <code>consensus_pubkey</code> is still a
+legacy (pre-v2) bare ed25519 key. Mirrors the detection in <code>validate_consensus_public_key</code>: a
+bare ed25519 key parses via <code>new_validated_public_key_from_bytes</code>, while a v2 BCS blob does not.
+Such a key cannot be deserialized into the v2 <code>ValidatorPublicKeys</code> format that DKG and
+consensus require, so the validator is dropped from the active set (same effect as falling below
+the minimum stake) until it rotates.
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_is_unrotated_legacy_key">is_unrotated_legacy_key</a>(consensus_pubkey: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_is_unrotated_legacy_key">is_unrotated_legacy_key</a>(consensus_pubkey: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool {
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_supra_validator_identity_v2_enabled">features::supra_validator_identity_v2_enabled</a>()
+        && <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(
+            &<a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_new_validated_public_key_from_bytes">ed25519::new_validated_public_key_from_bytes</a>(*consensus_pubkey)
+        )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_stake_is_eligible_active_validator"></a>
+
+## Function `is_eligible_active_validator`
+
+Active-set membership test applied identically when previewing the next validator set
+(<code>compute_next_validator_set_internal</code>) and when committing it (<code>on_new_epoch</code>): a validator is
+retained iff it meets the minimum stake AND (under the v2 identity format) still carries a valid
+v2 consensus key. Centralizing this keeps the DKG receiver committee / <code>set_dkg_output_keys</code>
+(which read the preview) consistent with the committed set / consensus committee.
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_is_eligible_active_validator">is_eligible_active_validator</a>(voting_power: u64, minimum_stake: u64, consensus_pubkey: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_is_eligible_active_validator">is_eligible_active_validator</a>(
+    voting_power: u64, minimum_stake: u64, consensus_pubkey: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): bool {
+    voting_power &gt;= minimum_stake && !<a href="stake.md#0x1_stake_is_unrotated_legacy_key">is_unrotated_legacy_key</a>(consensus_pubkey)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_stake_assert_consensus_pubkey_unique_in_next_validator_set"></a>
 
 ## Function `assert_consensus_pubkey_unique_in_next_validator_set`
@@ -4646,8 +4712,11 @@ power.
         <b>let</b> new_validator_info =
             <a href="stake.md#0x1_stake_generate_validator_info">generate_validator_info</a>(pool_address, stake_pool, *validator_config);
 
-        // A validator needs at least the <b>min</b> <a href="stake.md#0x1_stake">stake</a> required <b>to</b> join the validator set.
-        <b>if</b> (new_validator_info.voting_power &gt;= minimum_stake) {
+        <b>if</b> (<a href="stake.md#0x1_stake_is_eligible_active_validator">is_eligible_active_validator</a>(
+            new_validator_info.voting_power,
+            minimum_stake,
+            &validator_config.consensus_pubkey
+        )) {
             <b>spec</b> {
                 <b>assume</b> total_voting_power + new_validator_info.voting_power
                     &lt;= MAX_U128;
@@ -4862,6 +4931,7 @@ New joiners (<code>pending_active</code>) always read from <code><a href="stake.
         <b>assume</b> num_cur_actives + num_cur_pending_actives &lt;= <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>;
     };
     <b>let</b> num_candidates = num_cur_actives + num_cur_pending_actives;
+
     <b>while</b> ({
         <b>spec</b> {
             <b>invariant</b> candidate_idx &lt;= num_candidates;
@@ -4915,17 +4985,23 @@ New joiners (<code>pending_active</code>) always read from <code><a href="stake.
                     cur_pending_inactive
                 } + cur_pending_active + cur_reward + cur_fee;
 
-        <b>if</b> (new_voting_power &gt;= minimum_stake) {
-            <b>let</b> config =
-                <b>if</b> (use_current_config_for_actives
-                    && candidate_in_current_validator_set) {
-                    // Use the current-epoch config snapshot so that <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> mid-epoch changes
-                    // (consensus key, network addresses, etc.) only take effect after the
-                    // epoch transition, not during DKG.
-                    candidate.config
-                } <b>else</b> {
-                    *<b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(candidate.addr)
-                };
+        <b>let</b> config =
+            <b>if</b> (use_current_config_for_actives
+                && candidate_in_current_validator_set) {
+                // Use the current-epoch config snapshot so that <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> mid-epoch changes
+                // (consensus key, network addresses, etc.) only take effect after the
+                // epoch transition, not during DKG.
+                candidate.config
+            } <b>else</b> {
+                *<b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(candidate.addr)
+            };
+
+        // Shared <b>with</b> `on_new_epoch`, so this preview (which feeds the DKG receiver committee and
+        // `set_dkg_output_keys`) stays consistent <b>with</b> the committed set. validator_index stays
+        // contiguous because it is only advanced for included validators.
+        <b>if</b> (<a href="stake.md#0x1_stake_is_eligible_active_validator">is_eligible_active_validator</a>(
+            new_voting_power, minimum_stake, &config.consensus_pubkey
+        )) {
             config.validator_index = num_new_actives;
             <b>let</b> new_validator_info = <a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a> {
                 addr: candidate.addr,
@@ -4941,6 +5017,7 @@ New joiners (<code>pending_active</code>) always read from <code><a href="stake.
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> new_active_validators, new_validator_info);
             num_new_actives = num_new_actives + 1;
         };
+
         candidate_idx = candidate_idx + 1;
     };
 

--- a/aptos-move/framework/supra-framework/sources/stake.move
+++ b/aptos-move/framework/supra-framework/sources/stake.move
@@ -824,6 +824,30 @@ module supra_framework::stake {
         keys_bytes
     }
 
+    /// Returns true iff the v2 validator-identity format is enforced and `consensus_pubkey` is still a
+    /// legacy (pre-v2) bare ed25519 key. Mirrors the detection in `validate_consensus_public_key`: a
+    /// bare ed25519 key parses via `new_validated_public_key_from_bytes`, while a v2 BCS blob does not.
+    /// Such a key cannot be deserialized into the v2 `ValidatorPublicKeys` format that DKG and
+    /// consensus require, so the validator is dropped from the active set (same effect as falling below
+    /// the minimum stake) until it rotates.
+    fun is_unrotated_legacy_key(consensus_pubkey: &vector<u8>): bool {
+        features::supra_validator_identity_v2_enabled()
+            && option::is_some(
+                &ed25519::new_validated_public_key_from_bytes(*consensus_pubkey)
+            )
+    }
+
+    /// Active-set membership test applied identically when previewing the next validator set
+    /// (`compute_next_validator_set_internal`) and when committing it (`on_new_epoch`): a validator is
+    /// retained iff it meets the minimum stake AND (under the v2 identity format) still carries a valid
+    /// v2 consensus key. Centralizing this keeps the DKG receiver committee / `set_dkg_output_keys`
+    /// (which read the preview) consistent with the committed set / consensus committee.
+    fun is_eligible_active_validator(
+        voting_power: u64, minimum_stake: u64, consensus_pubkey: &vector<u8>
+    ): bool {
+        voting_power >= minimum_stake && !is_unrotated_legacy_key(consensus_pubkey)
+    }
+
     /// Aborts if any validator other than `self_addr` in the next validator set
     /// (the union of `active_validators` and `pending_active`) already uses
     /// `consensus_pubkey` as its latest on-chain consensus key.
@@ -1775,8 +1799,11 @@ module supra_framework::stake {
             let new_validator_info =
                 generate_validator_info(pool_address, stake_pool, *validator_config);
 
-            // A validator needs at least the min stake required to join the validator set.
-            if (new_validator_info.voting_power >= minimum_stake) {
+            if (is_eligible_active_validator(
+                new_validator_info.voting_power,
+                minimum_stake,
+                &validator_config.consensus_pubkey
+            )) {
                 spec {
                     assume total_voting_power + new_validator_info.voting_power
                         <= MAX_U128;
@@ -1911,6 +1938,7 @@ module supra_framework::stake {
             assume num_cur_actives + num_cur_pending_actives <= MAX_U64;
         };
         let num_candidates = num_cur_actives + num_cur_pending_actives;
+
         while ({
             spec {
                 invariant candidate_idx <= num_candidates;
@@ -1964,17 +1992,23 @@ module supra_framework::stake {
                         cur_pending_inactive
                     } + cur_pending_active + cur_reward + cur_fee;
 
-            if (new_voting_power >= minimum_stake) {
-                let config =
-                    if (use_current_config_for_actives
-                        && candidate_in_current_validator_set) {
-                        // Use the current-epoch config snapshot so that any mid-epoch changes
-                        // (consensus key, network addresses, etc.) only take effect after the
-                        // epoch transition, not during DKG.
-                        candidate.config
-                    } else {
-                        *borrow_global<ValidatorConfig>(candidate.addr)
-                    };
+            let config =
+                if (use_current_config_for_actives
+                    && candidate_in_current_validator_set) {
+                    // Use the current-epoch config snapshot so that any mid-epoch changes
+                    // (consensus key, network addresses, etc.) only take effect after the
+                    // epoch transition, not during DKG.
+                    candidate.config
+                } else {
+                    *borrow_global<ValidatorConfig>(candidate.addr)
+                };
+
+            // Shared with `on_new_epoch`, so this preview (which feeds the DKG receiver committee and
+            // `set_dkg_output_keys`) stays consistent with the committed set. validator_index stays
+            // contiguous because it is only advanced for included validators.
+            if (is_eligible_active_validator(
+                new_voting_power, minimum_stake, &config.consensus_pubkey
+            )) {
                 config.validator_index = num_new_actives;
                 let new_validator_info = ValidatorInfo {
                     addr: candidate.addr,
@@ -1990,6 +2024,7 @@ module supra_framework::stake {
                 vector::push_back(&mut new_active_validators, new_validator_info);
                 num_new_actives = num_new_actives + 1;
             };
+
             candidate_idx = candidate_idx + 1;
         };
 
@@ -2870,6 +2905,70 @@ module supra_framework::stake {
         let blob =
             validator_public_keys::serialized_keys_with_pop_for_test(&other_sk, &pk);
         initialize_validator(validator, blob, b"net", b"fn");
+    }
+
+    #[
+        test(
+            supra_framework = @supra_framework,
+            validator_keep = @0x123,
+            validator_eject = @0x234
+        )
+    ]
+    /// Once the v2 identity format is enforced, a validator that never rotated to a v2 consensus key
+    /// (still a legacy bare ed25519 key) is ejected from the active set at the next epoch transition,
+    /// while a rotated (v2) validator is retained with a contiguous validator_index. This is the
+    /// invariant that lets DKG / `set_dkg_output_keys` assume every active validator has a valid v2
+    /// key, and what prevents the DKG-committee resolution failure on unrotated validators.
+    public entry fun test_on_new_epoch_ejects_unrotated_legacy_validator(
+        supra_framework: &signer, validator_keep: &signer, validator_eject: &signer
+    ) acquires AllowedValidators, SupraCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
+        initialize_for_test(supra_framework);
+        // Model the pre-upgrade state: disable the v2 identity format so a legacy (bare ed25519)
+        // consensus key can still be registered (the test VM enables v2 by default).
+        features::change_feature_flags_for_testing(
+            supra_framework,
+            vector[],
+            vector[features::get_supra_validator_identity_v2_feature()]
+        );
+        let keep_addr = signer::address_of(validator_keep);
+        let eject_addr = signer::address_of(validator_eject);
+
+        // `validator_keep` registers with a v2 consensus key and joins the active set.
+        let (_keep_sk, keep_pk) = generate_identity();
+        initialize_test_validator(&keep_pk, validator_keep, 100, true, false);
+
+        // `validator_eject` registers with a legacy (bare ed25519) consensus key while v2 is still
+        // disabled, then joins. This models a validator that never rotated across the upgrade.
+        let (_eject_sk, eject_vpk) = ed25519::generate_keys();
+        let legacy_key_bytes = ed25519::validated_public_key_to_bytes(&eject_vpk);
+        account::create_account_for_test(eject_addr);
+        initialize_validator_genesis(
+            validator_eject,
+            legacy_key_bytes,
+            vector::empty(),
+            vector::empty()
+        );
+        mint_and_add_stake(validator_eject, 100);
+        join_validator_set(validator_eject, eject_addr);
+
+        // Both validators activate while v2 is disabled.
+        end_epoch();
+        assert!(get_validator_state(keep_addr) == VALIDATOR_STATUS_ACTIVE, 0);
+        assert!(get_validator_state(eject_addr) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Enforce the v2 identity format.
+        features::change_feature_flags_for_testing(
+            supra_framework,
+            vector[features::get_supra_validator_identity_v2_feature()],
+            vector[]
+        );
+
+        // The next epoch transition ejects the unrotated (legacy-key) validator and keeps the v2 one.
+        end_epoch();
+        assert!(get_validator_state(keep_addr) == VALIDATOR_STATUS_ACTIVE, 2);
+        assert!(get_validator_state(eject_addr) == VALIDATOR_STATUS_INACTIVE, 3);
+        // The surviving validator keeps a contiguous validator_index.
+        assert!(borrow_global<ValidatorConfig>(keep_addr).validator_index == 0, 4);
     }
 
     #[test(supra_framework = @supra_framework, validator = @0x123)]


### PR DESCRIPTION
Cherry-pick of https://github.com/Entropy-Foundation/aptos-core/pull/370 for dev.