### PR TITLE
[Issue-2944] Updated evm-config module initialization

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/automation_registry.rs
+++ b/aptos-move/e2e-move-tests/src/tests/automation_registry.rs
@@ -44,7 +44,7 @@ fn run_on_large_stack<F: FnOnce() + Send + 'static>(f: F) {
 
 /// Raw abort code emitted by `automation_registry` when a required feature is disabled.
 /// This is NOT wrapped with error::invalid_state — it is the plain u64 constant 15.
-const EDISABLED_AUTOMATION_FEATURE: u64 = 15;
+const EDISABLED_AUTOMATION_V2_1_FEATURE: u64 = 49;
 
 // -----------------------------------------------------------------------
 // Helpers
@@ -279,6 +279,6 @@ fn test_register_without_validation_feature_disabled_aborts() {
                 bcs::to_bytes(&user_aux_data()).unwrap(),
             ],
         );
-        assert_abort!(status, EDISABLED_AUTOMATION_FEATURE);
+        assert_abort!(status, EDISABLED_AUTOMATION_V2_1_FEATURE);
     });
 }

--- a/aptos-move/framework/supra-framework/doc/automation_registry.md
+++ b/aptos-move/framework/supra-framework/doc/automation_registry.md
@@ -4939,8 +4939,8 @@ May only be called by the VM (enforced via <code><a href="system_addresses.md#0x
 This is the runtime-side remedy for tasks registered through
 <code>register_without_validation</code>: because that path skips BCS/entry-function checks,
 a malformed payload may reach the scheduler and fail repeatedly. The runtime calls
-this function to remove the task immediately, refund the owner in full (same policy
-as a voluntary <code>stop_tasks</code> call), and emit a diagnostic event so the owner can see
+this function to remove the task immediately, refund the owner applying the same policy
+as a voluntary <code>stop_tasks</code> call, and emit a diagnostic event so the owner can see
 why the task was cancelled.
 
 Two events are emitted:

--- a/aptos-move/framework/supra-framework/doc/evm_config.md
+++ b/aptos-move/framework/supra-framework/doc/evm_config.md
@@ -8,7 +8,8 @@
 -  [Resource `EvmContractsDetails`](#0x1_evm_config_EvmContractsDetails)
 -  [Resource `EvmScalarConfig`](#0x1_evm_config_EvmScalarConfig)
 -  [Constants](#@Constants_0)
--  [Function `initialize`](#0x1_evm_config_initialize)
+-  [Function `initialize_scalar_config`](#0x1_evm_config_initialize_scalar_config)
+-  [Function `initialize_contracts_details`](#0x1_evm_config_initialize_contracts_details)
 -  [Function `upsert_evm_contract_details_for_next_epoch`](#0x1_evm_config_upsert_evm_contract_details_for_next_epoch)
 -  [Function `upsert_config_for_next_epoch`](#0x1_evm_config_upsert_config_for_next_epoch)
 -  [Function `get_contract_value`](#0x1_evm_config_get_contract_value)
@@ -223,18 +224,16 @@ DECIMAL_PRECISION
 
 
 
-<a id="0x1_evm_config_initialize"></a>
+<a id="0x1_evm_config_initialize_scalar_config"></a>
 
-## Function `initialize`
+## Function `initialize_scalar_config`
 
-Publishes both the EVM contract address map and the scalar config map.
-<code>contract_keys</code>/<code>contract_values</code> must be the same length and every address
-must be a valid 20-byte EVM address (upper 12 bytes of the 32-byte Move
-address must be zero).  <code>config_keys</code>/<code>config_values</code> must be the same
+Publishes evm scalar config map.
+<code>config_keys</code>/<code>config_values</code> must be the same
 length and must include all required keys (e.g. evm_gas_normalization_denom).
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="evm_config.md#0x1_evm_config_initialize">initialize</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, contract_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, contract_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, config_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, config_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u128&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="evm_config.md#0x1_evm_config_initialize_scalar_config">initialize_scalar_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, config_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u128&gt;)
 </code></pre>
 
 
@@ -243,38 +242,19 @@ length and must include all required keys (e.g. evm_gas_normalization_denom).
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="evm_config.md#0x1_evm_config_initialize">initialize</a>(
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="evm_config.md#0x1_evm_config_initialize_scalar_config">initialize_scalar_config</a>(
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    contract_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
-    contract_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
     config_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
     config_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u128&gt;
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
-    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&contract_keys), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EEMPTY_DATA">EEMPTY_DATA</a>));
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&config_keys), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EEMPTY_DATA">EEMPTY_DATA</a>));
     <b>let</b> supra_framework_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
-    <b>assert</b>!(!<b>exists</b>&lt;<a href="evm_config.md#0x1_evm_config_EvmContractsDetails">EvmContractsDetails</a>&gt;(supra_framework_addr),<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="evm_config.md#0x1_evm_config_ERESOURCE_ALREADY_EXISTS">ERESOURCE_ALREADY_EXISTS</a>));
     <b>assert</b>!(!<b>exists</b>&lt;<a href="evm_config.md#0x1_evm_config_EvmScalarConfig">EvmScalarConfig</a>&gt;(supra_framework_addr),<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="evm_config.md#0x1_evm_config_ERESOURCE_ALREADY_EXISTS">ERESOURCE_ALREADY_EXISTS</a>));
-    <b>assert</b>!(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&contract_keys) == <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&contract_values),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EKEYS_VALUES_MISMATCH">EKEYS_VALUES_MISMATCH</a>)
-    );
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config_keys) == <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config_values),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EKEYS_VALUES_MISMATCH">EKEYS_VALUES_MISMATCH</a>)
     );
-
-    // Check that no contract value is invalid EVM <b>address</b>
-    <b>let</b> all_valid_evm_address = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_all">vector::all</a>(&contract_values,
-    |v|{ <a href="evm_config.md#0x1_evm_config_is_valid_evm_address">is_valid_evm_address</a>(v) });
-    <b>assert</b>!(all_valid_evm_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EINVALID_EVM_ADDRESS">EINVALID_EVM_ADDRESS</a>));
-
-    <b>let</b> contract_details = <a href="evm_config.md#0x1_evm_config_EvmContractsDetails">EvmContractsDetails</a> {
-        details: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_new_from">simple_map::new_from</a>(contract_keys, contract_values)
-    };
-    <b>move_to</b>(supra_framework, contract_details);
-    <a href="event.md#0x1_event_emit">event::emit</a>(contract_details);
 
     <b>let</b> <a href="evm_config.md#0x1_evm_config">evm_config</a> = <a href="evm_config.md#0x1_evm_config_EvmScalarConfig">EvmScalarConfig</a> {
         config: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_new_from">simple_map::new_from</a>(config_keys, config_values)
@@ -282,6 +262,56 @@ length and must include all required keys (e.g. evm_gas_normalization_denom).
     <a href="evm_config.md#0x1_evm_config_validate_scalar_config">validate_scalar_config</a>(&<a href="evm_config.md#0x1_evm_config">evm_config</a>);
     <b>move_to</b>(supra_framework, <a href="evm_config.md#0x1_evm_config">evm_config</a>);
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="evm_config.md#0x1_evm_config">evm_config</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_evm_config_initialize_contracts_details"></a>
+
+## Function `initialize_contracts_details`
+
+Publishes EVM contract address map.
+<code>contract_keys</code>/<code>contract_values</code> must be the same length and every address
+must be a valid 20-byte EVM address (upper 12 bytes of the 32-byte Move
+address must be zero).
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="evm_config.md#0x1_evm_config_initialize_contracts_details">initialize_contracts_details</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, contract_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, contract_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="evm_config.md#0x1_evm_config_initialize_contracts_details">initialize_contracts_details</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    contract_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
+    contract_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
+) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_supra_framework">system_addresses::assert_supra_framework</a>(supra_framework);
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&contract_keys), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EEMPTY_DATA">EEMPTY_DATA</a>));
+    <b>let</b> supra_framework_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(supra_framework);
+    <b>assert</b>!(!<b>exists</b>&lt;<a href="evm_config.md#0x1_evm_config_EvmContractsDetails">EvmContractsDetails</a>&gt;(supra_framework_addr),<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="evm_config.md#0x1_evm_config_ERESOURCE_ALREADY_EXISTS">ERESOURCE_ALREADY_EXISTS</a>));
+    <b>assert</b>!(
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&contract_keys) == <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&contract_values),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EKEYS_VALUES_MISMATCH">EKEYS_VALUES_MISMATCH</a>)
+    );
+
+    // Check that no contract value is invalid EVM <b>address</b>
+    <b>let</b> all_valid_evm_address = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_all">vector::all</a>(&contract_values,
+        |v|{ <a href="evm_config.md#0x1_evm_config_is_valid_evm_address">is_valid_evm_address</a>(v) });
+    <b>assert</b>!(all_valid_evm_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="evm_config.md#0x1_evm_config_EINVALID_EVM_ADDRESS">EINVALID_EVM_ADDRESS</a>));
+
+    <b>let</b> contract_details = <a href="evm_config.md#0x1_evm_config_EvmContractsDetails">EvmContractsDetails</a> {
+        details: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_new_from">simple_map::new_from</a>(contract_keys, contract_values)
+    };
+    <b>move_to</b>(supra_framework, contract_details);
+    <a href="event.md#0x1_event_emit">event::emit</a>(contract_details);
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/doc/genesis.md
+++ b/aptos-move/framework/supra-framework/doc/genesis.md
@@ -19,7 +19,8 @@
 -  [Function `initialize_supra_native_automation_v2`](#0x1_genesis_initialize_supra_native_automation_v2)
 -  [Function `initialize_core_resources_and_supra_coin`](#0x1_genesis_initialize_core_resources_and_supra_coin)
 -  [Function `initialize_evm_genesis_config`](#0x1_genesis_initialize_evm_genesis_config)
--  [Function `initialize_evm_config`](#0x1_genesis_initialize_evm_config)
+-  [Function `initialize_evm_scalar_config`](#0x1_genesis_initialize_evm_scalar_config)
+-  [Function `initialize_evm_contracts_details`](#0x1_genesis_initialize_evm_contracts_details)
 -  [Function `initialize_leader_ban_registry_config`](#0x1_genesis_initialize_leader_ban_registry_config)
 -  [Function `create_accounts`](#0x1_genesis_create_accounts)
 -  [Function `create_account`](#0x1_genesis_create_account)
@@ -849,14 +850,14 @@ Initialize the EVM genesis config.
 
 </details>
 
-<a id="0x1_genesis_initialize_evm_config"></a>
+<a id="0x1_genesis_initialize_evm_scalar_config"></a>
 
-## Function `initialize_evm_config`
+## Function `initialize_evm_scalar_config`
 
-Initialize the EVM config.
+Initialize the EVM scalar config map.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_evm_config">initialize_evm_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, contract_names: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, contract_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, config_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, config_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u128&gt;)
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_evm_scalar_config">initialize_evm_scalar_config</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, config_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u128&gt;)
 </code></pre>
 
 
@@ -865,14 +866,41 @@ Initialize the EVM config.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_evm_config">initialize_evm_config</a>(
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_evm_scalar_config">initialize_evm_scalar_config</a>(
     supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    contract_names: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
-    contract_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
     config_keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
     config_values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u128&gt;
 ) {
-    <a href="evm_config.md#0x1_evm_config_initialize">evm_config::initialize</a>(supra_framework, contract_names, contract_addresses, config_keys, config_values);
+    <a href="evm_config.md#0x1_evm_config_initialize_scalar_config">evm_config::initialize_scalar_config</a>(supra_framework, config_keys, config_values);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_genesis_initialize_evm_contracts_details"></a>
+
+## Function `initialize_evm_contracts_details`
+
+Initialize the EVM contracts address map.
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_evm_contracts_details">initialize_evm_contracts_details</a>(supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, contract_names: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, contract_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_evm_contracts_details">initialize_evm_contracts_details</a>(
+    supra_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    contract_names: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
+    contract_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
+) {
+    <a href="evm_config.md#0x1_evm_config_initialize_contracts_details">evm_config::initialize_contracts_details</a>(supra_framework, contract_names, contract_addresses);
 }
 </code></pre>
 

--- a/aptos-move/framework/supra-framework/sources/automation_registry.move
+++ b/aptos-move/framework/supra-framework/sources/automation_registry.move
@@ -1453,8 +1453,8 @@ module supra_framework::automation_registry {
     /// This is the runtime-side remedy for tasks registered through
     /// `register_without_validation`: because that path skips BCS/entry-function checks,
     /// a malformed payload may reach the scheduler and fail repeatedly. The runtime calls
-    /// this function to remove the task immediately, refund the owner in full (same policy
-    /// as a voluntary `stop_tasks` call), and emit a diagnostic event so the owner can see
+    /// this function to remove the task immediately, refund the owner applying the same policy
+    /// as a voluntary `stop_tasks` call, and emit a diagnostic event so the owner can see
     /// why the task was cancelled.
     ///
     /// Two events are emitted:

--- a/aptos-move/framework/supra-framework/sources/configs/evm_config.move
+++ b/aptos-move/framework/supra-framework/sources/configs/evm_config.move
@@ -65,43 +65,22 @@ module supra_framework::evm_config {
         config: SimpleMap<String, u128>
     }
 
-    /// Publishes both the EVM contract address map and the scalar config map.
-    /// `contract_keys`/`contract_values` must be the same length and every address
-    /// must be a valid 20-byte EVM address (upper 12 bytes of the 32-byte Move
-    /// address must be zero).  `config_keys`/`config_values` must be the same
+    /// Publishes evm scalar config map.
+    /// `config_keys`/`config_values` must be the same
     /// length and must include all required keys (e.g. evm_gas_normalization_denom).
-    public(friend) fun initialize(
+    public(friend) fun initialize_scalar_config(
         supra_framework: &signer,
-        contract_keys: vector<String>,
-        contract_values: vector<address>,
         config_keys: vector<String>,
         config_values: vector<u128>
     ) {
         system_addresses::assert_supra_framework(supra_framework);
-        assert!(!vector::is_empty(&contract_keys), error::invalid_argument(EEMPTY_DATA));
         assert!(!vector::is_empty(&config_keys), error::invalid_argument(EEMPTY_DATA));
         let supra_framework_addr = signer::address_of(supra_framework);
-        assert!(!exists<EvmContractsDetails>(supra_framework_addr),error::invalid_state(ERESOURCE_ALREADY_EXISTS));
         assert!(!exists<EvmScalarConfig>(supra_framework_addr),error::invalid_state(ERESOURCE_ALREADY_EXISTS));
-        assert!(
-            vector::length(&contract_keys) == vector::length(&contract_values),
-            error::invalid_argument(EKEYS_VALUES_MISMATCH)
-        );
         assert!(
             vector::length(&config_keys) == vector::length(&config_values),
             error::invalid_argument(EKEYS_VALUES_MISMATCH)
         );
-        
-        // Check that no contract value is invalid EVM address
-        let all_valid_evm_address = vector::all(&contract_values,
-        |v|{ is_valid_evm_address(v) });
-        assert!(all_valid_evm_address, error::invalid_argument(EINVALID_EVM_ADDRESS));
-
-        let contract_details = EvmContractsDetails {
-            details: simple_map::new_from(contract_keys, contract_values)
-        };
-        move_to(supra_framework, contract_details);
-        event::emit(contract_details);
 
         let evm_config = EvmScalarConfig {
             config: simple_map::new_from(config_keys, config_values)
@@ -110,6 +89,37 @@ module supra_framework::evm_config {
         move_to(supra_framework, evm_config);
         event::emit(evm_config);
     }
+
+    /// Publishes EVM contract address map.
+    /// `contract_keys`/`contract_values` must be the same length and every address
+    /// must be a valid 20-byte EVM address (upper 12 bytes of the 32-byte Move
+    /// address must be zero).
+    public(friend) fun initialize_contracts_details(
+        supra_framework: &signer,
+        contract_keys: vector<String>,
+        contract_values: vector<address>,
+    ) {
+        system_addresses::assert_supra_framework(supra_framework);
+        assert!(!vector::is_empty(&contract_keys), error::invalid_argument(EEMPTY_DATA));
+        let supra_framework_addr = signer::address_of(supra_framework);
+        assert!(!exists<EvmContractsDetails>(supra_framework_addr),error::invalid_state(ERESOURCE_ALREADY_EXISTS));
+        assert!(
+            vector::length(&contract_keys) == vector::length(&contract_values),
+            error::invalid_argument(EKEYS_VALUES_MISMATCH)
+        );
+
+        // Check that no contract value is invalid EVM address
+        let all_valid_evm_address = vector::all(&contract_values,
+            |v|{ is_valid_evm_address(v) });
+        assert!(all_valid_evm_address, error::invalid_argument(EINVALID_EVM_ADDRESS));
+
+        let contract_details = EvmContractsDetails {
+            details: simple_map::new_from(contract_keys, contract_values)
+        };
+        move_to(supra_framework, contract_details);
+        event::emit(contract_details);
+    }
+
 
     /// This can be called by on-chain governance to update on-chain evm contract
     /// details for the next epoch.
@@ -165,7 +175,7 @@ module supra_framework::evm_config {
             error::invalid_argument(EKEYS_VALUES_MISMATCH)
         );
         if (!exists<EvmScalarConfig>(@supra_framework)) {
-            let evm_config = 
+            let evm_config =
                 EvmScalarConfig { config: simple_map::new_from(keys, values) };
             // Config did not exist earlier, so validate the config for
             // presence of required keys and value type match
@@ -414,7 +424,7 @@ module supra_framework::evm_config {
         let estimate_margin_key = std::string::utf8(CONFIG_KEY_EVM_GAS_ESTIMATE_MARGIN);
         let gas_used_ratio_key = std::string::utf8(SUPRA_EVM_GAS_USED_RATIO);
         let decimal_precision_key = std::string::utf8(SUPRA_EVM_GAS_USED_RATIO_DECIMAL_PRECISION);
-        
+
 
         let evm_config = EvmScalarConfig {
             config: simple_map::new_from(vector[config_key, estimate_margin_key, gas_used_ratio_key, decimal_precision_key], vector[100u128, 1000u128, 500u128, 1000u128])
@@ -477,7 +487,7 @@ module supra_framework::evm_config {
                 vector[100u128, 1000u128, 1500u128, 1000u128] // gas used ratio exceeds decimal precision -> must abort
             )
         };
-        validate_scalar_config(&evm_config);        
+        validate_scalar_config(&evm_config);
 
 }
 

--- a/aptos-move/framework/supra-framework/sources/genesis.move
+++ b/aptos-move/framework/supra-framework/sources/genesis.move
@@ -301,15 +301,22 @@ module supra_framework::genesis {
         evm_genesis_config::initialize(supra_framework, evm_genesis_config);
     }
 
-    /// Initialize the EVM config.
-    fun initialize_evm_config(
+    /// Initialize the EVM scalar config map.
+    fun initialize_evm_scalar_config(
         supra_framework: &signer,
-        contract_names: vector<String>,
-        contract_addresses: vector<address>,
         config_keys: vector<String>,
         config_values: vector<u128>
     ) {
-        evm_config::initialize(supra_framework, contract_names, contract_addresses, config_keys, config_values);
+        evm_config::initialize_scalar_config(supra_framework, config_keys, config_values);
+    }
+
+    /// Initialize the EVM contracts address map.
+    fun initialize_evm_contracts_details(
+        supra_framework: &signer,
+        contract_names: vector<String>,
+        contract_addresses: vector<address>,
+    ) {
+        evm_config::initialize_contracts_details(supra_framework, contract_names, contract_addresses);
     }
 
     /// Initialize the leader ban config

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -31,7 +31,7 @@ use aptos_types::{
     },
     move_utils::as_move_value::AsMoveValue,
     on_chain_config::{
-        APTOS_MAX_KNOWN_VERSION, AutomationRegistryConfig, BanRegistryParameters, BanRegistryParametersV0, FeatureFlag, Features, GasScheduleV2, OnChainConsensusConfig, OnChainEvmGenesisConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig, RandomnessConfigMoveStruct, randomness_api_v0_config::{AllowCustomMaxGasFlag, RequiredGasDeposit}
+        APTOS_MAX_KNOWN_VERSION, AutomationRegistryConfig, BanRegistryParameters, FeatureFlag, Features, GasScheduleV2, OnChainConsensusConfig, OnChainEvmGenesisConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig, RandomnessConfigMoveStruct, randomness_api_v0_config::{AllowCustomMaxGasFlag, RequiredGasDeposit}
     },
     transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
     validator_public_keys::ValidatorPublicKeys,
@@ -351,8 +351,12 @@ pub fn encode_genesis_change_set_for_testnet(
         initialize_evm_genesis_config(&mut session, &evm_genesis_config);
     }
 
-    if let (Some(evm_contracts_details), Some(evm_scalar_config)) = (evm_contracts_details, evm_scalar_config) {
-        initialize_evm_config(&mut session, evm_contracts_details, evm_scalar_config);
+    if let Some(evm_contracts_details) = evm_contracts_details {
+        initialize_evm_contracts_details(&mut session, evm_contracts_details);
+    }
+
+    if let Some(evm_scalar_config) = evm_scalar_config {
+        initialize_evm_scalar_config(&mut session, evm_scalar_config);
     }
 
     create_accounts(&mut session, accounts);
@@ -631,26 +635,42 @@ fn initialize_evm_genesis_config(
     );
 }
 
-fn initialize_evm_config(
+fn initialize_evm_scalar_config(
     session: &mut SessionExt,
-    evm_contracts_details: OnChainEvmContractsDetails,
     evm_scalar_config: OnChainEvmConfig,
 ) {
 
-    let (contract_names, contract_addresses) = evm_contracts_details.to_move_values();
     let (config_keys, config_values) = evm_scalar_config.to_move_values();
 
     exec_function(
         session,
         GENESIS_MODULE_NAME,
-        "initialize_evm_config",
+        "initialize_evm_scalar_config",
+        vec![],
+        serialize_values(&vec![
+            MoveValue::Signer(CORE_CODE_ADDRESS),
+            config_keys,
+            config_values
+        ]),
+    );
+}
+
+fn initialize_evm_contracts_details(
+    session: &mut SessionExt,
+    evm_contracts_details: OnChainEvmContractsDetails,
+) {
+
+    let (contract_names, contract_addresses) = evm_contracts_details.to_move_values();
+
+    exec_function(
+        session,
+        GENESIS_MODULE_NAME,
+        "initialize_evm_contracts_details",
         vec![],
         serialize_values(&vec![
             MoveValue::Signer(CORE_CODE_ADDRESS),
             contract_names,
             contract_addresses,
-            config_keys,
-            config_values
         ]),
     );
 }


### PR DESCRIPTION
- Split evm-contracts-details and evm-scalar-config initialization to be independent
- Fixed the test failure
- Fixed the comment for `automation_registry::cancel_invalid_task` to match the underlying logic.

Fixes: https://github.com/Entropy-Foundation/smr-moonshot/issues/2944